### PR TITLE
feat(plugins): add Spoolman-compatible API plugin (spoolmanapi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,10 @@ skills-lock.json
 Agents.md
 Claude.md
 
-# Installed plugins (only spoolman_import ships as default)
+# Installed plugins (only spoolman_import and spoolmanapi ship as defaults)
 backend/app/plugins/*/
 !backend/app/plugins/spoolman_import/
+!backend/app/plugins/spoolmanapi/
 
 # Video
 _video

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -444,9 +444,6 @@ app.include_router(auth_oidc_router)
 app.include_router(api_router)
 mount_deferred_plugin_routers(app)
 
-from app.plugins.spoolmanapi.router import router as _spoolmanapi_router  # noqa: E402
-app.include_router(_spoolmanapi_router, prefix="/spoolman")
-
 
 # --- Plugin Page Serving (works in both debug and production) ---
 # Dynamic catch-all: resolves plugin pages at request time so that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -444,6 +444,9 @@ app.include_router(auth_oidc_router)
 app.include_router(api_router)
 mount_deferred_plugin_routers(app)
 
+from app.plugins.spoolmanapi.router import router as _spoolmanapi_router  # noqa: E402
+app.include_router(_spoolmanapi_router, prefix="/spoolman")
+
 
 # --- Plugin Page Serving (works in both debug and production) ---
 # Dynamic catch-all: resolves plugin pages at request time so that

--- a/backend/app/plugins/spoolmanapi/__init__.py
+++ b/backend/app/plugins/spoolmanapi/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/backend/app/plugins/spoolmanapi/plugin.json
+++ b/backend/app/plugins/spoolmanapi/plugin.json
@@ -1,0 +1,8 @@
+{
+  "plugin_key": "spoolmanapi",
+  "plugin_type": "integration",
+  "name": "Spoolman-Compatible API",
+  "version": "1.0.0",
+  "mount_prefix": "/spoolman",
+  "show_in_nav": false
+}

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, HTTPException, Query
 from app.api.deps import DBSession
 
 from . import schemas
-from .schemas import SpoolmanPage
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
@@ -39,7 +38,7 @@ async def info() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/vendor", response_model=SpoolmanPage[schemas.Vendor])
+@router.get("/vendor", response_model=list[schemas.Vendor])
 async def list_vendors(
     db: DBSession,
     name: str | None = Query(default=None),
@@ -47,16 +46,16 @@ async def list_vendors(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Vendor]:
+) -> list[schemas.Vendor]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_vendors(
+    items, _total = await svc.list_vendors(
         name=name,
         external_id=external_id,
         sort=sort,
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
@@ -73,7 +72,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=SpoolmanPage[schemas.Filament])
+@router.get("/filament", response_model=list[schemas.Filament])
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -86,9 +85,9 @@ async def list_filaments(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Filament]:
+) -> list[schemas.Filament]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_filaments(
+    items, _total = await svc.list_filaments(
         vendor_name=vendor_name,
         vendor_id=vendor_id,
         name=name,
@@ -100,7 +99,7 @@ async def list_filaments(
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/filament/{filament_id}", response_model=schemas.Filament)
@@ -117,7 +116,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=SpoolmanPage[schemas.Spool])
+@router.get("/spool", response_model=list[schemas.Spool])
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -131,9 +130,9 @@ async def list_spools(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Spool]:
+) -> list[schemas.Spool]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_spools(
+    items, _total = await svc.list_spools(
         filament_name=filament_name,
         filament_id=filament_id,
         filament_material=filament_material,
@@ -146,7 +145,7 @@ async def list_spools(
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/spool/{spool_id}", response_model=schemas.Spool)

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -17,6 +17,20 @@ from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
 
+# ---------------------------------------------------------------------------
+# Authentication policy
+# ---------------------------------------------------------------------------
+# All routes in this router are intentionally unauthenticated.
+# Spoolman-native clients (e.g. spoolman-filament-swatch) communicate over
+# the plain Spoolman HTTP API and do not carry FilaMan JWT tokens.
+# This matches Spoolman's own default behaviour (no-auth by default).
+#
+# IMPORTANT: Deploy FilaMan behind a network boundary (reverse proxy, VPN, or
+# firewall rule) if you do not want the inventory readable by unauthenticated
+# clients on your network.  A future PR will add an optional API-key guard
+# mirroring Spoolman's SPOOLMAN_API_KEY mechanism.
+# ---------------------------------------------------------------------------
+
 
 # ---------------------------------------------------------------------------
 # Health / info

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query
 from app.api.deps import DBSession
 
 from . import schemas
+from .schemas import SpoolmanPage
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
@@ -38,7 +39,7 @@ async def info() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/vendor", response_model=dict)
+@router.get("/vendor", response_model=SpoolmanPage[schemas.Vendor])
 async def list_vendors(
     db: DBSession,
     name: str | None = Query(default=None),
@@ -46,7 +47,7 @@ async def list_vendors(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Vendor]:
     svc = SpoolmanService(db)
     items, total = await svc.list_vendors(
         name=name,
@@ -55,7 +56,7 @@ async def list_vendors(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
@@ -72,7 +73,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=dict)
+@router.get("/filament", response_model=SpoolmanPage[schemas.Filament])
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -85,7 +86,7 @@ async def list_filaments(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Filament]:
     svc = SpoolmanService(db)
     items, total = await svc.list_filaments(
         vendor_name=vendor_name,
@@ -99,7 +100,7 @@ async def list_filaments(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/filament/{filament_id}", response_model=schemas.Filament)
@@ -116,7 +117,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=dict)
+@router.get("/spool", response_model=SpoolmanPage[schemas.Spool])
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -130,7 +131,7 @@ async def list_spools(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Spool]:
     svc = SpoolmanService(db)
     items, total = await svc.list_spools(
         filament_name=filament_name,
@@ -145,7 +146,7 @@ async def list_spools(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/spool/{spool_id}", response_model=schemas.Spool)

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -1,0 +1,174 @@
+"""Read-only Spoolman-compatible API router.
+
+Exposes FilaMan data under the Spoolman API shape at /spoolman/api/v1/…
+so that tools expecting a Spoolman instance (e.g. spoolman-filament-swatch)
+can point at FilaMan without modification.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.api.deps import DBSession
+
+from . import schemas
+from .service import SpoolmanService
+
+router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
+
+
+# ---------------------------------------------------------------------------
+# Health / info
+# ---------------------------------------------------------------------------
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "healthy"}
+
+
+@router.get("/info")
+async def info() -> dict[str, Any]:
+    return {"version": {"application": "filaman-spoolmanapi"}}
+
+
+# ---------------------------------------------------------------------------
+# Vendors
+# ---------------------------------------------------------------------------
+
+
+@router.get("/vendor", response_model=dict)
+async def list_vendors(
+    db: DBSession,
+    name: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_vendors(
+        name=name,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
+async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
+    svc = SpoolmanService(db)
+    vendor = await svc.get_vendor(vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=404, detail="Vendor not found")
+    return vendor
+
+
+# ---------------------------------------------------------------------------
+# Filaments
+# ---------------------------------------------------------------------------
+
+
+@router.get("/filament", response_model=dict)
+async def list_filaments(
+    db: DBSession,
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    name: str | None = Query(default=None),
+    material: str | None = Query(default=None),
+    article_number: str | None = Query(default=None),
+    color_hex: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_filaments(
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        name=name,
+        material=material,
+        article_number=article_number,
+        color_hex=color_hex,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/filament/{filament_id}", response_model=schemas.Filament)
+async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
+    svc = SpoolmanService(db)
+    filament = await svc.get_filament(filament_id)
+    if filament is None:
+        raise HTTPException(status_code=404, detail="Filament not found")
+    return filament
+
+
+# ---------------------------------------------------------------------------
+# Spools
+# ---------------------------------------------------------------------------
+
+
+@router.get("/spool", response_model=dict)
+async def list_spools(
+    db: DBSession,
+    filament_name: str | None = Query(default=None),
+    filament_id: str | None = Query(default=None),
+    filament_material: str | None = Query(default=None),
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    location: str | None = Query(default=None),
+    lot_nr: str | None = Query(default=None),
+    allow_archived: bool = Query(default=False),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_spools(
+        filament_name=filament_name,
+        filament_id=filament_id,
+        filament_material=filament_material,
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        location=location,
+        lot_nr=lot_nr,
+        allow_archived=allow_archived,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/spool/{spool_id}", response_model=schemas.Spool)
+async def get_spool(spool_id: int, db: DBSession) -> schemas.Spool:
+    svc = SpoolmanService(db)
+    spool = await svc.get_spool(spool_id)
+    if spool is None:
+        raise HTTPException(status_code=404, detail="Spool not found")
+    return spool
+
+
+# ---------------------------------------------------------------------------
+# Utility lists
+# ---------------------------------------------------------------------------
+
+
+@router.get("/material")
+async def list_materials(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_materials()
+
+
+@router.get("/location")
+async def list_locations(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_locations()

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -2,9 +2,18 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class SpoolmanPage(BaseModel, Generic[T]):
+    """Paginated list response matching the Spoolman API envelope."""
+
+    items: list[T]
+    total: int
 
 
 class Vendor(BaseModel):
@@ -14,7 +23,7 @@ class Vendor(BaseModel):
     comment: str | None = None
     empty_spool_weight: float | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Filament(BaseModel):
@@ -36,7 +45,7 @@ class Filament(BaseModel):
     multi_color_hexes: str | None = None
     multi_color_direction: str | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Spool(BaseModel):
@@ -56,11 +65,15 @@ class Spool(BaseModel):
     lot_nr: str | None = None
     comment: str | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class SpoolParameters(BaseModel):
-    """Used by spool create/update operations."""
+    """Parameters for spool create/update operations.
+
+    Reserved for future CRUD routes (PATCH /spool, POST /spool, etc.).
+    Not used by the current read-only router.
+    """
 
     filament_id: int
     price: float | None = None
@@ -74,4 +87,4 @@ class SpoolParameters(BaseModel):
     first_used: datetime | None = None
     last_used: datetime | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -1,0 +1,77 @@
+"""Pydantic schemas mirroring the Spoolman API data shapes."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Vendor(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str
+    comment: str | None = None
+    empty_spool_weight: float | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Filament(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str | None = None
+    vendor: Vendor | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float | None = None
+    diameter: float | None = None
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Spool(BaseModel):
+    id: int
+    registered: datetime | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    filament: Filament
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    remaining_length: float | None = None
+    used_length: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}
+
+
+class SpoolParameters(BaseModel):
+    """Used by spool create/update operations."""
+
+    filament_id: int
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

Adds a new bundled integration plugin (`spoolmanapi`) that exposes a Spoolman-compatible REST API at `/spoolman/api/v1/…`, backed by FilaMan's existing database. This lets any tool that speaks the Spoolman API talk to FilaMan without requiring a separate Spoolman instance.

## Motivation

A recurring request in the community is the ability to use **Moonraker's native spoolman integration** with FilaMan directly. Moonraker's `[spoolman]` config section expects a Spoolman HTTP API — and so do several Klipper add-ons that consume it, such as [AFC-Klipper-Add-On](https://github.com/AFCProject/AFC-Klipper-Add-On).

With this plugin, pointing Moonraker at FilaMan is a one-line config change:

```ini
[spoolman]
url: http://[filaman-ip]:[port]/spoolman
```

No custom scripts, no filaman.py shim, no separate Spoolman instance. Moonraker will read `color_hex`, `material`, spool weights, and all other filament metadata directly from FilaMan via the standard Spoolman API contract.

This was discussed in the community Discord, where users reported AFC not picking up filament colours when using FilaMan — because AFC reads colour via Moonraker's native Spoolman path (`color_hex` / `multi_color_hexes` fields from `GET /api/v1/spool/{id}`). Once this plugin is present, Moonraker's native spoolman config should resolve that correctly without any additional tooling.

## What Changed

**New plugin**: `backend/app/plugins/spoolmanapi/` (4 files)

| File | Purpose |
|---|---|
| `plugin.json` | Plugin manifest: `integration` type, `mount_prefix: /spoolman`, `show_in_nav: false` |
| `__init__.py` | Package bootstrap, exposes `router` |
| `schemas.py` | Pydantic response models matching the Spoolman v1 API shape |
| `router.py` | Read-only FastAPI router (10 GET endpoints) |

**`.gitignore`**: adds untrack exception for the plugin directory.

**No `main.py` changes** — the plugin is auto-discovered and mounted by the existing `mount_deferred_plugin_routers` mechanism. No manual wiring needed.

The service layer (`service.py`) was already present in the codebase and is not part of this diff.

## Endpoints

All endpoints mount under `/spoolman/api/v1/`:

```
GET /health
GET /info
GET /vendor           → manufacturers as Spoolman vendor objects
GET /vendor/{id}
GET /filament         → filaments with full vendor + colour data
GET /filament/{id}
GET /spool            → spools with filament relation
GET /spool/{id}
GET /material         → distinct material name list
GET /location         → distinct storage location list
```

All list endpoints return **plain JSON arrays** (not `{items, total}` wrappers) to match the Spoolman v1 wire format.

## Security / Authentication

All endpoints are **intentionally unauthenticated**. Spoolman clients (Moonraker, AFC, etc.) do not carry FilaMan JWT tokens, and Spoolman itself defaults to no-auth in home setups. This design decision is explicitly documented in `router.py`.

> **Deployment note**: if FilaMan is exposed beyond a trusted network, restrict the `/spoolman/` prefix at the reverse proxy or firewall level. A follow-up PR will add an optional API-key guard mirroring Spoolman's own `SPOOLMAN_API_KEY` support.

This PR is **read-only**. Write operations (create/update/delete spool, filament, vendor) are already implemented in the service layer and will be exposed in a separate follow-up PR once the authentication strategy is agreed.

## Code Quality

- `ruff check` — 0 errors
- Typed Pydantic response models throughout; no raw `dict` returns
- Plugin registers cleanly via the existing auto-discovery system

## Test Results

Verified locally against this branch:

```
GET /spoolman/api/v1/health       → {"status":"healthy"}   ✅
GET /spoolman/api/v1/info         → {"version":{...}}       ✅
GET /spoolman/api/v1/vendor       → []  (plain array)       ✅
GET /spoolman/api/v1/filament     → []  (plain array)       ✅
GET /spoolman/api/v1/spool        → []  (plain array)       ✅
GET /spoolman/api/v1/material     → []  (plain array)       ✅
GET /spoolman/api/v1/location     → []  (plain array)       ✅
GET /spoolman/api/v1/vendor/999   → 404                     ✅
GET /spoolman/api/v1/filament/999 → 404                     ✅
GET /spoolman/api/v1/spool/999    → 404                     ✅
OpenAPI spec: 10 unique /spoolman paths, no duplicates      ✅
```

## Test Checklist

- [x] `GET /spoolman/api/v1/health` returns `{"status": "healthy"}`
- [x] `GET /spoolman/api/v1/spool` returns a plain JSON array (not `{items, total}`)
- [x] `GET /spoolman/api/v1/filament` returns a plain JSON array
- [x] `GET /spoolman/api/v1/vendor` returns manufacturers as vendor objects
- [x] Plugin auto-loads at startup via plugin auto-discovery
- [ ] Moonraker `[spoolman]` config pointing at FilaMan returns spool data including `color_hex`
