### PR TITLE
fix: enable sorting filaments by spool count

### DIFF
--- a/backend/app/api/v1/filaments.py
+++ b/backend/app/api/v1/filaments.py
@@ -574,13 +574,14 @@ async def list_filaments(
     search: str | None = Query(None, max_length=200),
     sort_by: str = Query(
         "designation",
-        pattern="^(id|designation|material_type|diameter_mm|price|manufacturer_color_name|density_g_cm3|raw_material_weight_g|finish_type|material_subgroup|manufacturer)$",
+        pattern="^(id|designation|material_type|diameter_mm|price|manufacturer_color_name|density_g_cm3|raw_material_weight_g|finish_type|material_subgroup|manufacturer|spool_count)$",
     ),
     sort_order: str = Query("asc", pattern="^(asc|desc)$"),
 ):
     # -- Build filter conditions (shared between data query and count query) --
     conditions = []
     needs_manufacturer_join = False
+    needs_spool_count_join = False
 
     if type:
         conditions.append(Filament.material_type == type)
@@ -603,9 +604,23 @@ async def list_filaments(
     if sort_by == "manufacturer":
         sort_column = Manufacturer.name
         needs_manufacturer_join = True
+    elif sort_by == "spool_count":
+        spool_count_subquery = (
+            select(
+                Spool.filament_id.label("filament_id"),
+                func.count(Spool.id).label("spool_count"),
+            )
+            .join(SpoolStatus, Spool.status_id == SpoolStatus.id)
+            .where(SpoolStatus.key != "archived")
+            .group_by(Spool.filament_id)
+            .subquery()
+        )
+        sort_column = func.coalesce(spool_count_subquery.c.spool_count, 0)
+        needs_spool_count_join = True
     else:
         sort_column = getattr(Filament, sort_by, Filament.designation)
     order = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+    tie_breaker = Filament.id.asc() if sort_order == "asc" else Filament.id.desc()
 
     # -- Data query --
     query = select(Filament).options(
@@ -616,11 +631,15 @@ async def list_filaments(
         query = query.join(
             Manufacturer, Filament.manufacturer_id == Manufacturer.id, isouter=True
         )
+    if needs_spool_count_join:
+        query = query.outerjoin(
+            spool_count_subquery, spool_count_subquery.c.filament_id == Filament.id
+        )
 
     for cond in conditions:
         query = query.where(cond)
 
-    query = query.order_by(order).offset((page - 1) * page_size).limit(page_size)
+    query = query.order_by(order, tie_breaker).offset((page - 1) * page_size).limit(page_size)
 
     # -- Count query (same filters, no eager loading / pagination) --
     count_query = select(func.count()).select_from(Filament)

--- a/backend/tests/test_filaments.py
+++ b/backend/tests/test_filaments.py
@@ -359,6 +359,59 @@ class TestFilamentCRUD:
         assert item["colors"][0]["color_id"] == color.id
 
     @pytest.mark.asyncio
+    async def test_list_filaments_sort_by_spool_count(self, auth_client, db_session):
+        client, _ = auth_client
+
+        manufacturer = await _create_manufacturer(db_session, name="SortMaker")
+        zero_spools = await _create_filament(db_session, manufacturer.id, designation="Zero Spools")
+        one_spool_a = await _create_filament(db_session, manufacturer.id, designation="One Spool A")
+        one_spool_b = await _create_filament(db_session, manufacturer.id, designation="One Spool B")
+        two_spools = await _create_filament(db_session, manufacturer.id, designation="Two Spools")
+
+        new_status = await _get_status(db_session, "new")
+        archived_status = await _get_status(db_session, "archived")
+
+        await _create_spool(db_session, one_spool_a.id, new_status.id)
+        await _create_spool(db_session, one_spool_a.id, archived_status.id)
+        await _create_spool(db_session, one_spool_b.id, new_status.id)
+        await _create_spool(db_session, two_spools.id, new_status.id)
+        await _create_spool(db_session, two_spools.id, new_status.id)
+
+        asc_response = await client.get(
+            "/api/v1/filaments?page=1&page_size=10&sort_by=spool_count&sort_order=asc"
+        )
+
+        assert asc_response.status_code == 200
+        asc_items = [
+            item
+            for item in asc_response.json()["items"]
+            if item["id"] in {zero_spools.id, one_spool_a.id, one_spool_b.id, two_spools.id}
+        ]
+        assert [(item["id"], item["spool_count"]) for item in asc_items] == [
+            (zero_spools.id, 0),
+            (one_spool_a.id, 1),
+            (one_spool_b.id, 1),
+            (two_spools.id, 2),
+        ]
+
+        desc_response = await client.get(
+            "/api/v1/filaments?page=1&page_size=10&sort_by=spool_count&sort_order=desc"
+        )
+
+        assert desc_response.status_code == 200
+        desc_items = [
+            item
+            for item in desc_response.json()["items"]
+            if item["id"] in {zero_spools.id, one_spool_a.id, one_spool_b.id, two_spools.id}
+        ]
+        assert [(item["id"], item["spool_count"]) for item in desc_items] == [
+            (two_spools.id, 2),
+            (one_spool_b.id, 1),
+            (one_spool_a.id, 1),
+            (zero_spools.id, 0),
+        ]
+
+    @pytest.mark.asyncio
     async def test_create_filament_basic(self, auth_client, db_session):
         client, csrf_token = auth_client
 

--- a/frontend/src/pages/filaments/index.astro
+++ b/frontend/src/pages/filaments/index.astro
@@ -251,6 +251,7 @@ import Layout from '../../layouts/Layout.astro'
 
     function sortFilaments(filaments: any[]): any[] {
       if (!sortKey || !sortDirection) return filaments
+      if (sortKey === 'spool_count') return filaments  // server-only sort: skip client re-sort
       return [...filaments].sort((a, b) => {
         const aVal = getSortValue(a, sortKey)
         const bVal = getSortValue(b, sortKey)
@@ -417,7 +418,6 @@ import Layout from '../../layouts/Layout.astro'
       const sortKeyMap: Record<string, string> = {
         'type': 'material_type',
         'colors': '', // not sortable server-side
-        'spool_count': '', // not sortable server-side
       }
       if (sortKey && sortDirection) {
         const backendSortKey = sortKeyMap[sortKey] ?? sortKey


### PR DESCRIPTION
## Summary

Clicking the **Spool Count** column header in the filaments list had no effect. `spool_count` was missing from the backend `sort_by` allowlist, and the frontend explicitly skipped client-side sorting for it. This PR implements proper server-side sorting by spool count.   I had a use case for this, saw the button for sorting, and found it wasn't working.

---

## Changes

### Backend (`backend/app/api/v1/filaments.py`)

- Added `spool_count` to the `sort_by` query parameter allowlist.
- Added a subquery (built only when `sort_by=spool_count`) that counts non-archived spools per filament (`SpoolStatus.key != "archived"`).
- When `sort_by=spool_count`, the query outer-joins the subquery and orders by `COALESCE(spool_count, 0)` so filaments with no spools sort correctly.
- Added a stable tie-breaker (`ORDER BY id`) to all sorted queries for consistent pagination.

### Frontend (`frontend/src/pages/filaments/index.astro`)

- Removed `spool_count` from the "not sortable server-side" exclusion map so clicks now trigger a server-side sort request.
- Added an inline guard to skip client-side re-sort when `sortKey === 'spool_count'` (server already returned sorted results).

### Tests (`backend/tests/test_filaments.py`)

- Added `test_list_filaments_sort_by_spool_count`: creates 4 filaments with 0/1/1/2 non-archived spools each (one archived spool also created to confirm it is excluded), then verifies both ascending and descending sort order.

---

## Validation

- ✅ `pytest tests/test_filaments.py` — 31/31 passed, no regressions
- ✅ New test `test_list_filaments_sort_by_spool_count` — verifies asc/desc order and archived spool exclusion
- ✅ Live API: `sort_by=spool_count&sort_order=asc` → `[0,1,1,1,…]`, `sort_order=desc` → `[2,2,1,1,…]`
- ✅ Invalid `sort_by` still returns `422`
- ✅ Pagination stable (no duplicates across pages)
- ✅ Other sort columns unaffected
- ✅ Browser UI: ↑/↓ indicator shown, sort updates correctly on click
- ✅ Frontend build clean