### PR TITLE
feat: add read-only Spoolman-compatible API plugin (spoolmanapi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,10 @@ skills-lock.json
 Agents.md
 Claude.md
 
-# Installed plugins (only spoolman_import ships as default)
+# Installed plugins (only spoolman_import and spoolmanapi ship as defaults)
 backend/app/plugins/*/
 !backend/app/plugins/spoolman_import/
+!backend/app/plugins/spoolmanapi/
 
 # Video
 _video

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -410,6 +410,9 @@ app.include_router(auth_oidc_router)
 app.include_router(api_router)
 mount_deferred_plugin_routers(app)
 
+from app.plugins.spoolmanapi.router import router as _spoolmanapi_router  # noqa: E402
+app.include_router(_spoolmanapi_router, prefix="/spoolman")
+
 
 # --- Plugin Page Serving (works in both debug and production) ---
 # Dynamic catch-all: resolves plugin pages at request time so that

--- a/backend/app/plugins/spoolmanapi/__init__.py
+++ b/backend/app/plugins/spoolmanapi/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/backend/app/plugins/spoolmanapi/plugin.json
+++ b/backend/app/plugins/spoolmanapi/plugin.json
@@ -1,0 +1,8 @@
+{
+  "plugin_key": "spoolmanapi",
+  "plugin_type": "integration",
+  "name": "Spoolman-Compatible API",
+  "version": "1.0.0",
+  "mount_prefix": "/spoolman",
+  "show_in_nav": false
+}

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query
 from app.api.deps import DBSession
 
 from . import schemas
+from .schemas import SpoolmanPage
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
@@ -38,7 +39,7 @@ async def info() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/vendor", response_model=dict)
+@router.get("/vendor", response_model=SpoolmanPage[schemas.Vendor])
 async def list_vendors(
     db: DBSession,
     name: str | None = Query(default=None),
@@ -46,7 +47,7 @@ async def list_vendors(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Vendor]:
     svc = SpoolmanService(db)
     items, total = await svc.list_vendors(
         name=name,
@@ -55,7 +56,7 @@ async def list_vendors(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
@@ -72,7 +73,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=dict)
+@router.get("/filament", response_model=SpoolmanPage[schemas.Filament])
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -85,7 +86,7 @@ async def list_filaments(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Filament]:
     svc = SpoolmanService(db)
     items, total = await svc.list_filaments(
         vendor_name=vendor_name,
@@ -99,7 +100,7 @@ async def list_filaments(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/filament/{filament_id}", response_model=schemas.Filament)
@@ -116,7 +117,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=dict)
+@router.get("/spool", response_model=SpoolmanPage[schemas.Spool])
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -130,7 +131,7 @@ async def list_spools(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Spool]:
     svc = SpoolmanService(db)
     items, total = await svc.list_spools(
         filament_name=filament_name,
@@ -145,7 +146,7 @@ async def list_spools(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/spool/{spool_id}", response_model=schemas.Spool)

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -1,0 +1,174 @@
+"""Read-only Spoolman-compatible API router.
+
+Exposes FilaMan data under the Spoolman API shape at /spoolman/api/v1/…
+so that tools expecting a Spoolman instance (e.g. spoolman-filament-swatch)
+can point at FilaMan without modification.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.api.deps import DBSession
+
+from . import schemas
+from .service import SpoolmanService
+
+router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
+
+
+# ---------------------------------------------------------------------------
+# Health / info
+# ---------------------------------------------------------------------------
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "healthy"}
+
+
+@router.get("/info")
+async def info() -> dict[str, Any]:
+    return {"version": {"application": "filaman-spoolmanapi"}}
+
+
+# ---------------------------------------------------------------------------
+# Vendors
+# ---------------------------------------------------------------------------
+
+
+@router.get("/vendor", response_model=dict)
+async def list_vendors(
+    db: DBSession,
+    name: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_vendors(
+        name=name,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
+async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
+    svc = SpoolmanService(db)
+    vendor = await svc.get_vendor(vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=404, detail="Vendor not found")
+    return vendor
+
+
+# ---------------------------------------------------------------------------
+# Filaments
+# ---------------------------------------------------------------------------
+
+
+@router.get("/filament", response_model=dict)
+async def list_filaments(
+    db: DBSession,
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    name: str | None = Query(default=None),
+    material: str | None = Query(default=None),
+    article_number: str | None = Query(default=None),
+    color_hex: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_filaments(
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        name=name,
+        material=material,
+        article_number=article_number,
+        color_hex=color_hex,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/filament/{filament_id}", response_model=schemas.Filament)
+async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
+    svc = SpoolmanService(db)
+    filament = await svc.get_filament(filament_id)
+    if filament is None:
+        raise HTTPException(status_code=404, detail="Filament not found")
+    return filament
+
+
+# ---------------------------------------------------------------------------
+# Spools
+# ---------------------------------------------------------------------------
+
+
+@router.get("/spool", response_model=dict)
+async def list_spools(
+    db: DBSession,
+    filament_name: str | None = Query(default=None),
+    filament_id: str | None = Query(default=None),
+    filament_material: str | None = Query(default=None),
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    location: str | None = Query(default=None),
+    lot_nr: str | None = Query(default=None),
+    allow_archived: bool = Query(default=False),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_spools(
+        filament_name=filament_name,
+        filament_id=filament_id,
+        filament_material=filament_material,
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        location=location,
+        lot_nr=lot_nr,
+        allow_archived=allow_archived,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/spool/{spool_id}", response_model=schemas.Spool)
+async def get_spool(spool_id: int, db: DBSession) -> schemas.Spool:
+    svc = SpoolmanService(db)
+    spool = await svc.get_spool(spool_id)
+    if spool is None:
+        raise HTTPException(status_code=404, detail="Spool not found")
+    return spool
+
+
+# ---------------------------------------------------------------------------
+# Utility lists
+# ---------------------------------------------------------------------------
+
+
+@router.get("/material")
+async def list_materials(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_materials()
+
+
+@router.get("/location")
+async def list_locations(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_locations()

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -2,9 +2,18 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class SpoolmanPage(BaseModel, Generic[T]):
+    """Paginated list response matching the Spoolman API envelope."""
+
+    items: list[T]
+    total: int
 
 
 class Vendor(BaseModel):
@@ -14,7 +23,7 @@ class Vendor(BaseModel):
     comment: str | None = None
     empty_spool_weight: float | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Filament(BaseModel):
@@ -36,7 +45,7 @@ class Filament(BaseModel):
     multi_color_hexes: str | None = None
     multi_color_direction: str | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Spool(BaseModel):
@@ -56,11 +65,15 @@ class Spool(BaseModel):
     lot_nr: str | None = None
     comment: str | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class SpoolParameters(BaseModel):
-    """Used by spool create/update operations."""
+    """Parameters for spool create/update operations.
+
+    Reserved for future CRUD routes (PATCH /spool, POST /spool, etc.).
+    Not used by the current read-only router.
+    """
 
     filament_id: int
     price: float | None = None
@@ -74,4 +87,4 @@ class SpoolParameters(BaseModel):
     first_used: datetime | None = None
     last_used: datetime | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -1,0 +1,77 @@
+"""Pydantic schemas mirroring the Spoolman API data shapes."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Vendor(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str
+    comment: str | None = None
+    empty_spool_weight: float | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Filament(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str | None = None
+    vendor: Vendor | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float | None = None
+    diameter: float | None = None
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Spool(BaseModel):
+    id: int
+    registered: datetime | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    filament: Filament
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    remaining_length: float | None = None
+    used_length: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}
+
+
+class SpoolParameters(BaseModel):
+    """Used by spool create/update operations."""
+
+    filament_id: int
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

Adds a built-in read-only Spoolman-compatible REST API (`spoolmanapi`) that exposes FilaMan data under the Spoolman API envelope. This enables tools that expect a Spoolman instance (e.g. `spoolman-filament-swatch`) to point directly at a FilaMan server without modification.

## Base / Branch Context

- **Branch**: `feat/spoolmanapi` on `akira69/filaman-system`
- **Base**: `Fire-Devils/filaman-system:main`
- **Standalone**: yes — no dependencies on other open PRs

## Why

Part of the filament-swatch plugin integration effort. The swatch SPA (being adapted to run as a hosted FilaMan plugin) needs a Spoolman-shaped API to fetch vendors, filaments, and spools. Rather than modifying the SPA to call FilaMan's native API, this adapter plugin provides the expected interface.

## Implementation

New files under `backend/app/plugins/spoolmanapi/`:

| File | Purpose |
|---|---|
| `schemas.py` | Pydantic models: `Vendor`, `Filament`, `Spool`, `SpoolmanPage[T]`, `SpoolParameters` |
| `router.py` | 10 read-only routes — no authentication required |
| `__init__.py` | `from .router import router` |
| `plugin.json` | Metadata: `plugin_key=spoolmanapi`, `mount_prefix=/spoolman`, `show_in_nav=false` |

Routes exposed at `/spoolman/api/v1/…`:
```
GET /vendor          → SpoolmanPage[Vendor]
GET /vendor/{id}     → Vendor
GET /filament        → SpoolmanPage[Filament]
GET /filament/{id}   → Filament
GET /spool           → SpoolmanPage[Spool]
GET /spool/{id}      → Spool
GET /material        → list[str]
GET /location        → list[str]
GET /health          → {"status": "healthy"}
GET /info            → {"version": {"application": "filaman-spoolmanapi"}}
```

All list endpoints support the same query parameters as Spoolman (`name`, `vendor_id`, `material`, `color_hex`, `sort`, `limit`, `offset`, etc.).

**Wiring**: `backend/app/main.py` — `app.include_router(_spoolmanapi_router, prefix="/spoolman")` immediately after `mount_deferred_plugin_routers(app)`, following the existing `noqa: E402` import pattern already in that file.

**`.gitignore`**: Added `!backend/app/plugins/spoolmanapi/` exception so this built-in plugin is tracked in source control alongside `spoolman_import`.

## Code Quality / Validation

- `ruff check app/plugins/spoolmanapi/` → **0 errors**
- Pre-existing E712 errors in `main.py` (lines 127, 150) are not introduced by this PR
- `SpoolmanPage[T]` typed response model used on all list endpoints — no `response_model=dict` or manual `model_dump()` calls
- `extra` fields use `Field(default_factory=dict)` throughout
- Import check: `from app.plugins.spoolmanapi.router import router` resolves cleanly with all 10 routes

## Test Checklist

- [x] `ruff check` passes with 0 new errors on all new files
- [x] Router import resolves; all 10 route paths confirmed in Python
- [x] `GET /spoolman/api/v1/health` → `{"status": "healthy"}` (live server test)
- [x] `GET /spoolman/api/v1/vendor?limit=2` → `{"items": [], "total": 0}` (empty DB, correct shape)
- [x] `GET /spoolman/api/v1/filament?limit=2` → `{"items": [], "total": 0}`
- [x] `GET /spoolman/api/v1/spool?limit=2` → `{"items": [], "total": 0}`
- [x] `GET /spoolman/api/v1/material` → `[]`
- [x] `GET /spoolman/api/v1/location` → `[]`
- [x] `GET /spoolman/api/v1/info` → `{"version": {"application": "filaman-spoolmanapi"}}`
- [ ] End-to-end: spoolman-filament-swatch SPA loaded against live FilaMan with real data (Step 4 smoke test — pending)
- [ ] `GET /spoolman/api/v1/vendor/{id}` with real data → correct Vendor shape
- [ ] `GET /spoolman/api/v1/spool/{id}` with real data → correct Spool shape with nested Filament

## Remaining

- Write routes (PATCH /spool, POST /spool, etc.) for OrcaSlicer compatibility deferred to a follow-up PR
- `multi_color_direction` vocabulary mapping (Filaman `"striped"/"gradient"` vs Spoolman `"coaxial"/"longitudinal"`) to be verified in Step 4 smoke test