### PR TITLE
feat: add Spoolman-compatible API plugin (spoolmanapi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,11 @@ skills-lock.json
 Agents.md
 Claude.md
 
-# Installed plugins (only spoolman_import ships as default)
+# Installed plugins – only spoolman_import ships as a built-in.
+# spoolmanapi source is tracked here so it can be packaged for manual installation.
 backend/app/plugins/*/
 !backend/app/plugins/spoolman_import/
+!backend/app/plugins/spoolmanapi/
 
 # Video
 _video

--- a/backend/app/plugins/spoolmanapi/plugin.json
+++ b/backend/app/plugins/spoolmanapi/plugin.json
@@ -1,0 +1,9 @@
+{
+    "plugin_key": "spoolmanapi",
+    "name": "Spoolman API",
+    "version": "1.0.0",
+    "plugin_type": "integration",
+    "description": "Spoolman-compatible REST API endpoints for Bambuddy and other Spoolman clients.",
+    "author": "FilaMan",
+    "mount_prefix": "/spoolman"
+}

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -1,0 +1,243 @@
+"""Spoolman-compatible REST API router.
+
+Actual endpoints live under /api/v1 (standard Spoolman API layout).
+Short-path aliases (/spoolman/spool, /spoolman/filament, /spoolman/vendor)
+issue a 307 redirect so that clients configured without the /api/v1 prefix
+(e.g. Bambuddy) are transparently forwarded to the correct location.
+
+Mounted at /spoolman via plugin.json mount_prefix.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
+from fastapi.responses import RedirectResponse
+
+from app.api.deps import DBSession, PrincipalDep
+from . import schemas
+from .service import SpoolmanService
+
+
+# ---------------------------------------------------------------------------
+# Implementation router – all real routes live here under /api/v1
+# ---------------------------------------------------------------------------
+_v1 = APIRouter(prefix="/api/v1")
+
+
+# --- Vendors ---
+
+@_v1.get("/vendor", response_model=list[schemas.Vendor])
+async def list_vendors(
+    db: DBSession,
+    principal: PrincipalDep,
+    response: Response,
+    name: str | None = Query(None),
+    external_id: str | None = Query(None),
+    sort: str | None = Query(None),
+    limit: int | None = Query(None),
+    offset: int = Query(0, ge=0),
+):
+    items, total = await SpoolmanService(db).list_vendors(
+        name=name, external_id=external_id, sort=sort, limit=limit, offset=offset,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    return items
+
+
+@_v1.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
+async def get_vendor(vendor_id: int, db: DBSession, principal: PrincipalDep):
+    vendor = await SpoolmanService(db).get_vendor(vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vendor not found")
+    return vendor
+
+
+@_v1.post("/vendor", response_model=schemas.Vendor, status_code=status.HTTP_201_CREATED)
+async def create_vendor(data: schemas.VendorParameters, db: DBSession, principal: PrincipalDep):
+    return await SpoolmanService(db).create_vendor(data)
+
+
+@_v1.patch("/vendor/{vendor_id}", response_model=schemas.Vendor)
+async def update_vendor(vendor_id: int, data: schemas.VendorUpdateParameters, db: DBSession, principal: PrincipalDep):
+    vendor = await SpoolmanService(db).update_vendor(vendor_id, data)
+    if vendor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vendor not found")
+    return vendor
+
+
+@_v1.delete("/vendor/{vendor_id}", status_code=status.HTTP_200_OK)
+async def delete_vendor(vendor_id: int, db: DBSession, principal: PrincipalDep):
+    if not await SpoolmanService(db).delete_vendor(vendor_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vendor not found")
+    return {}
+
+
+# --- Filaments ---
+
+@_v1.get("/filament", response_model=list[schemas.Filament])
+async def list_filaments(
+    db: DBSession,
+    principal: PrincipalDep,
+    response: Response,
+    vendor_name: str | None = Query(None),
+    vendor_id: str | None = Query(None),
+    name: str | None = Query(None),
+    material: str | None = Query(None),
+    article_number: str | None = Query(None),
+    color_hex: str | None = Query(None),
+    external_id: str | None = Query(None),
+    sort: str | None = Query(None),
+    limit: int | None = Query(None),
+    offset: int = Query(0, ge=0),
+):
+    items, total = await SpoolmanService(db).list_filaments(
+        vendor_name=vendor_name, vendor_id=vendor_id, name=name, material=material,
+        article_number=article_number, color_hex=color_hex, external_id=external_id,
+        sort=sort, limit=limit, offset=offset,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    return items
+
+
+@_v1.get("/filament/{filament_id}", response_model=schemas.Filament)
+async def get_filament(filament_id: int, db: DBSession, principal: PrincipalDep):
+    filament = await SpoolmanService(db).get_filament(filament_id)
+    if filament is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Filament not found")
+    return filament
+
+
+@_v1.post("/filament", response_model=schemas.Filament, status_code=status.HTTP_201_CREATED)
+async def create_filament(data: schemas.FilamentParameters, db: DBSession, principal: PrincipalDep):
+    return await SpoolmanService(db).create_filament(data)
+
+
+@_v1.patch("/filament/{filament_id}", response_model=schemas.Filament)
+async def update_filament(filament_id: int, data: schemas.FilamentUpdateParameters, db: DBSession, principal: PrincipalDep):
+    filament = await SpoolmanService(db).update_filament(filament_id, data)
+    if filament is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Filament not found")
+    return filament
+
+
+# --- Spools ---
+
+@_v1.get("/spool", response_model=list[schemas.Spool])
+async def list_spools(
+    db: DBSession,
+    principal: PrincipalDep,
+    response: Response,
+    filament_name: str | None = Query(None),
+    filament_id: str | None = Query(None),
+    filament_material: str | None = Query(None),
+    vendor_name: str | None = Query(None),
+    vendor_id: str | None = Query(None),
+    location: str | None = Query(None),
+    lot_nr: str | None = Query(None),
+    allow_archived: bool = Query(False),
+    sort: str | None = Query(None),
+    limit: int | None = Query(None),
+    offset: int = Query(0, ge=0),
+):
+    items, total = await SpoolmanService(db).list_spools(
+        filament_name=filament_name, filament_id=filament_id,
+        filament_material=filament_material, vendor_name=vendor_name,
+        vendor_id=vendor_id, location=location, lot_nr=lot_nr,
+        allow_archived=allow_archived, sort=sort, limit=limit, offset=offset,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    return items
+
+
+@_v1.get("/spool/{spool_id}", response_model=schemas.Spool)
+async def get_spool(spool_id: int, db: DBSession, principal: PrincipalDep):
+    spool = await SpoolmanService(db).get_spool(spool_id)
+    if spool is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Spool not found")
+    return spool
+
+
+@_v1.post("/spool", response_model=schemas.Spool, status_code=status.HTTP_201_CREATED)
+async def create_spool(data: schemas.SpoolParameters, db: DBSession, principal: PrincipalDep):
+    return await SpoolmanService(db).create_spool(data)
+
+
+@_v1.patch("/spool/{spool_id}", response_model=schemas.Spool)
+async def update_spool(spool_id: int, data: schemas.SpoolUpdateParameters, db: DBSession, principal: PrincipalDep):
+    spool = await SpoolmanService(db).update_spool(spool_id, data)
+    if spool is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Spool not found")
+    return spool
+
+
+@_v1.delete("/spool/{spool_id}", status_code=status.HTTP_200_OK)
+async def delete_spool(spool_id: int, db: DBSession, principal: PrincipalDep):
+    """Archives the spool (Spoolman-compatible DELETE behaviour)."""
+    if not await SpoolmanService(db).delete_spool(spool_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Spool not found")
+    return {}
+
+
+@_v1.put("/spool/{spool_id}/use", response_model=schemas.Spool)
+async def use_spool(spool_id: int, data: schemas.SpoolUseParameters, db: DBSession, principal: PrincipalDep):
+    spool = await SpoolmanService(db).use_spool(spool_id, data)
+    if spool is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Spool not found")
+    return spool
+
+
+@_v1.put("/spool/{spool_id}/measure", response_model=schemas.Spool)
+async def measure_spool(spool_id: int, data: schemas.SpoolMeasureParameters, db: DBSession, principal: PrincipalDep):
+    spool = await SpoolmanService(db).measure_spool(spool_id, data)
+    if spool is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Spool not found")
+    return spool
+
+
+# --- Info ---
+
+@_v1.get("/info")
+async def get_info():
+    """Version info endpoint probed by Spoolman clients."""
+    return {"version": "0.21.0", "git_commit": "filaman", "debug_mode": False}
+
+
+# ---------------------------------------------------------------------------
+# Main router – mounted at /spoolman by plugin.json
+# ---------------------------------------------------------------------------
+router = APIRouter(tags=["spoolman"])
+
+# Register /api/v1/... routes first so they take precedence over the redirects.
+router.include_router(_v1)
+
+# Short-path compatibility redirects:
+# Clients configured with /spoolman as base URL and no /api/v1 prefix
+# (e.g. Bambuddy calling /spoolman/spool) are forwarded transparently.
+_KNOWN_RESOURCES = {"spool", "filament", "vendor", "info"}
+
+
+@router.api_route(
+    "/{resource}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    include_in_schema=False,
+)
+async def _compat_redirect(resource: str, request: Request):
+    if resource not in _KNOWN_RESOURCES:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+    target = f"/spoolman/api/v1/{resource}"
+    if request.url.query:
+        target += f"?{request.url.query}"
+    return RedirectResponse(url=target, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@router.api_route(
+    "/{resource}/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    include_in_schema=False,
+)
+async def _compat_redirect_with_path(resource: str, path: str, request: Request):
+    if resource not in _KNOWN_RESOURCES:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+    target = f"/spoolman/api/v1/{resource}/{path}"
+    if request.url.query:
+        target += f"?{request.url.query}"
+    return RedirectResponse(url=target, status_code=status.HTTP_307_TEMPORARY_REDIRECT)

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Vendor(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str
+    comment: str | None = None
+    empty_spool_weight: float | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class VendorParameters(BaseModel):
+    name: str
+    empty_spool_weight: float | None = None
+    comment: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class VendorUpdateParameters(BaseModel):
+    name: str | None = None
+    empty_spool_weight: float | None = None
+    comment: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class Filament(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str | None = None
+    vendor: Vendor | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float | None = None
+    diameter: float | None = None
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class FilamentParameters(BaseModel):
+    name: str | None = None
+    vendor_id: int | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float = 1.24
+    diameter: float = 1.75
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class FilamentUpdateParameters(BaseModel):
+    name: str | None = None
+    vendor_id: int | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float | None = None
+    diameter: float | None = None
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class Spool(BaseModel):
+    id: int
+    registered: datetime | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    filament: Filament
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    remaining_length: float | None = None
+    used_length: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}
+
+
+class SpoolParameters(BaseModel):
+    filament_id: int
+    location: str | None = None
+    price: float | None = None
+    lot_nr: str | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    archived: bool = False
+    comment: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class SpoolUpdateParameters(BaseModel):
+    filament_id: int | None = None
+    location: str | None = None
+    price: float | None = None
+    lot_nr: str | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    archived: bool | None = None
+    comment: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+class SpoolUseParameters(BaseModel):
+    use_weight: float | None = None
+    use_length: float | None = None
+
+
+class SpoolMeasureParameters(BaseModel):
+    weight: float


### PR DESCRIPTION
### Summary

- Adds the `spoolmanapi` plugin — a Spoolman-compatible REST API that allows Bambuddy and other Spoolman clients to connect to FilaMan
- The plugin must be **manually installed** via the admin UI (ZIP upload); it is not active by default
- Source files are tracked in the repo so the plugin package can be built from them

### Endpoints

All real endpoints follow the standard Spoolman API layout under `/spoolman/api/v1/`:

| Method | Path |
|--------|------|
| `GET` / `POST` | `/spoolman/api/v1/spool` |
| `GET` / `PATCH` / `DELETE` | `/spoolman/api/v1/spool/{id}` |
| `PUT` | `/spoolman/api/v1/spool/{id}/use` |
| `PUT` | `/spoolman/api/v1/spool/{id}/measure` |
| `GET` / `POST` | `/spoolman/api/v1/filament` |
| `GET` / `PATCH` | `/spoolman/api/v1/filament/{id}` |
| `GET` / `POST` | `/spoolman/api/v1/vendor` |
| `GET` / `PATCH` / `DELETE` | `/spoolman/api/v1/vendor/{id}` |
| `GET` | `/spoolman/api/v1/info` |

Short-path aliases (`/spoolman/spool`, `/spoolman/filament`, `/spoolman/vendor`) issue a **307 redirect** to the `/api/v1/` equivalents. This covers clients like Bambuddy that call the base URL directly without the `/api/v1/` prefix. The 307 preserves the HTTP method, so `POST`/`PUT`/`PATCH` requests are forwarded correctly.

Authentication uses the existing FilaMan API key mechanism (`Authorization: Bearer <api_key>`).

### New files

```
backend/app/plugins/spoolmanapi/plugin.json   type: integration, mount_prefix: /spoolman
backend/app/plugins/spoolmanapi/__init__.py
backend/app/plugins/spoolmanapi/schemas.py    Pydantic schemas (Spool, Filament, Vendor)
backend/app/plugins/spoolmanapi/router.py     FastAPI router with /api/v1/ routes + redirects
```

### Test plan

- [ ] Install the plugin via Admin → Plugins → Upload ZIP
- [ ] Verify `GET /spoolman/api/v1/spool` returns `200` with a JSON array
- [ ] Verify `GET /spoolman/spool` returns `307` and redirects to `/spoolman/api/v1/spool`
- [ ] Connect Bambuddy with URL `https://<host>/spoolman` — spools should be listed
- [ ] Verify without plugin installed: `GET /spoolman/spool` returns `404`
- [ ] Confirm no regression on existing `/api/v1/*` endpoints (`302 passed`)