### PR TITLE
chore(frontend): reduce shared Astro TypeScript baseline errors (batch 1)

### DIFF
--- a/frontend/src/pages/filaments/[id]/edit.astro
+++ b/frontend/src/pages/filaments/[id]/edit.astro
@@ -901,7 +901,7 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
     async function loadColors(): Promise<void> {
       try {
         const data = await cachedFetchAllPages(CACHE_KEYS.COLORS, '/api/v1/colors')
-        allColors = data.items
+        allColors = data.items as { id: number; name: string; hex_code: string }[]
         renderColorGrid()
       } catch (error) {
         if (isAbortError(error)) return

--- a/frontend/src/pages/filaments/[id]/index.astro
+++ b/frontend/src/pages/filaments/[id]/index.astro
@@ -406,7 +406,7 @@ const { id } = Astro.params
         const archivedStatusId = archivedStatus ? archivedStatus.id : -1
 
         // 1. Render Table (exclude archived)
-        const activeSpools = allSpools.filter(s => s.status_id !== archivedStatusId)
+        const activeSpools = allSpools.filter((s: any) => s.status_id !== archivedStatusId)
         document.getElementById('spools-section')!.classList.remove('hidden')
         renderSpools(activeSpools)
 

--- a/frontend/src/pages/filaments/index.astro
+++ b/frontend/src/pages/filaments/index.astro
@@ -268,9 +268,10 @@ import Layout from '../../layouts/Layout.astro'
     function sortFilaments(filaments: any[]): any[] {
       if (!sortKey || !sortDirection) return filaments
       if (sortKey === 'spool_count') return filaments  // server-only sort: skip client re-sort
+      const sortBy = sortKey
       return [...filaments].sort((a, b) => {
-        const aVal = getSortValue(a, sortKey)
-        const bVal = getSortValue(b, sortKey)
+        const aVal = getSortValue(a, sortBy)
+        const bVal = getSortValue(b, sortBy)
         let cmp = 0
         if (aVal == null && bVal == null) cmp = 0
         else if (aVal == null) cmp = 1

--- a/frontend/src/pages/filaments/new.astro
+++ b/frontend/src/pages/filaments/new.astro
@@ -830,7 +830,7 @@ import Layout from '../../layouts/Layout.astro'
     async function loadColors() {
       try {
         const data = await cachedFetchAllPages(CACHE_KEYS.COLORS, '/api/v1/colors')
-        allColors = data.items
+        allColors = data.items as { id: number; name: string; hex_code: string }[]
         renderColorGrid()
       } catch (error) {
         if (isAbortError(error)) return

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -508,7 +508,8 @@ interface PaginatedResponse<T> {
       if (!currentVersion) return
 
       const lang = getLang() || 'en'
-      const changes = currentVersion.changes[lang] || currentVersion.changes['en'] || []
+      const localizedChanges = currentVersion.changes as Record<string, { type: string; text: string }[]>
+      const changes = localizedChanges[lang] || localizedChanges['en'] || []
       if (changes.length === 0) return
 
       const overlay = document.getElementById('fm-changelog-overlay')

--- a/frontend/src/pages/manufacturers/index.astro
+++ b/frontend/src/pages/manufacturers/index.astro
@@ -321,9 +321,10 @@ import Layout from '../../layouts/Layout.astro'
 
     function sortManufacturers(items: any[]): any[] {
       if (!sortKey || !sortDirection) return items
+      const sortBy = sortKey
       return [...items].sort((a, b) => {
-        const aVal = getSortValue(a, sortKey) ?? ''
-        const bVal = getSortValue(b, sortKey) ?? ''
+        const aVal = getSortValue(a, sortBy) ?? ''
+        const bVal = getSortValue(b, sortBy) ?? ''
         let cmp = 0
         if (typeof aVal === 'string') cmp = aVal.localeCompare(bVal)
         else cmp = aVal - bVal
@@ -542,7 +543,7 @@ import Layout from '../../layouts/Layout.astro'
           <td class="col-url">${mf.url ? `<a href="${escapeHtml(mf.url)}" target="_blank" rel="noopener" class="stop-prop" style="color: var(--accent); text-decoration: none;">${escapeHtml(mf.url)}</a>` : '<span style="color: var(--text-muted);">-</span>'}</td>
           <td class="col-filaments"><a href="/filaments?manufacturer_id=${mf.id}" class="stop-prop" style="color: var(--accent); text-decoration: none; font-weight: 500;">${mf.filament_count || 0}</a></td>
           <td class="col-spools"><a href="/spools?manufacturer_id=${mf.id}" class="stop-prop" style="color: var(--accent); text-decoration: none; font-weight: 500;">${mf.spool_count || 0}</a></td>
-          <td class="col-materials">${mf.materials && mf.materials.length > 0 ? mf.materials.map(m => escapeHtml(m)).join(', ') : '<span style="color: var(--text-muted);">-</span>'}</td>
+          <td class="col-materials">${mf.materials && mf.materials.length > 0 ? mf.materials.map((m: string) => escapeHtml(m)).join(', ') : '<span style="color: var(--text-muted);">-</span>'}</td>
           <td class="col-total_price" style="font-family: monospace;">${mf.total_price_available != null ? formatPrice(mf.total_price_available, getCurrency()) : '-'}</td>
           <td class="col-archived" style="color: var(--text-muted);">${mf.archived_spool_count ?? '-'}</td>
           <td class="col-spool_weight" style="font-family: monospace;">${mf.empty_spool_weight_g != null ? mf.empty_spool_weight_g + 'g' : '-'}</td>

--- a/frontend/src/pages/spools/index.astro
+++ b/frontend/src/pages/spools/index.astro
@@ -348,9 +348,10 @@ import Layout from '../../layouts/Layout.astro'
 
     function sortSpools(spools: any[]): any[] {
       if (!sortKey || !sortDirection) return spools
+      const sortBy = sortKey
       return [...spools].sort((a, b) => {
-        const aVal = getSortValue(a, sortKey)
-        const bVal = getSortValue(b, sortKey)
+        const aVal = getSortValue(a, sortBy)
+        const bVal = getSortValue(b, sortBy)
         let cmp = 0
         if (aVal == null && bVal == null) cmp = 0
         else if (aVal == null) cmp = 1

--- a/frontend/src/types/swagger-ui-dist.d.ts
+++ b/frontend/src/types/swagger-ui-dist.d.ts
@@ -1,0 +1,1 @@
+declare module 'swagger-ui-dist/swagger-ui-es-bundle.js';


### PR DESCRIPTION
## Summary

This PR fixes a first batch of frontend Astro TypeScript issues found during `astro check` and local frontend validation.

The goal is to reduce type-noise in shared list/detail page logic without changing product behavior.

> **Cross-reference:** This is the upstream clean cherry-pick of [akira69/filaman-system#17](https://github.com/akira69/filaman-system/pull/17). It contains only the 5 directly relevant commits — no README changes or unrelated file modifications.

## Why

These frontend type issues repeatedly surfaced during local checks and made ongoing frontend work noisy and harder to review.

## What Was Fixed

### 1. Safer sort-key usage in list views

Files:
- `frontend/src/pages/filaments/index.astro`
- `frontend/src/pages/manufacturers/index.astro`
- `frontend/src/pages/spools/index.astro`

**Why it was wrong:**
Sort helpers used a nullable/union sort key directly in comparator calls, which can produce avoidable TS narrowing errors.

**How it was found:**
Type-checking highlighted comparator/key-access paths where sort key narrowing was incomplete.

**How the fix addresses it:**
A narrowed local `sortBy` key is introduced before comparisons, so comparator access uses a stable non-null key.

---

### 2. Color payload typing in filament create/edit pages

Files:
- `frontend/src/pages/filaments/new.astro`
- `frontend/src/pages/filaments/[id]/edit.astro`

**Why it was wrong:**
Color list assignment from API response lacked explicit structural typing.

**How it was found:**
Type-checking flagged assignment paths where inferred response types were too loose.

**How the fix addresses it:**
Color arrays are explicitly cast to the expected `{ id, name, hex_code }[]` shape before render usage.

---

### 3. Spool filtering callback typing in filament detail page

File:
- `frontend/src/pages/filaments/[id]/index.astro`

**Why it was wrong:**
Filter callback typing was implicit in a critical list path.

**How it was found:**
Type-checking reported implicit parameter typing in callback usage.

**How the fix addresses it:**
Callback typing is made explicit to remove ambiguity and stabilize static analysis.

---

### 4. Changelog localization index typing

File:
- `frontend/src/pages/index.astro`

**Why it was wrong:**
Language-based indexing into changelog data relied on loosely typed object access.

**How it was found:**
Type-checking reported unsafe index access for localized change entries.

**How the fix addresses it:**
Localized changes are narrowed with an explicit indexed record type before language lookup.

---

### 5. Missing module declaration for Swagger UI ESM bundle

File:
- `frontend/src/types/swagger-ui-dist.d.ts` *(new file)*

**Why it was wrong:**
The Swagger UI ESM import path had no declaration in local type space.

**How it was found:**
Type-checking surfaced unresolved module typing around the Swagger UI bundle import.

**How the fix addresses it:**
A dedicated module declaration file is added for `swagger-ui-dist/swagger-ui-es-bundle.js`.

---

## Scope Notes

- This is intentionally **batch 1** — scoped to the specific frontend TS cleanup files listed above.
- No backend changes.
- No runtime behavior change.

## Code Quality / Validation

Executed directly on this branch (clean cherry-pick of the 5 commits from the fork PR).

### Frontend Build + Static Validation

- `cd frontend && cp ../version.txt ./version.txt && npm run build && rm -f ./version.txt` ✅ pass
- `cd frontend && npm run lint` ✅ pass (0 errors, 11 warnings)
- `cd frontend && npm run check` ⚠️ project-wide baseline remains noisy (421 existing errors; major remaining cluster in `src/pages/spools/[id]/index.astro` — outside this batch's scope)

## Test Checklist

- [x] Frontend production build passes
- [x] Frontend PR-scoped lint run (0 errors)
- [ ] Frontend project-wide `astro check` clean (baseline errors remain outside this batch)

## Behavior Impact

No intended runtime behavior change. This PR focuses on type-safety and static-analysis clarity for frontend code paths.

## Reviewer Notes

This PR is a focused, standalone frontend cleanup batch. It is a clean cherry-pick with no unrelated file changes (no README, no Roadmap, no backend modifications). All 5 commits are directly traceable to the fixes described above.