### PR TITLE
Add label modifier token chips

### DIFF
--- a/frontend/src/lib/label-template.ts
+++ b/frontend/src/lib/label-template.ts
@@ -7,6 +7,8 @@
  *                            omitted entirely when token resolves to "?"
  *   **bold**               — <strong> text
  *   *italic*               — <em> text (single asterisk, not part of **)
+ *   __underline__          — <u> text
+ *   ^^caps^^               — uppercase text
  *   ==inverse==            — inverted text (black bg, white text)
  *   @@inverse@@            — inverted text using filament color with automatic black/white text
  *   [size=120]text[/size]  — inline relative size in percent (50..300)
@@ -80,6 +82,10 @@ function renderColorSwatchMarker(token: string, data: SpoolData): string | null 
   return `[[FM_SWATCH|${widthCh}|${hex}]]`
 }
 
+function applyCapsMarkup(text: string): string {
+  return text.replace(/\^\^([\s\S]*?)\^\^/g, (_match, inner: string) => inner.toUpperCase())
+}
+
 /** Resolve a dot-path token against the spool data object. */
 function resolveToken(token: string, data: SpoolData): string {
   if (token.startsWith('extra.')) {
@@ -99,7 +105,7 @@ export function renderTemplateText(template: string, data: SpoolData): string {
     : template
   // Match both optional-block {{inner}} style and simple {token}
   // Process longest matches first (optional blocks) before simple tokens.
-  return boundedTemplate.replace(
+  const rendered = boundedTemplate.replace(
     /{(?:[^{}]|{[^{}]*})*}/g,
     (match) => {
       // Optional block: {prefix{token}suffix}
@@ -119,13 +125,16 @@ export function renderTemplateText(template: string, data: SpoolData): string {
       return resolved === '?' ? '' : resolved
     }
   )
+  // Caps runs after token resolution so wrapped tokens uppercase their values,
+  // without forcing fields like color_hex to be uppercase by default.
+  return applyCapsMarkup(rendered)
 }
 
-/** Apply **bold**, *italic*, ==inverse==, @@inverse@@ and [size=..] inline markup. */
+/** Apply inline markup to rendered template text. */
 function applyMarkup(text: string, frag: DocumentFragment | HTMLElement, data: SpoolData): void {
   // Regex: match swatch marker, [size=NNN]...[/size] (case-insensitive),
-  // bold (**…**), italic (*…*), inverse (==…==), filament inverse (@@…@@)
-  const regex = /(\[\[FM_SWATCH\|\d{1,3}\|#[0-9A-F]{6}\]\]|\[size=\d{1,3}%?\][\s\S]*?\[\/size\]|\*\*[\s\S]*?\*\*|\*(?!\*)([\s\S]*?)\*(?!\*)|==[\s\S]*?==|@@[\s\S]*?@@)/gi
+  // bold (**...**), underline (__...__), italic (*...*), inverse (==...==), filament inverse (@@...@@)
+  const regex = /(\[\[FM_SWATCH\|\d{1,3}\|#[0-9A-F]{6}\]\]|\[size=\d{1,3}%?\][\s\S]*?\[\/size\]|\*\*[\s\S]*?\*\*|__[\s\S]*?__|\*(?!\*)([\s\S]*?)\*(?!\*)|==[\s\S]*?==|@@[\s\S]*?@@)/gi
   let last = 0
 
   const appendPlainText = (raw: string, container: DocumentFragment | HTMLElement) => {
@@ -174,6 +183,11 @@ function applyMarkup(text: string, frag: DocumentFragment | HTMLElement, data: S
     } else if (part.startsWith('**') && part.endsWith('**')) {
       const inner = part.slice(2, -2)
       const el = document.createElement('strong')
+      applyMarkup(inner, el, data)
+      frag.appendChild(el)
+    } else if (part.startsWith('__') && part.endsWith('__')) {
+      const inner = part.slice(2, -2)
+      const el = document.createElement('u')
       applyMarkup(inner, el, data)
       frag.appendChild(el)
     } else if (part.startsWith('==') && part.endsWith('==')) {

--- a/frontend/src/pages/spools/[id]/print.astro
+++ b/frontend/src/pages/spools/[id]/print.astro
@@ -1592,6 +1592,208 @@ const { id } = Astro.params
     color: var(--btn-primary-text);
   }
 
+  .ds-tokens-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin: 0 -6px 4px -6px;
+    padding: 4px 6px 3px 6px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .ds-tokens-group-header .ds-tokens-group-label {
+    margin: 0;
+    padding: 0;
+    border-bottom: none;
+  }
+
+  .ds-modifier-chips {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 3px;
+    margin-left: auto;
+  }
+
+  .ds-modifier-chip {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 4px;
+    border: 1px solid color-mix(in srgb, var(--accent) 70%, var(--border));
+    background: color-mix(in srgb, var(--bg-elevated) 72%, var(--accent) 12%);
+    color: var(--accent);
+    cursor: pointer;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 0.57rem;
+    font-weight: 700;
+    line-height: 1;
+    transition: background var(--transition), border-color var(--transition), color var(--transition);
+  }
+
+  .ds-modifier-chip:hover,
+  .ds-modifier-chip.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--btn-primary-text);
+  }
+
+  .ds-modifier-chip.active {
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 60%, transparent);
+  }
+
+  /* Visual-only tooltip; aria-label remains the stable accessible name. */
+  .ds-modifier-chip::before {
+    content: '';
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    z-index: 20;
+    max-width: 160px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-elevated) 94%, var(--text) 6%);
+    color: var(--text-muted);
+    font-family: Inter, system-ui, sans-serif;
+    font-size: 0.62rem;
+    font-weight: 600;
+    line-height: 1.2;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transform: translate(-50%, 2px);
+    transition: opacity var(--transition), transform var(--transition);
+  }
+
+  .ds-modifier-chip:hover::before,
+  .ds-modifier-chip:focus-visible::before {
+    content: attr(data-tooltip);
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+
+  .ds-modifier-chip:nth-last-child(-n + 2)::before {
+    left: auto;
+    right: 0;
+    transform: translate(0, 2px);
+  }
+
+  .ds-modifier-chip:nth-last-child(-n + 2):hover::before,
+  .ds-modifier-chip:nth-last-child(-n + 2):focus-visible::before {
+    transform: translate(0, 0);
+  }
+
+  .ds-modifier-bold::before {
+    color: var(--text);
+    font-weight: 900;
+  }
+
+  .ds-modifier-italic::before {
+    color: var(--text);
+    font-style: italic;
+  }
+
+  .ds-modifier-underline::before {
+    color: var(--text);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .ds-modifier-inverse::before {
+    background: #000;
+    border-color: #000;
+    color: #fff;
+  }
+
+  .ds-modifier-color-inverse::before {
+    background: color-mix(in srgb, var(--accent) 72%, #000);
+    border-color: var(--accent);
+    color: var(--btn-primary-text);
+  }
+
+  .ds-modifier-color-inverse.has-filament-color::before {
+    background: var(--ds-filament-bg, #000);
+    border-color: var(--ds-filament-bg, #000);
+    color: var(--ds-filament-fg, #fff);
+  }
+
+  .ds-modifier-caps::before {
+    color: var(--text);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .ds-modifier-bold {
+    font-weight: 900;
+  }
+
+  .ds-modifier-italic {
+    font-style: italic;
+  }
+
+  .ds-modifier-underline {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .ds-modifier-inverse {
+    min-width: 24px;
+    padding: 0;
+    background: #000;
+    border-color: #000;
+    color: #fff;
+    font-size: 0.84rem;
+  }
+
+  .ds-modifier-inverse:hover,
+  .ds-modifier-inverse.active {
+    background: #fff;
+    border-color: #fff;
+    color: #000;
+  }
+
+  .ds-modifier-color-inverse {
+    min-width: 24px;
+    padding: 0;
+    background: color-mix(in srgb, var(--accent) 72%, #000);
+    border-color: var(--accent);
+    color: var(--btn-primary-text);
+    font-size: 0.84rem;
+  }
+
+  .ds-modifier-color-inverse::after {
+    content: '';
+    position: absolute;
+    right: 3px;
+    bottom: 2px;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 1px solid var(--btn-primary-text);
+  }
+
+  .ds-modifier-color-inverse.has-filament-color {
+    background: var(--ds-filament-bg, #000);
+    border-color: var(--ds-filament-bg, #000);
+    color: var(--ds-filament-fg, #fff);
+  }
+
+  .ds-modifier-color-inverse.has-filament-color::after {
+    content: none;
+  }
+
+  .ds-modifier-caps {
+    font-size: 0.72rem;
+    line-height: 0.9;
+  }
+
   /* Token area sections — must be global because they're created dynamically via JS */
   .ds-token-area {
     margin-top: 5px;
@@ -1807,6 +2009,13 @@ const { id } = Astro.params
     finish: params.get('finish') || '',
     density: params.get('density') || '',
     price: params.get('price') || '',
+  }
+
+  function getFilamentInverseChipTheme() {
+    const background = normalizeHexColor(labelData.hex_code)
+    // Null keeps the neutral fallback icon when the current label has no valid color hex.
+    if (!background) return null
+    return { background, foreground: getReadableTextColor(background) }
   }
 
   let extraFields: {key: string, label: string, value: string, source?: string}[] = []
@@ -2070,6 +2279,23 @@ const { id } = Astro.params
     { token: '{filament.finish}',       label: 'finish' },
     { token: '{filament.density}',      label: 'density' },
     { token: '{filament.price}',        label: 'price' },
+  ]
+
+  interface DesignerModifier {
+    key: string
+    label: string
+    title: string
+    className?: string
+    wrap: (token: string) => string
+  }
+
+  const DESIGNER_MODIFIERS: DesignerModifier[] = [
+    { key: 'bold', label: 'B', title: 'Bold', className: 'ds-modifier-bold', wrap: (token) => `**${token}**` },
+    { key: 'italic', label: 'I', title: 'Italic', className: 'ds-modifier-italic', wrap: (token) => `*${token}*` },
+    { key: 'underline', label: 'U', title: 'Underline', className: 'ds-modifier-underline', wrap: (token) => `__${token}__` },
+    { key: 'inverse', label: '◐', title: 'Inverse', className: 'ds-modifier-inverse', wrap: (token) => `==${token}==` },
+    { key: 'colorInverse', label: '◐', title: 'Color Hex Inverse', className: 'ds-modifier-color-inverse', wrap: (token) => `@@${token}@@` },
+    { key: 'caps', label: '⇧', title: 'Uppercase', className: 'ds-modifier-caps', wrap: (token) => `^^${token}^^` },
   ]
 
   function saveDesignerSettings() {
@@ -2398,9 +2624,12 @@ const { id } = Astro.params
       <tr><td>[size=120%]text[/size]</td><td>Inline relative text size in % (50..300, % optional); works with literal text, field values, and swatches.<br><span class="ds-popover-eg">e.g. [size=140%]{filament.extruder_temp}[/size]°C or [size=120%]{color_swatch[6]}[/size] {filament.color}</span></td></tr>
       <tr><td>**text**</td><td><strong>Bold</strong></td></tr>
       <tr><td>*text*</td><td><em>Italic</em></td></tr>
+      <tr><td>__text__</td><td><u>Underline</u></td></tr>
+      <tr><td>^^text^^</td><td>Uppercase text and field values.<br><span class="ds-popover-eg">e.g. ^^{filament.color_hex}^^ → FF6A00</span></td></tr>
       <tr><td>==text==</td><td style="background:#000;color:#fff;padding:0 2px;border-radius:2px">Inverse (white on black)</td></tr>
       <tr><td>@@text@@</td><td>Inverse using filament color with automatic black/white text chosen for best contrast.<br><span class="ds-popover-eg"><span style="background:#2A5BE8;color:#fff;padding:0 2px;border-radius:2px">Blue uses white text</span> <span style="background:#F5E663;color:#000;padding:0 2px;border-radius:2px">Yellow uses black text</span></span></td></tr>
-      <tr><td>\\n</td><td>New line (in info textarea, just press Enter)</td></tr>
+      <tr><td>Nested</td><td>Text modifiers can be nested manually.<br><span class="ds-popover-eg">e.g. **__{filament.name}__** → bold + underline</span></td></tr>
+      <tr><td>Line breaks</td><td>Use an actual Return/Enter in the text area for a new line.</td></tr>
     </table>`
 
   let _activeSyntaxPopover: HTMLElement | null = null
@@ -2463,19 +2692,35 @@ const { id } = Astro.params
     // so state is preserved across rebuilds.
     area.innerHTML = ''
 
+    let activeModifier: DesignerModifier | null = null
+
+    function updateModifierButtons(group: HTMLElement) {
+      group.querySelectorAll<HTMLButtonElement>('.ds-modifier-chip').forEach(btn => {
+        const isActive = btn.dataset.modifier === activeModifier?.key
+        btn.classList.toggle('active', isActive)
+        btn.setAttribute('aria-pressed', String(isActive))
+      })
+    }
+
     function insertTok(tok: string) {
       const el = document.getElementById(targetId) as HTMLInputElement | HTMLTextAreaElement
       if (!el) return
+      const formattedTok = activeModifier ? activeModifier.wrap(tok) : tok
       const start = el.selectionStart ?? el.value.length
       const end   = el.selectionEnd   ?? el.value.length
       const before = el.value.slice(0, start)
       const after  = el.value.slice(end)
       const needSpaceBefore = before.length > 0 && !/\s$/.test(before)
       const needSpaceAfter  = after.length  > 0 && !/^\s/.test(after)
-      const insert = (needSpaceBefore ? ' ' : '') + tok + (needSpaceAfter ? ' ' : '')
+      const insert = (needSpaceBefore ? ' ' : '') + formattedTok + (needSpaceAfter ? ' ' : '')
       el.value = before + insert + after
       el.selectionStart = el.selectionEnd = start + insert.length
       el.focus()
+      // Modifiers are one-shot: apply to this token, then clear for the next click.
+      if (activeModifier) {
+        activeModifier = null
+        updateModifierButtons(area)
+      }
       saveDesignerSettings()
       updateDesignerPreview()
     }
@@ -2487,6 +2732,31 @@ const { id } = Astro.params
       chip.textContent = label
       chip.title = tok          // full token shown on hover
       chip.addEventListener('click', () => insertTok(tok))
+      return chip
+    }
+
+    function makeModifierChip(modifier: DesignerModifier, group: HTMLElement): HTMLButtonElement {
+      const chip = document.createElement('button')
+      chip.className = `ds-modifier-chip ${modifier.className ?? ''}`.trim()
+      chip.type = 'button'
+      chip.textContent = modifier.label
+      chip.title = `${modifier.title}: click, then click a token`
+      chip.dataset.tooltip = modifier.title
+      chip.dataset.modifier = modifier.key
+      if (modifier.key === 'colorInverse') {
+        const theme = getFilamentInverseChipTheme()
+        if (theme) {
+          chip.classList.add('has-filament-color')
+          chip.style.setProperty('--ds-filament-bg', theme.background)
+          chip.style.setProperty('--ds-filament-fg', theme.foreground)
+        }
+      }
+      chip.setAttribute('aria-label', `${modifier.title} token modifier`)
+      chip.setAttribute('aria-pressed', 'false')
+      chip.addEventListener('click', () => {
+        activeModifier = activeModifier?.key === modifier.key ? null : modifier
+        updateModifierButtons(group)
+      })
       return chip
     }
 
@@ -2506,13 +2776,22 @@ const { id } = Astro.params
 
     // ── Filament group ──
     const filGroup = document.createElement('div')
+    const filHeader = document.createElement('div')
+    filHeader.className = 'ds-tokens-group-header'
     const filLbl = document.createElement('div')
     filLbl.className = 'ds-tokens-group-label'
     filLbl.textContent = 'Filament'
+    const modifierGroup = document.createElement('div')
+    modifierGroup.className = 'ds-modifier-chips'
+    for (const modifier of DESIGNER_MODIFIERS) {
+      modifierGroup.appendChild(makeModifierChip(modifier, modifierGroup))
+    }
     const filChips = document.createElement('div')
     filChips.className = 'ds-token-hints'
     for (const { token, label } of DESIGNER_TOKENS) filChips.appendChild(makeChip(token, label))
-    filGroup.appendChild(filLbl)
+    filHeader.appendChild(filLbl)
+    filHeader.appendChild(modifierGroup)
+    filGroup.appendChild(filHeader)
     filGroup.appendChild(filChips)
     body.appendChild(filGroup)
 


### PR DESCRIPTION
## Intro

After incorporating the label designer, it became clear that a little more control over token text formatting would be helpful.

This started as a small PR to add CAPS, but it grew into clickable modifier chips for the text options directly in the clickable-token header. That gives the designer a visible way to show which text modification options are available.

## Summary

- Add modifier chips beside the Filament token header in the advanced label designer.
- Support click-a-modifier then click-a-token insertion for bold, italic, underline, inverse, color-hex inverse, and caps.
- Add first-class caps support with `^^text^^`, including token-chip insertion and parser rendering after token resolution.
- Add underline syntax with `__text__`.
- Use compact contrast-style icons for inverse modifiers instead of long `INV` labels.
- Show the Color Hex Inverse icon in the current spool hex color when one is available; fall back to the normal accent icon when no valid hex is defined.
- Harden modifier controls with explicit accessible labels and pressed state.

## Behavior

- Clicking a modifier arms it for that token area.
- Clicking a token inserts the wrapped syntax, for example `^^{filament.color_hex}^^` or `__{filament.name}__`.
- Caps uses `^^...^^` and uppercases resolved field values, so `^^{filament.color_hex}^^` renders the current value in uppercase without forcing uppercase by default.
- Modifiers are one-shot: after a modified token is inserted, the active modifier clears before the next token click.
- Hovering or focusing a modifier chip shows a compact, theme-muted tooltip with the modifier name styled to match the modifier.
- Print Format Syntax now documents nested modifiers and points users to actual Return/Enter line breaks instead of a visible `\n` helper row.
- Size, strikethrough, and font selection are intentionally left out of this PR.

## Nested Modifiers

The renderer supports manually nested modifiers because markup is parsed recursively. For example, `**__{filament.name}__**` renders bold + underline, and caps can be combined with other wrappers because `^^...^^` is resolved before rich markup rendering.

The chip workflow is intentionally one-shot for clarity: one modifier click applies to the next token only. Combining modifiers is done by editing/nesting the generated syntax.

## Screenshots

Screenshots are stored locally only under `_pr/label-modifier-chips/.screenshots/`; they are not committed to this branch.

![Modifier chips in the Filament token tray](https://gist.githubusercontent.com/akira69/71ad22c81ab79b377115862dbc1db606/raw/modifier-chips-token-area.svg)

## Hardening Review

- Security: no new server endpoint, database access, or external request path is introduced.
- Injection surface: token/modifier labels are written with `textContent`, and inserted syntax goes into the format textarea. Rendering still builds DOM nodes/text nodes rather than injecting token values with `innerHTML`.
- Parser behavior: caps is applied after token resolution and before rich markup rendering, so `^^{filament.color_hex}^^` uppercases the resolved value without forcing color hex uppercase by default.
- State isolation: active modifier state is scoped per token area rebuild and clears after token insertion.
- Accessibility: modifier buttons expose `aria-label` and `aria-pressed`, matching the visible active state. Hover/focus tooltips use generated visual text while the accessible name remains stable.
- Tooltip styling: default tooltips use the app surface/border/muted-text palette; bold, underline, inverse, Color Hex Inverse, and caps tooltips visually reflect their modifiers.
- Color safety: the Color Hex Inverse icon only uses `labelData.hex_code` after `normalizeHexColor`; invalid or missing hex values keep the normal fallback icon. Foreground color uses the same `getReadableTextColor` contrast helper as preview/print rendering.
- Efficiency: modifier definitions stay centralized in `DESIGNER_MODIFIERS`; insertion is a small local string operation with no repeated search/indexing beyond the active token area.
- Line count: removed an unused CSS transition target while keeping the modifier implementation centralized.

## Validation

- `npm run lint`
  - Passed with existing warnings.
- `npm run build`
  - Passed. The existing frontend build script still prints `cat: ./version.txt: No such file or directory` when run from `frontend/`, but Astro completed successfully.
- Browser verification on `http://127.0.0.1:4321/spools/1/print`
  - Modifier chips rendered in the token trays with compact contrast-style inverse icons and styled hover tooltips.
  - Tooltip styles verified for Bold, Underline, Inverse, Color Hex Inverse, and Uppercase.
  - Valid `hex_code=F5E663` rendered the Color Hex Inverse chip with yellow background and black glyph.
  - Missing `hex_code` kept the fallback color-inverse icon.
  - Bold + `name` inserted `**{filament.name}**` and cleared the active modifier.
  - Caps + `color_hex` inserted `^^{filament.color_hex}^^` and cleared the active modifier.
  - Underline + `name` inserted `__{filament.name}__`.
  - Removed the user-facing `\n` syntax-popover row; users can use actual line breaks in multiline textareas.
  - Screenshot capture verified the token tray and inserted caps syntax views.
