### PR TITLE
chore(frontend): Astro/TypeScript baseline fixes — Batch 4 (final two errors)

### DIFF
--- a/frontend/src/pages/filaments/[id]/index.astro
+++ b/frontend/src/pages/filaments/[id]/index.astro
@@ -406,7 +406,7 @@ const { id } = Astro.params
         const archivedStatusId = archivedStatus ? archivedStatus.id : -1
 
         // 1. Render Table (exclude archived)
-        const activeSpools = allSpools.filter(s => s.status_id !== archivedStatusId)
+        const activeSpools = allSpools.filter((s: any) => s.status_id !== archivedStatusId)
         document.getElementById('spools-section')!.classList.remove('hidden')
         renderSpools(activeSpools)
 

--- a/frontend/src/pages/spools/print.astro
+++ b/frontend/src/pages/spools/print.astro
@@ -142,7 +142,7 @@ import Layout from '../../layouts/Layout.astro'
   import { t, initI18n } from '../../lib/i18n'
 
   ;(window as any).filamanPrint = function() {
-    try { document.execCommand('print', false, null) } catch { window.print() }
+    try { document.execCommand('print', false, undefined) } catch { window.print() }
   }
 
   const SETTINGS_KEY = 'filaman-label-settings'


### PR DESCRIPTION
> **Cross-reference:** This is the upstream clean cherry-pick of [akira69/filaman-system#20](https://github.com/akira69/filaman-system/pull/20). It contains only the 2 directly relevant commits — no README, Roadmap, or unrelated file modifications.

## Summary

Fixes the two remaining TypeScript errors reported by `npx astro check` not covered by any earlier batch. Together with [PR #70](https://github.com/Fire-Devils/filaman-system/pull/70), [PR #71](https://github.com/Fire-Devils/filaman-system/pull/71), [PR #73](https://github.com/Fire-Devils/filaman-system/pull/73), and [PR #74](https://github.com/Fire-Devils/filaman-system/pull/74), this brings the total `astro check` error count from **433 → 0**.

---

## What Was Fixed

### `spools/print.astro` — ts(2345)

`document.execCommand('print', false, null)` passed `null` for the `value` argument typed as `string | undefined`. Replace with `undefined` — identical runtime behaviour (browsers ignore the value for the `print` command):

```diff
- document.execCommand('print', false, null)
+ document.execCommand('print', false, undefined)
```

### `filaments/[id]/index.astro` — ts(7006)

`allSpools` is assigned from `spoolsData.items` where `spoolsData` comes from `Response.json()` (`any`). Calling `.filter(s => …)` on `any` leaves the callback param without an inferred type, triggering `noImplicitAny`. Annotating as `(s: any)` makes the type explicit:

```diff
- allSpools.filter(s =>
+ allSpools.filter((s: any) =>
```

---

## Batch summary

| PR | Errors fixed |
|----|-------------|
| #70 | Backend/frontend baseline typing |
| #71 | 11 (index + filament pages) |
| #73 | 67 (`spools/new`, `filamentdb-lookup`) |
| #74 | 354 (`spools/[id]/index`, `spools/[id]/edit`) |
| **#75** | **2 (this PR — final two)** |

All five PRs are independent cherry-picks from the same `main` baseline and can be merged in any order.

---

## Code Quality / Validation

- `npx astro check`: **0 errors** after all batches applied
- `npm run build`: ✅ clean
- `npm run lint`: ✅ 0 errors

---

## Test Checklist

- [x] `npx astro check` — 0 errors project-wide (with all batches applied)
- [x] `npm run build` — clean
- [x] Filament detail page loads and renders spools list correctly
- [x] Print label page accessible with no runtime errors