### PR TITLE
Add fuzzy FilamentDB lookup fallback

### DIFF
--- a/backend/app/api/v1/filamentdb_proxy.py
+++ b/backend/app/api/v1/filamentdb_proxy.py
@@ -5,6 +5,7 @@ and a prepare-filament endpoint that auto-creates missing manufacturers
 and colors locally before returning pre-filled data for the create form.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -30,21 +31,21 @@ router = APIRouter(prefix="/filamentdb", tags=["FilamentDB Proxy"])
 
 _TIMEOUT = 15.0  # seconds
 _BASE_URL = property(lambda _: settings.filamentdb_url.rstrip("/"))
+_FUZZY_FALLBACK_TIMEOUT = 8.0
 _FUZZY_PROBE_PAGE_SIZE = 50
-_LOOKUP_TEXT_KEYS = {
-    "brand",
+_LOOKUP_TEXT_MAX_DEPTH = 4
+_LOOKUP_TEXT_MAX_VALUES = 32
+_FILAMENT_LOOKUP_TEXT_KEYS = {
     "color_name",
     "designation",
-    "key",
-    "manufacturer_name",
-    "material",
     "material_key",
     "material_name",
     "material_subtype",
+}
+_SPOOL_PROFILE_LOOKUP_TEXT_KEYS = {
+    "manufacturer_name",
     "name",
-    "slug",
-    "spool_profile_name",
-    "title",
+    "spool_material",
 }
 
 
@@ -64,14 +65,25 @@ def _api_url(path: str) -> str:
     return f"{settings.filamentdb_url.rstrip('/')}/api/v1{path}"
 
 
-async def _proxy_get(path: str, params: dict[str, Any] | None = None) -> Any:
+async def _proxy_get(
+    path: str,
+    params: dict[str, Any] | None = None,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> Any:
     """Forward a GET request to the FilamentDB API."""
     url = _api_url(path)
+
+    async def fetch(active_client: httpx.AsyncClient) -> Any:
+        resp = await active_client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
     try:
+        if client is not None:
+            return await fetch(client)
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-            resp = await client.get(url, params=params)
-            resp.raise_for_status()
-            return resp.json()
+            return await fetch(client)
     except httpx.TimeoutException:
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
@@ -107,24 +119,30 @@ def _response_items(data: Any) -> list[dict[str, Any]]:
     return [item for item in items if isinstance(item, dict)]
 
 
-def _item_key(item: dict[str, Any], fallback_index: int) -> tuple[str, Any]:
+def _item_key(
+    item: dict[str, Any],
+    fallback_index: int,
+    text_keys: set[str],
+) -> tuple[str, Any]:
     item_id = item.get("id")
     if item_id is not None:
         return ("id", item_id)
-    return ("text", _lookup_text(item) or fallback_index)
+    return ("text", _lookup_text(item, text_keys) or fallback_index)
 
 
-def _lookup_text(item: dict[str, Any]) -> str:
+def _lookup_text(item: dict[str, Any], text_keys: set[str]) -> str:
     values: list[str] = []
 
-    def collect(value: Any, key: str | None = None) -> None:
+    def collect(value: Any, key: str | None = None, depth: int = 0) -> None:
+        if depth > _LOOKUP_TEXT_MAX_DEPTH or len(values) >= _LOOKUP_TEXT_MAX_VALUES:
+            return
         if isinstance(value, dict):
             for child_key, child_value in value.items():
-                collect(child_value, child_key)
+                collect(child_value, child_key, depth + 1)
         elif isinstance(value, list):
             for child_value in value:
-                collect(child_value, key)
-        elif isinstance(value, str) and key in _LOOKUP_TEXT_KEYS:
+                collect(child_value, key, depth + 1)
+        elif isinstance(value, str) and key in text_keys:
             values.append(value)
 
     collect(item)
@@ -138,6 +156,7 @@ async def _search_with_fuzzy_fallback(
     search: str | None,
     page: int,
     page_size: int,
+    text_keys: set[str],
 ) -> Any:
     direct_data = await _proxy_get(path, params)
     if not search or _response_items(direct_data):
@@ -155,20 +174,43 @@ async def _search_with_fuzzy_fallback(
     probe_page_size = min(max(page_size, _FUZZY_PROBE_PAGE_SIZE), 100)
     candidates: dict[tuple[str, Any], dict[str, Any]] = {}
 
-    for term in probe_terms:
-        probe_params = {
+    probe_params_list = [
+        {
             **base_params,
             "search": term,
             "page": 1,
             "page_size": probe_page_size,
         }
-        probe_data = await _proxy_get(path, probe_params)
+        for term in probe_terms
+    ]
+
+    async def fetch_probe(
+        client: httpx.AsyncClient,
+        probe_params: dict[str, Any],
+    ) -> Any | None:
+        try:
+            return await _proxy_get(path, probe_params, client=client)
+        except HTTPException:
+            return None
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            probe_data_list = await asyncio.wait_for(
+                asyncio.gather(
+                    *(fetch_probe(client, probe_params) for probe_params in probe_params_list)
+                ),
+                timeout=_FUZZY_FALLBACK_TIMEOUT,
+            )
+    except TimeoutError:
+        return direct_data
+
+    for probe_data in probe_data_list:
         for index, item in enumerate(_response_items(probe_data)):
-            candidates.setdefault(_item_key(item, index), item)
+            candidates.setdefault(_item_key(item, index, text_keys), item)
 
     scored: list[tuple[float, str, dict[str, Any]]] = []
     for item in candidates.values():
-        text = _lookup_text(item)
+        text = _lookup_text(item, text_keys)
         score = fuzzy_token_score(search, text)
         if score >= FUZZY_MATCH_THRESHOLD:
             label = item.get("designation") or item.get("name") or ""
@@ -263,6 +305,7 @@ async def search_filaments(
         search=search,
         page=page,
         page_size=page_size,
+        text_keys=_FILAMENT_LOOKUP_TEXT_KEYS,
     )
 
 
@@ -283,6 +326,7 @@ async def search_spool_profiles(
         search=search,
         page=page,
         page_size=page_size,
+        text_keys=_SPOOL_PROFILE_LOOKUP_TEXT_KEYS,
     )
 
 

--- a/backend/app/api/v1/filamentdb_proxy.py
+++ b/backend/app/api/v1/filamentdb_proxy.py
@@ -18,6 +18,11 @@ from app.api.deps import DBSession, PrincipalDep
 from app.core.config import settings, MANUFACTURER_LOGO_DIR
 from app.models import Color, FilamentColor, Manufacturer
 from app.models.plugin import InstalledPlugin
+from app.utils.search import (
+    FUZZY_MATCH_THRESHOLD,
+    fuzzy_token_score,
+    search_probe_terms,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +30,22 @@ router = APIRouter(prefix="/filamentdb", tags=["FilamentDB Proxy"])
 
 _TIMEOUT = 15.0  # seconds
 _BASE_URL = property(lambda _: settings.filamentdb_url.rstrip("/"))
+_FUZZY_PROBE_PAGE_SIZE = 50
+_LOOKUP_TEXT_KEYS = {
+    "brand",
+    "color_name",
+    "designation",
+    "key",
+    "manufacturer_name",
+    "material",
+    "material_key",
+    "material_name",
+    "material_subtype",
+    "name",
+    "slug",
+    "spool_profile_name",
+    "title",
+}
 
 
 @router.get("/status")
@@ -75,6 +96,101 @@ async def _proxy_get(path: str, params: dict[str, Any] | None = None) -> Any:
                 "message": "Cannot reach FilamentDB",
             },
         )
+
+
+def _response_items(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, dict):
+        return []
+    items = data.get("items")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _item_key(item: dict[str, Any], fallback_index: int) -> tuple[str, Any]:
+    item_id = item.get("id")
+    if item_id is not None:
+        return ("id", item_id)
+    return ("text", _lookup_text(item) or fallback_index)
+
+
+def _lookup_text(item: dict[str, Any]) -> str:
+    values: list[str] = []
+
+    def collect(value: Any, key: str | None = None) -> None:
+        if isinstance(value, dict):
+            for child_key, child_value in value.items():
+                collect(child_value, child_key)
+        elif isinstance(value, list):
+            for child_value in value:
+                collect(child_value, key)
+        elif isinstance(value, str) and key in _LOOKUP_TEXT_KEYS:
+            values.append(value)
+
+    collect(item)
+    return " ".join(values)
+
+
+async def _search_with_fuzzy_fallback(
+    path: str,
+    params: dict[str, Any],
+    *,
+    search: str | None,
+    page: int,
+    page_size: int,
+) -> Any:
+    direct_data = await _proxy_get(path, params)
+    if not search or _response_items(direct_data):
+        return direct_data
+
+    probe_terms = search_probe_terms(search)
+    if not probe_terms:
+        return direct_data
+
+    base_params = {
+        key: value
+        for key, value in params.items()
+        if key not in {"search", "page", "page_size"}
+    }
+    probe_page_size = min(max(page_size, _FUZZY_PROBE_PAGE_SIZE), 100)
+    candidates: dict[tuple[str, Any], dict[str, Any]] = {}
+
+    for term in probe_terms:
+        probe_params = {
+            **base_params,
+            "search": term,
+            "page": 1,
+            "page_size": probe_page_size,
+        }
+        probe_data = await _proxy_get(path, probe_params)
+        for index, item in enumerate(_response_items(probe_data)):
+            candidates.setdefault(_item_key(item, index), item)
+
+    scored: list[tuple[float, str, dict[str, Any]]] = []
+    for item in candidates.values():
+        text = _lookup_text(item)
+        score = fuzzy_token_score(search, text)
+        if score >= FUZZY_MATCH_THRESHOLD:
+            label = item.get("designation") or item.get("name") or ""
+            scored.append((score, str(label).lower(), item))
+
+    scored.sort(key=lambda entry: (-entry[0], entry[1]))
+
+    start = (page - 1) * page_size
+    paged_items = [item for _, _, item in scored[start : start + page_size]]
+    if not paged_items:
+        return direct_data
+
+    response = dict(direct_data) if isinstance(direct_data, dict) else {}
+    response.update(
+        {
+            "items": paged_items,
+            "total": len(scored),
+            "page": page,
+            "page_size": page_size,
+        }
+    )
+    return response
 
 
 # ── Search endpoints ───────────────────────────────────────────────
@@ -141,7 +257,13 @@ async def search_filaments(
         params["manufacturer_id"] = manufacturer_id
     if material_key:
         params["material_key"] = material_key
-    return await _proxy_get("/filaments", params)
+    return await _search_with_fuzzy_fallback(
+        "/filaments",
+        params,
+        search=search,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.get("/spool-profiles")
@@ -155,7 +277,13 @@ async def search_spool_profiles(
     params: dict[str, Any] = {"page": page, "page_size": page_size}
     if search:
         params["search"] = search
-    return await _proxy_get("/spool-profiles", params)
+    return await _search_with_fuzzy_fallback(
+        "/spool-profiles",
+        params,
+        search=search,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.get("/spool-profile-image")

--- a/backend/app/services/filamentdb_import_service.py
+++ b/backend/app/services/filamentdb_import_service.py
@@ -2,7 +2,6 @@
 
 import copy
 import logging
-import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -15,6 +14,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.cache import response_cache
 from app.models.filament import Color, Filament, FilamentColor, Manufacturer
+from app.utils.search import FUZZY_MATCH_THRESHOLD, fuzzy_token_score
 
 logger = logging.getLogger(__name__)
 
@@ -33,52 +33,7 @@ SYNC_CACHE_TTL_SECONDS = 300
 from app.core.config import MANUFACTURER_LOGO_DIR as LOGO_DIR
 
 # Schwellwert fuer Fuzzy-Matching (75%)
-FUZZY_THRESHOLD = 0.75
-
-# Synonyme fuer Normalisierung (werden auf die kanonische Form gemappt)
-_SYNONYMS: dict[str, str] = {
-    "+": "plus",
-}
-
-
-def _normalize_designation(name: str) -> str:
-    """Normalisiert eine Filament-Bezeichnung fuer Fuzzy-Matching.
-
-    - Lowercase
-    - Klammern werden zu Leerzeichen (Inhalt bleibt erhalten)
-    - Sonderzeichen (_, -, /, ,) → Leerzeichen
-    - Whitespace normalisieren
-    """
-    s = name.lower().strip()
-    s = re.sub(r"[()[\]{}<>]", " ", s)
-    s = re.sub(r"[_,\-/]", " ", s)
-    s = re.sub(r"\s+", " ", s).strip()
-    return s
-
-
-def _tokenize(name: str) -> set[str]:
-    """Tokenisiert und vereinheitlicht Synonyme."""
-    tokens: set[str] = set()
-    for tok in _normalize_designation(name).split():
-        tokens.add(_SYNONYMS.get(tok, tok))
-    return tokens
-
-
-def _fuzzy_match_score(a: str, b: str) -> float:
-    """Symmetrischer Token-Overlap Score.
-
-    Gibt den hoeheren Wert aus beiden Richtungen zurueck:
-      max(|A∩B|/|A|, |A∩B|/|B|)
-
-    So matchen sowohl "Feuerrot" vs "Rot (Feuerrot)" als auch
-    "PLA Rot (Feuerrot)" vs "PLA Rot".
-    """
-    tokens_a = _tokenize(a)
-    tokens_b = _tokenize(b)
-    if not tokens_a or not tokens_b:
-        return 0.0
-    overlap = len(tokens_a & tokens_b)
-    return max(overlap / len(tokens_a), overlap / len(tokens_b))
+FUZZY_THRESHOLD = FUZZY_MATCH_THRESHOLD
 
 
 def _resolve_mfr_id(fil: dict[str, Any]) -> int | None:
@@ -510,7 +465,7 @@ class FilamentDBImportService:
                 best_score = 0.0
                 best_name: str | None = None
                 for local_desig in candidates:
-                    score = _fuzzy_match_score(local_desig, designation)
+                    score = fuzzy_token_score(local_desig, designation)
                     if score > best_score:
                         best_score = score
                         best_name = local_desig
@@ -669,7 +624,7 @@ class FilamentDBImportService:
                 best_score = 0.0
                 best_fil: Filament | None = None
                 for local_desig, local_fil in candidates:
-                    score = _fuzzy_match_score(local_desig, fdb_desig_raw)
+                    score = fuzzy_token_score(local_desig, fdb_desig_raw)
                     if score > best_score:
                         best_score = score
                         best_fil = local_fil
@@ -1193,7 +1148,7 @@ class FilamentDBImportService:
                 best_score = 0.0
                 best_candidate: Filament | None = None
                 for candidate in fuzzy_candidates_result.scalars().all():
-                    score = _fuzzy_match_score(candidate.designation or "", designation)
+                    score = fuzzy_token_score(candidate.designation or "", designation)
                     if score > best_score:
                         best_score = score
                         best_candidate = candidate

--- a/backend/app/utils/search.py
+++ b/backend/app/utils/search.py
@@ -1,0 +1,69 @@
+"""Shared text normalization and fuzzy search helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+FUZZY_MATCH_THRESHOLD = 0.75
+
+_SYNONYMS: dict[str, str] = {
+    "+": "plus",
+}
+
+
+def normalize_search_text(value: str) -> str:
+    """Normalize product names for token-based fuzzy matching."""
+    normalized = value.lower().strip()
+    normalized = normalized.replace("+", " + ")
+    normalized = re.sub(r"[()[\]{}<>]", " ", normalized)
+    normalized = re.sub(r"[_,\-/]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def search_tokens(value: str) -> set[str]:
+    """Tokenize normalized search text and map known synonyms."""
+    return {
+        _SYNONYMS.get(token, token)
+        for token in normalize_search_text(value).split()
+        if token
+    }
+
+
+def fuzzy_token_score(a: str, b: str) -> float:
+    """Return a symmetric token-overlap score from 0.0 to 1.0."""
+    tokens_a = search_tokens(a)
+    tokens_b = search_tokens(b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+
+    overlap = len(tokens_a & tokens_b)
+    return max(overlap / len(tokens_a), overlap / len(tokens_b))
+
+
+def search_probe_terms(
+    value: str,
+    *,
+    max_terms: int = 4,
+    min_token_length: int = 2,
+) -> list[str]:
+    """Return bounded remote-search probe terms from a fuzzy query."""
+    tokens = [
+        token
+        for token in normalize_search_text(value).split()
+        if len(token) >= min_token_length
+    ]
+    words = [token for token in tokens if not token.isdigit()]
+    numbers = [token for token in tokens if token.isdigit()]
+    return _unique_preserving_order([*words, *numbers])[:max_terms]
+
+
+def _unique_preserving_order(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result

--- a/backend/tests/test_filamentdb_proxy.py
+++ b/backend/tests/test_filamentdb_proxy.py
@@ -1,0 +1,128 @@
+import pytest
+
+from app.api.v1 import filamentdb_proxy
+
+
+@pytest.mark.asyncio
+async def test_search_filaments_returns_direct_results_without_fallback(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+    direct_result = {
+        "items": [{"id": 1, "designation": "Matte Marine Blue"}],
+        "total": 1,
+        "page": 1,
+        "page_size": 20,
+    }
+
+    async def fake_proxy_get(path, params=None):
+        calls.append((path, params or {}))
+        return direct_result
+
+    monkeypatch.setattr(filamentdb_proxy, "_proxy_get", fake_proxy_get)
+
+    result = await filamentdb_proxy.search_filaments(
+        _principal=None,
+        search="Matte Marine Blue",
+        manufacturer_id=42,
+        manufacturer_name=None,
+        material_key="PLA",
+        page=1,
+        page_size=20,
+    )
+
+    assert result == direct_result
+    assert calls == [
+        (
+            "/filaments",
+            {
+                "page": 1,
+                "page_size": 20,
+                "search": "Matte Marine Blue",
+                "manufacturer_id": 42,
+                "material_key": "PLA",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_filaments_fuzzy_fallback_finds_punctuated_match(monkeypatch):
+    calls: list[tuple[str, dict]] = []
+    candidate = {
+        "id": 11600,
+        "designation": "Matte - Marine Blue (11600)",
+        "material_key": "PLA",
+        "manufacturer": {"name": "Example Filaments"},
+    }
+
+    async def fake_proxy_get(path, params=None):
+        params = params or {}
+        calls.append((path, params))
+        if params.get("search") in {"marine", "blue"}:
+            return {
+                "items": [candidate],
+                "total": 1,
+                "page": 1,
+                "page_size": params["page_size"],
+            }
+        return {
+            "items": [],
+            "total": 0,
+            "page": params.get("page", 1),
+            "page_size": params.get("page_size", 20),
+        }
+
+    monkeypatch.setattr(filamentdb_proxy, "_proxy_get", fake_proxy_get)
+
+    result = await filamentdb_proxy.search_filaments(
+        _principal=None,
+        search="Matte Marine Blue",
+        manufacturer_id=42,
+        manufacturer_name=None,
+        material_key="PLA",
+        page=1,
+        page_size=20,
+    )
+
+    assert result["items"] == [candidate]
+    assert result["total"] == 1
+    assert all(call[1].get("manufacturer_id") == 42 for call in calls)
+    assert all(call[1].get("material_key") == "PLA" for call in calls)
+    assert [call[1]["search"] for call in calls] == [
+        "Matte Marine Blue",
+        "matte",
+        "marine",
+        "blue",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_spool_profiles_fuzzy_fallback_deduplicates(monkeypatch):
+    candidate = {"id": 7, "name": "Bambu - Reusable Spool"}
+
+    async def fake_proxy_get(path, params=None):
+        params = params or {}
+        if params.get("search") in {"bambu", "reusable"}:
+            return {
+                "items": [candidate],
+                "total": 1,
+                "page": 1,
+                "page_size": params["page_size"],
+            }
+        return {
+            "items": [],
+            "total": 0,
+            "page": params.get("page", 1),
+            "page_size": params.get("page_size", 20),
+        }
+
+    monkeypatch.setattr(filamentdb_proxy, "_proxy_get", fake_proxy_get)
+
+    result = await filamentdb_proxy.search_spool_profiles(
+        _principal=None,
+        search="Bambu Reusable",
+        page=1,
+        page_size=20,
+    )
+
+    assert result["items"] == [candidate]
+    assert result["total"] == 1

--- a/backend/tests/test_filamentdb_proxy.py
+++ b/backend/tests/test_filamentdb_proxy.py
@@ -13,7 +13,7 @@ async def test_search_filaments_returns_direct_results_without_fallback(monkeypa
         "page_size": 20,
     }
 
-    async def fake_proxy_get(path, params=None):
+    async def fake_proxy_get(path, params=None, *, client=None):
         calls.append((path, params or {}))
         return direct_result
 
@@ -54,7 +54,7 @@ async def test_search_filaments_fuzzy_fallback_finds_punctuated_match(monkeypatc
         "manufacturer": {"name": "Example Filaments"},
     }
 
-    async def fake_proxy_get(path, params=None):
+    async def fake_proxy_get(path, params=None, *, client=None):
         params = params or {}
         calls.append((path, params))
         if params.get("search") in {"marine", "blue"}:
@@ -99,7 +99,7 @@ async def test_search_filaments_fuzzy_fallback_finds_punctuated_match(monkeypatc
 async def test_search_spool_profiles_fuzzy_fallback_deduplicates(monkeypatch):
     candidate = {"id": 7, "name": "Bambu - Reusable Spool"}
 
-    async def fake_proxy_get(path, params=None):
+    async def fake_proxy_get(path, params=None, *, client=None):
         params = params or {}
         if params.get("search") in {"bambu", "reusable"}:
             return {
@@ -126,3 +126,60 @@ async def test_search_spool_profiles_fuzzy_fallback_deduplicates(monkeypatch):
 
     assert result["items"] == [candidate]
     assert result["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_filaments_fuzzy_fallback_rejects_low_overlap(monkeypatch):
+    candidate = {
+        "id": 99,
+        "designation": "Marine Blue",
+        "material_key": "PLA",
+    }
+
+    async def fake_proxy_get(path, params=None, *, client=None):
+        params = params or {}
+        if params.get("search") == "marine":
+            return {
+                "items": [candidate],
+                "total": 1,
+                "page": 1,
+                "page_size": params["page_size"],
+            }
+        return {
+            "items": [],
+            "total": 0,
+            "page": params.get("page", 1),
+            "page_size": params.get("page_size", 20),
+        }
+
+    monkeypatch.setattr(filamentdb_proxy, "_proxy_get", fake_proxy_get)
+
+    result = await filamentdb_proxy.search_filaments(
+        _principal=None,
+        search="Marine Crimson Chartreuse",
+        manufacturer_id=None,
+        manufacturer_name=None,
+        material_key=None,
+        page=1,
+        page_size=20,
+    )
+
+    assert result["items"] == []
+    assert result["total"] == 0
+
+
+def test_lookup_text_caps_nested_remote_response_traversal():
+    current = {"designation": "Root"}
+    root = current
+    for index in range(20):
+        current["nested"] = {"designation": f"Nested {index}"}
+        current = current["nested"]
+
+    text = filamentdb_proxy._lookup_text(
+        root,
+        filamentdb_proxy._FILAMENT_LOOKUP_TEXT_KEYS,
+    )
+
+    assert "Root" in text
+    assert "Nested 2" in text
+    assert "Nested 3" not in text

--- a/backend/tests/test_search_utils.py
+++ b/backend/tests/test_search_utils.py
@@ -1,0 +1,25 @@
+from app.utils.search import fuzzy_token_score, search_probe_terms
+
+
+def test_fuzzy_token_score_matches_punctuation_and_catalog_suffix():
+    score = fuzzy_token_score("Matte Marine Blue", "Matte - Marine Blue (11600)")
+
+    assert score == 1.0
+
+
+def test_fuzzy_token_score_handles_plus_synonym():
+    score = fuzzy_token_score("PLA+", "PLA Plus")
+
+    assert score == 1.0
+
+
+def test_fuzzy_token_score_rejects_unrelated_text():
+    score = fuzzy_token_score("Matte Marine Blue", "Silk Crimson Red")
+
+    assert score == 0.0
+
+
+def test_search_probe_terms_prefers_words_before_numbers():
+    terms = search_probe_terms("Matte Marine Blue 11600", max_terms=4)
+
+    assert terms == ["matte", "marine", "blue", "11600"]


### PR DESCRIPTION
## Why

FilaManDB lookup currently depends on the remote API returning direct search matches. A query like `Matte Marine Blue` can miss a record named `Matte - Marine Blue (11600)` because punctuation and catalog suffixes prevent a direct match from being returned.

## Summary

- Add a shared backend fuzzy search utility for normalization, token scoring, and bounded probe-term generation.
- Use that utility in the FilaManDB proxy so empty direct filament/spool-profile searches fall back to fuzzy token probes.
- Refactor the FilamentDB import service to reuse the shared fuzzy scorer instead of keeping a private duplicate.
- Harden the fallback path with bounded probe time, bounded remote-response traversal, endpoint-specific scoring fields, and negative coverage for low-overlap matches.

## Behavior

- Existing direct remote results are preserved.
- Fuzzy fallback only runs when a direct lookup returns no items.
- Fallback probes are bounded, run under an overall timeout budget, and preserve existing filters such as manufacturer and material.
- Fuzzy candidates are deduplicated, scored locally, and returned in the existing response shape.

## Hardening

- Probe calls are parallelized under an `8s` overall fallback budget instead of multiplying the normal `15s` upstream timeout per token.
- Fallback probe failures are best-effort: if a probe fails, the endpoint falls back to the direct empty result rather than making fuzzy search less reliable than the original behavior.
- Remote response scoring text is capped by traversal depth and collected string count.
- Filament and spool-profile fallback scoring use endpoint-specific fields instead of one broad field list.
- Added regression coverage proving a low-overlap query such as `Marine Crimson Chartreuse` does not return a merely-blue candidate.

## Live FilaManDB Comparison

Run on 2026-05-30 against the live FilaManDB API. "Normal" is the direct remote `/api/v1` search. "This PR" is the proxy fallback path from this branch using the same search/filter inputs.

| Case | Input | Normal FilaManDB output | This PR fuzzy output | Correct output from shown list |
| --- | --- | --- | --- | --- |
| User example, unfiltered | `/filaments?search=Matte Marine Blue` | `0` results | `3` results: `23991 Matte - Marine Blue`, `18079 Matte - Marine Blue`, `144 Matte - Marine Blue (11600)`; all score `1.0` | All three are valid normalized-name matches. If the user specifically means Bambu Lab catalog color `11600`, choose `id 144`. |
| User example, normal app filters | `/filaments?search=Matte Marine Blue&manufacturer_id=119&material_key=pla` | `0` results | `1` result: `144 Matte - Marine Blue (11600)` | Correct: `id 144`, Bambu Lab PLA, `Marine Blue (11600)`. |
| Exact/catalog query | `/filaments?search=Matte - Marine Blue (11600)` | `1` result: `144 Matte - Marine Blue (11600)` | Same `1` result | Correct: direct exact result is preserved; fuzzy fallback is not used. |
| Normal broad search | `/filaments?search=Marine Blue` | `17` results | Same `17` results | Correct: existing normal search behavior is preserved, including remote ordering. |
| Nonsense query | `/filaments?search=ZXQ Never Match Blue` | `0` results | `0` results | Correct: no fuzzy output. |
| Low-overlap query | `/filaments?search=Marine Crimson Chartreuse` | `0` results | `0` results | Correct: no fuzzy output; one shared token such as `Marine` is not enough to pass the `0.75` fuzzy threshold. |

### Not Overly Eager

- Fallback only runs after direct remote search returns zero items, so existing exact or broad search results are not re-ranked or filtered.
- Candidate scoring uses token overlap with a `0.75` threshold. A candidate that shares only one token with a multi-token query is rejected.
- Probe terms are bounded and preserve the original filters. In the filtered Bambu Lab PLA case, the fallback returns only the correct catalog item instead of unrelated Marine Blue entries.

## Validation

- `env DEBUG=false uv run pytest`
  - Result: 327 passed, 26 warnings
- `env DEBUG=false uv run pytest tests/test_filamentdb_proxy.py tests/test_search_utils.py`
  - Result: 9 passed, 26 warnings
- Live FilaManDB filtered comparison after hardening:
  - `/filaments?search=Matte Marine Blue&manufacturer_id=119&material_key=pla` returned exactly `144 Matte - Marine Blue (11600)`.


