### PR TITLE
fix(manufacturers): prevent duplicate material filter options

### DIFF
--- a/frontend/src/pages/manufacturers/index.astro
+++ b/frontend/src/pages/manufacturers/index.astro
@@ -329,6 +329,10 @@ import Layout from '../../layouts/Layout.astro'
 
     function populateMaterialFilter(items: any[]) {
       const materialSelect = document.getElementById('filter-material') as HTMLSelectElement
+      const selectedValue = materialSelect.value
+      const defaultOption = materialSelect.querySelector('option[value=""]')?.cloneNode(true) as HTMLOptionElement | null
+      materialSelect.replaceChildren(defaultOption ?? new Option(t('manufacturers.allMaterials'), ''))
+
       const materials = new Set<string>()
       items.forEach(mf => {
         if (mf.materials) {
@@ -342,6 +346,8 @@ import Layout from '../../layouts/Layout.astro'
         opt.textContent = mat
         materialSelect.appendChild(opt)
       })
+
+      materialSelect.value = selectedValue && materials.has(selectedValue) ? selectedValue : ''
     }
 
     async function loadManufacturers() {


### PR DESCRIPTION
## Summary
Fixes the manufacturers page material filter so repeated data reloads do not append duplicate material options.

The selected material is preserved when it still exists in the refreshed dataset, and the filter falls back to `All Materials` only when the previous selection is no longer valid.

## Base / Branch Context
- Target repo: `Fire-Devils/filaman-system`
- Base branch: `main`
- Head branch: `akira69:fd/pr5-material-filter-fix`
- Standalone upstream PR containing only the one real fix commit

## What Changed
- reset the material filter options before repopulating them
- preserved the current selected value during repopulation when it is still valid
- kept the default `All Materials` option intact instead of duplicating it or appending new options onto the old list

## Why
The manufacturers page repopulates the material filter whenever the manufacturer dataset reloads. Without clearing the existing options first, repeated reloads could leave duplicate material choices in the dropdown and make the filter state harder to trust.

## Validation
- verified the manufacturers page reload path repopulates the material filter without duplicate options
- verified an active selection remains selected after a reload when that material still exists
- verified the filter resets cleanly to `All Materials` when the previous selection is no longer present

## Test Checklist
- [x] Reload the manufacturers dataset and verify the material filter does not accumulate duplicate options.
- [x] Keep a material selected, trigger a reload, and verify the selection is preserved when that material still exists.
- [x] Trigger a reload where the previously selected material is no longer present and verify the filter falls back to `All Materials`.

## Screenshots

Before: base `main` after a manufacturers-data reload, showing duplicate material options in the filter

<img width="1116" alt="PR5 bug repro showing duplicate material filter options on base main" src="https://raw.githubusercontent.com/akira69/filaman-system/pr-assets-filaman-prs/pr5/01-material-filter-problem-duplicates.png" />

After: the same reload path on PR5, with the material filter staying deduplicated

<img width="1116" alt="PR5 fix showing deduplicated material filter options after reload" src="https://raw.githubusercontent.com/akira69/filaman-system/pr-assets-filaman-prs/pr5/02-material-filter-fixed-deduped.png" />
