### PR TITLE
fix(spoolmanapi): complete plugin wiring, add Moonraker WebSocket endpoints, fix color serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,10 @@ skills-lock.json
 Agents.md
 Claude.md
 
-# Installed plugins (only spoolman_import ships as default)
+# Installed plugins (only spoolman_import and spoolmanapi ship as defaults)
 backend/app/plugins/*/
 !backend/app/plugins/spoolman_import/
+!backend/app/plugins/spoolmanapi/
 
 # Video
 _video

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -444,9 +444,6 @@ app.include_router(auth_oidc_router)
 app.include_router(api_router)
 mount_deferred_plugin_routers(app)
 
-from app.plugins.spoolmanapi.router import router as _spoolmanapi_router  # noqa: E402
-app.include_router(_spoolmanapi_router, prefix="/spoolman")
-
 
 # --- Plugin Page Serving (works in both debug and production) ---
 # Dynamic catch-all: resolves plugin pages at request time so that

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -444,6 +444,9 @@ app.include_router(auth_oidc_router)
 app.include_router(api_router)
 mount_deferred_plugin_routers(app)
 
+from app.plugins.spoolmanapi.router import router as _spoolmanapi_router  # noqa: E402
+app.include_router(_spoolmanapi_router, prefix="/spoolman")
+
 
 # --- Plugin Page Serving (works in both debug and production) ---
 # Dynamic catch-all: resolves plugin pages at request time so that

--- a/backend/app/plugins/spoolmanapi/__init__.py
+++ b/backend/app/plugins/spoolmanapi/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/backend/app/plugins/spoolmanapi/plugin.json
+++ b/backend/app/plugins/spoolmanapi/plugin.json
@@ -1,0 +1,8 @@
+{
+  "plugin_key": "spoolmanapi",
+  "plugin_type": "integration",
+  "name": "Spoolman-Compatible API",
+  "version": "1.0.0",
+  "mount_prefix": "/spoolman",
+  "show_in_nav": false
+}

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, HTTPException, Query
 from app.api.deps import DBSession
 
 from . import schemas
-from .schemas import SpoolmanPage
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
@@ -39,7 +38,7 @@ async def info() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/vendor", response_model=SpoolmanPage[schemas.Vendor])
+@router.get("/vendor", response_model=list[schemas.Vendor])
 async def list_vendors(
     db: DBSession,
     name: str | None = Query(default=None),
@@ -47,16 +46,16 @@ async def list_vendors(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Vendor]:
+) -> list[schemas.Vendor]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_vendors(
+    items, _total = await svc.list_vendors(
         name=name,
         external_id=external_id,
         sort=sort,
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
@@ -73,7 +72,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=SpoolmanPage[schemas.Filament])
+@router.get("/filament", response_model=list[schemas.Filament])
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -86,9 +85,9 @@ async def list_filaments(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Filament]:
+) -> list[schemas.Filament]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_filaments(
+    items, _total = await svc.list_filaments(
         vendor_name=vendor_name,
         vendor_id=vendor_id,
         name=name,
@@ -100,7 +99,7 @@ async def list_filaments(
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/filament/{filament_id}", response_model=schemas.Filament)
@@ -117,7 +116,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=SpoolmanPage[schemas.Spool])
+@router.get("/spool", response_model=list[schemas.Spool])
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -131,9 +130,9 @@ async def list_spools(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> SpoolmanPage[schemas.Spool]:
+) -> list[schemas.Spool]:
     svc = SpoolmanService(db)
-    items, total = await svc.list_spools(
+    items, _total = await svc.list_spools(
         filament_name=filament_name,
         filament_id=filament_id,
         filament_material=filament_material,
@@ -146,7 +145,7 @@ async def list_spools(
         limit=limit,
         offset=offset,
     )
-    return SpoolmanPage(items=items, total=total)
+    return items
 
 
 @router.get("/spool/{spool_id}", response_model=schemas.Spool)

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -17,6 +17,20 @@ from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
 
+# ---------------------------------------------------------------------------
+# Authentication policy
+# ---------------------------------------------------------------------------
+# All routes in this router are intentionally unauthenticated.
+# Spoolman-native clients (e.g. spoolman-filament-swatch) communicate over
+# the plain Spoolman HTTP API and do not carry FilaMan JWT tokens.
+# This matches Spoolman's own default behaviour (no-auth by default).
+#
+# IMPORTANT: Deploy FilaMan behind a network boundary (reverse proxy, VPN, or
+# firewall rule) if you do not want the inventory readable by unauthenticated
+# clients on your network.  A future PR will add an optional API-key guard
+# mirroring Spoolman's SPOOLMAN_API_KEY mechanism.
+# ---------------------------------------------------------------------------
+
 
 # ---------------------------------------------------------------------------
 # Health / info

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query
 from app.api.deps import DBSession
 
 from . import schemas
+from .schemas import SpoolmanPage
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
@@ -38,7 +39,7 @@ async def info() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/vendor", response_model=dict)
+@router.get("/vendor", response_model=SpoolmanPage[schemas.Vendor])
 async def list_vendors(
     db: DBSession,
     name: str | None = Query(default=None),
@@ -46,7 +47,7 @@ async def list_vendors(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Vendor]:
     svc = SpoolmanService(db)
     items, total = await svc.list_vendors(
         name=name,
@@ -55,7 +56,7 @@ async def list_vendors(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
@@ -72,7 +73,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=dict)
+@router.get("/filament", response_model=SpoolmanPage[schemas.Filament])
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -85,7 +86,7 @@ async def list_filaments(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Filament]:
     svc = SpoolmanService(db)
     items, total = await svc.list_filaments(
         vendor_name=vendor_name,
@@ -99,7 +100,7 @@ async def list_filaments(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/filament/{filament_id}", response_model=schemas.Filament)
@@ -116,7 +117,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=dict)
+@router.get("/spool", response_model=SpoolmanPage[schemas.Spool])
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -130,7 +131,7 @@ async def list_spools(
     sort: str | None = Query(default=None),
     limit: int | None = Query(default=None),
     offset: int = Query(default=0),
-) -> dict:
+) -> SpoolmanPage[schemas.Spool]:
     svc = SpoolmanService(db)
     items, total = await svc.list_spools(
         filament_name=filament_name,
@@ -145,7 +146,7 @@ async def list_spools(
         limit=limit,
         offset=offset,
     )
-    return {"items": [item.model_dump() for item in items], "total": total}
+    return SpoolmanPage(items=items, total=total)
 
 
 @router.get("/spool/{spool_id}", response_model=schemas.Spool)

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -6,9 +6,10 @@ can point at FilaMan without modification.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect
 
 from app.api.deps import DBSession
 
@@ -16,20 +17,6 @@ from . import schemas
 from .service import SpoolmanService
 
 router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
-
-# ---------------------------------------------------------------------------
-# Authentication policy
-# ---------------------------------------------------------------------------
-# All routes in this router are intentionally unauthenticated.
-# Spoolman-native clients (e.g. spoolman-filament-swatch) communicate over
-# the plain Spoolman HTTP API and do not carry FilaMan JWT tokens.
-# This matches Spoolman's own default behaviour (no-auth by default).
-#
-# IMPORTANT: Deploy FilaMan behind a network boundary (reverse proxy, VPN, or
-# firewall rule) if you do not want the inventory readable by unauthenticated
-# clients on your network.  A future PR will add an optional API-key guard
-# mirroring Spoolman's SPOOLMAN_API_KEY mechanism.
-# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +73,7 @@ async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/filament", response_model=list[schemas.Filament])
+@router.get("/filament", response_model=list[schemas.Filament], response_model_exclude_none=True)
 async def list_filaments(
     db: DBSession,
     vendor_name: str | None = Query(default=None),
@@ -116,7 +103,7 @@ async def list_filaments(
     return items
 
 
-@router.get("/filament/{filament_id}", response_model=schemas.Filament)
+@router.get("/filament/{filament_id}", response_model=schemas.Filament, response_model_exclude_none=True)
 async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
     svc = SpoolmanService(db)
     filament = await svc.get_filament(filament_id)
@@ -130,7 +117,7 @@ async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/spool", response_model=list[schemas.Spool])
+@router.get("/spool", response_model=list[schemas.Spool], response_model_exclude_none=True)
 async def list_spools(
     db: DBSession,
     filament_name: str | None = Query(default=None),
@@ -162,13 +149,42 @@ async def list_spools(
     return items
 
 
-@router.get("/spool/{spool_id}", response_model=schemas.Spool)
+@router.get("/spool/{spool_id}", response_model=schemas.Spool, response_model_exclude_none=True)
 async def get_spool(spool_id: int, db: DBSession) -> schemas.Spool:
     svc = SpoolmanService(db)
     spool = await svc.get_spool(spool_id)
     if spool is None:
         raise HTTPException(status_code=404, detail="Spool not found")
     return spool
+
+
+@router.websocket("/spool")
+async def websocket_spool_list(websocket: WebSocket) -> None:
+    """WebSocket endpoint required by Moonraker's native [spoolman] integration.
+
+    Moonraker connects here to receive real-time spool-change events.
+    This implementation keeps the connection alive; future work can push
+    FilaMan spool-change events over this socket.
+    """
+    await websocket.accept()
+    try:
+        while True:
+            await asyncio.sleep(30)
+            await websocket.send_json({"type": "ping"})
+    except (WebSocketDisconnect, Exception):
+        pass
+
+
+@router.websocket("/spool/{spool_id}")
+async def websocket_spool_single(websocket: WebSocket, spool_id: int) -> None:  # noqa: ARG001
+    """WebSocket endpoint for a specific spool, required by Moonraker."""
+    await websocket.accept()
+    try:
+        while True:
+            await asyncio.sleep(30)
+            await websocket.send_json({"type": "ping"})
+    except (WebSocketDisconnect, Exception):
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/plugins/spoolmanapi/router.py
+++ b/backend/app/plugins/spoolmanapi/router.py
@@ -1,0 +1,174 @@
+"""Read-only Spoolman-compatible API router.
+
+Exposes FilaMan data under the Spoolman API shape at /spoolman/api/v1/…
+so that tools expecting a Spoolman instance (e.g. spoolman-filament-swatch)
+can point at FilaMan without modification.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from app.api.deps import DBSession
+
+from . import schemas
+from .service import SpoolmanService
+
+router = APIRouter(prefix="/api/v1", tags=["Spoolman Compat API"])
+
+
+# ---------------------------------------------------------------------------
+# Health / info
+# ---------------------------------------------------------------------------
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "healthy"}
+
+
+@router.get("/info")
+async def info() -> dict[str, Any]:
+    return {"version": {"application": "filaman-spoolmanapi"}}
+
+
+# ---------------------------------------------------------------------------
+# Vendors
+# ---------------------------------------------------------------------------
+
+
+@router.get("/vendor", response_model=dict)
+async def list_vendors(
+    db: DBSession,
+    name: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_vendors(
+        name=name,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/vendor/{vendor_id}", response_model=schemas.Vendor)
+async def get_vendor(vendor_id: int, db: DBSession) -> schemas.Vendor:
+    svc = SpoolmanService(db)
+    vendor = await svc.get_vendor(vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=404, detail="Vendor not found")
+    return vendor
+
+
+# ---------------------------------------------------------------------------
+# Filaments
+# ---------------------------------------------------------------------------
+
+
+@router.get("/filament", response_model=dict)
+async def list_filaments(
+    db: DBSession,
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    name: str | None = Query(default=None),
+    material: str | None = Query(default=None),
+    article_number: str | None = Query(default=None),
+    color_hex: str | None = Query(default=None),
+    external_id: str | None = Query(default=None),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_filaments(
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        name=name,
+        material=material,
+        article_number=article_number,
+        color_hex=color_hex,
+        external_id=external_id,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/filament/{filament_id}", response_model=schemas.Filament)
+async def get_filament(filament_id: int, db: DBSession) -> schemas.Filament:
+    svc = SpoolmanService(db)
+    filament = await svc.get_filament(filament_id)
+    if filament is None:
+        raise HTTPException(status_code=404, detail="Filament not found")
+    return filament
+
+
+# ---------------------------------------------------------------------------
+# Spools
+# ---------------------------------------------------------------------------
+
+
+@router.get("/spool", response_model=dict)
+async def list_spools(
+    db: DBSession,
+    filament_name: str | None = Query(default=None),
+    filament_id: str | None = Query(default=None),
+    filament_material: str | None = Query(default=None),
+    vendor_name: str | None = Query(default=None),
+    vendor_id: str | None = Query(default=None),
+    location: str | None = Query(default=None),
+    lot_nr: str | None = Query(default=None),
+    allow_archived: bool = Query(default=False),
+    sort: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    offset: int = Query(default=0),
+) -> dict:
+    svc = SpoolmanService(db)
+    items, total = await svc.list_spools(
+        filament_name=filament_name,
+        filament_id=filament_id,
+        filament_material=filament_material,
+        vendor_name=vendor_name,
+        vendor_id=vendor_id,
+        location=location,
+        lot_nr=lot_nr,
+        allow_archived=allow_archived,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+    return {"items": [item.model_dump() for item in items], "total": total}
+
+
+@router.get("/spool/{spool_id}", response_model=schemas.Spool)
+async def get_spool(spool_id: int, db: DBSession) -> schemas.Spool:
+    svc = SpoolmanService(db)
+    spool = await svc.get_spool(spool_id)
+    if spool is None:
+        raise HTTPException(status_code=404, detail="Spool not found")
+    return spool
+
+
+# ---------------------------------------------------------------------------
+# Utility lists
+# ---------------------------------------------------------------------------
+
+
+@router.get("/material")
+async def list_materials(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_materials()
+
+
+@router.get("/location")
+async def list_locations(db: DBSession) -> list[str]:
+    svc = SpoolmanService(db)
+    return await svc.list_locations()

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -2,9 +2,18 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+T = TypeVar("T")
+
+
+class SpoolmanPage(BaseModel, Generic[T]):
+    """Paginated list response matching the Spoolman API envelope."""
+
+    items: list[T]
+    total: int
 
 
 class Vendor(BaseModel):
@@ -14,7 +23,7 @@ class Vendor(BaseModel):
     comment: str | None = None
     empty_spool_weight: float | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Filament(BaseModel):
@@ -36,7 +45,7 @@ class Filament(BaseModel):
     multi_color_hexes: str | None = None
     multi_color_direction: str | None = None
     external_id: str | None = None
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class Spool(BaseModel):
@@ -56,11 +65,15 @@ class Spool(BaseModel):
     lot_nr: str | None = None
     comment: str | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class SpoolParameters(BaseModel):
-    """Used by spool create/update operations."""
+    """Parameters for spool create/update operations.
+
+    Reserved for future CRUD routes (PATCH /spool, POST /spool, etc.).
+    Not used by the current read-only router.
+    """
 
     filament_id: int
     price: float | None = None
@@ -74,4 +87,4 @@ class SpoolParameters(BaseModel):
     first_used: datetime | None = None
     last_used: datetime | None = None
     archived: bool = False
-    extra: dict[str, Any] = {}
+    extra: dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/plugins/spoolmanapi/schemas.py
+++ b/backend/app/plugins/spoolmanapi/schemas.py
@@ -1,0 +1,77 @@
+"""Pydantic schemas mirroring the Spoolman API data shapes."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Vendor(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str
+    comment: str | None = None
+    empty_spool_weight: float | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Filament(BaseModel):
+    id: int
+    registered: datetime | None = None
+    name: str | None = None
+    vendor: Vendor | None = None
+    material: str | None = None
+    price: float | None = None
+    density: float | None = None
+    diameter: float | None = None
+    weight: float | None = None
+    spool_weight: float | None = None
+    article_number: str | None = None
+    comment: str | None = None
+    settings_extruder_temp: int | None = None
+    settings_bed_temp: int | None = None
+    color_hex: str | None = None
+    multi_color_hexes: str | None = None
+    multi_color_direction: str | None = None
+    external_id: str | None = None
+    extra: dict[str, Any] = {}
+
+
+class Spool(BaseModel):
+    id: int
+    registered: datetime | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    filament: Filament
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    remaining_length: float | None = None
+    used_length: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}
+
+
+class SpoolParameters(BaseModel):
+    """Used by spool create/update operations."""
+
+    filament_id: int
+    price: float | None = None
+    initial_weight: float | None = None
+    spool_weight: float | None = None
+    remaining_weight: float | None = None
+    used_weight: float | None = None
+    location: str | None = None
+    lot_nr: str | None = None
+    comment: str | None = None
+    first_used: datetime | None = None
+    last_used: datetime | None = None
+    archived: bool = False
+    extra: dict[str, Any] = {}


### PR DESCRIPTION
## Summary

Completes the `spoolmanapi` plugin that already has a `service.py` in `main`, adds the missing plugin infrastructure, and fixes two bugs that prevent colors from reaching Moonraker/AFC/BoxTurtle integrations.

## Base / Branch Context

- **Target repo**: Fire-Devils/filaman-system (`main`)
- **Head**: `akira69:feat/spoolmanapi`
- **Standalone**: yes — no unrelated changes, no stacked deps
- **Prior art**: upstream already has `backend/app/plugins/spoolmanapi/service.py` from an earlier PR. This PR adds `plugin.json`, `__init__.py`, `router.py`, and `schemas.py` to make it a loadable plugin, plus the fixes below.

## Why

### Bug 1 — Missing WebSocket endpoints (Moonraker integration broken)

Moonraker's native `[spoolman]` config opens a WebSocket to `ws://[host]/spoolman/api/v1/spool` on startup. Without this endpoint, Moonraker logs an error and **cannot initialize the spoolman integration at all** — no color data flows downstream even though the REST API responses are correct.

Real Spoolman serves this via `@router.websocket("")` in its spool router ([source](https://github.com/Donkie/Spoolman/blob/master/spoolman/api/v1/spool.py)).

### Bug 2 — `null` color fields break AFC lane coloring

Real Spoolman uses `response_model_exclude_none=True` on all spool/filament endpoints. Without this, filaments with no color set return `"color_hex": null`. AFC does:

```python
cur_lane.color = '#{}'.format(filament['color_hex'])
```

This produces `"#None"` — an invalid color value — causing lane indicators to render blank.

## Implementation

**New files** (plugin infrastructure):
- `plugin.json` — declares `mount_prefix: /spoolman`, `plugin_type: integration`, `show_in_nav: false`
- `__init__.py` — exposes the router for plugin auto-discovery
- `schemas.py` — Pydantic models matching the Spoolman API shape (`Vendor`, `Filament`, `Spool`), including `color_hex` and `multi_color_hexes`
- `router.py` — FastAPI router at prefix `/api/v1` (full path: `/spoolman/api/v1/…`) with:
  - GET endpoints for `/health`, `/info`, `/vendor`, `/vendor/{id}`, `/filament`, `/filament/{id}`, `/spool`, `/spool/{id}`, `/material`, `/location`
  - WebSocket endpoints at `/spool` and `/spool/{spool_id}` for Moonraker compatibility
  - `response_model_exclude_none=True` on all filament and spool endpoints

**`service.py`**: unchanged from what is already in `main`.

## Code Quality / Validation

- `ruff check backend/app/plugins/spoolmanapi/router.py` — ✅ all checks passed
- `python -m compileall backend/app/plugins/spoolmanapi/` — ✅ no errors

## Test Checklist

- [ ] Moonraker `[spoolman]` section pointing at `http://[host]:8000/spoolman` — no WebSocket error in Moonraker log
- [ ] `GET /spoolman/api/v1/spool` returns spool list with filament data
- [ ] Filament with color set: `color_hex` field is present and has no `#` prefix (e.g. `"2D6A3F"`)
- [ ] Filament without color set: `color_hex` field is **absent** from the response (not `null`)
- [ ] AFC lane colors populate correctly when spool is assigned in Moonraker
- [ ] `GET /spoolman/api/v1/health` returns `{"status": "healthy"}`
- [ ] WebSocket connection to `ws://[host]:8000/spoolman/api/v1/spool` is accepted and stays open