### PR TITLE
fix(print): hide zoom bar in print output; add explicit page orientation for label printers

### DIFF
--- a/frontend/src/pages/spools/[id]/print.astro
+++ b/frontend/src/pages/spools/[id]/print.astro
@@ -1710,6 +1710,11 @@ const { id } = Astro.params
       background: white !important;
     }
 
+    /* Hide UI chrome during print */
+    .preview-zoom-bar {
+      display: none !important;
+    }
+
     /* The label */
     .label-preview {
       box-shadow: none !important;
@@ -3472,9 +3477,10 @@ const { id } = Astro.params
     const style = document.createElement('style')
     // Safari doesn't support @page { size } — use default page margins so label stays in printable area
     // Chrome/Edge support @page { size } — set exact label dimensions with no margin
+    const printOrientation = widthMm >= heightMm ? 'landscape' : 'portrait'
     const pageRule = isSafari
       ? ''
-      : `@page { size: ${w}mm ${h}mm; margin: 0; }`
+      : `@page { size: ${w}mm ${h}mm ${printOrientation}; margin: 0; }`
     style.innerHTML = `
       ${pageRule}
       @media print {
@@ -3785,7 +3791,8 @@ const { id } = Astro.params
 
     // Print page style
     const isSafari = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent)
-    const pageRule = isSafari ? '' : `@page { size: ${w}mm ${h}mm; margin: 0; }`
+    const printOrientation = w >= h ? 'landscape' : 'portrait'
+    const pageRule = isSafari ? '' : `@page { size: ${w}mm ${h}mm ${printOrientation}; margin: 0; }`
     const style = document.createElement('style')
     style.innerHTML = `
       ${pageRule}


### PR DESCRIPTION
## Summary

Two bugs in the spool label print page that affect narrow-roll label printers (e.g. Brother QL-800):

1. **Zoom bar prints** — the `−` / slider / `+` / `100%` / `⟳` control bar was not hidden during print, appearing as a dark stripe at the top of every label.
2. **Wrong orientation** — `@page { size }` lacked the orientation keyword, so the print driver received no orientation hint and could rotate the label incorrectly.

---

## Base / Branch Context

- **Target repo**: `Fire-Devils/filaman-system`
- **Base**: `main` (includes advanced label designer PR #80 — clickable `Print Settings` / `Label Designer` tabs — compatible, no conflicts)
- **Branch**: `fix/label-print-zoom-bar-orientation`
- **Standalone**: yes — one file, no stacking

---

## Why

Reported against the Brother QL-800: the zoom bar was being printed at the top of labels, and labels were printed at the wrong orientation (sometimes cut off).

---

## Implementation

**File**: `frontend/src/pages/spools/[id]/print.astro`

1. Added `.preview-zoom-bar { display: none !important; }` to the existing `@media print` block — zoom controls are now excluded from all print output.

2. Both `@page { size }` generators (Classic tab and Label Designer tab) now compute the orientation keyword from the configured dimensions:
   ```js
   const printOrientation = widthMm >= heightMm ? 'landscape' : 'portrait'
   // → @page { size: 60mm 40mm landscape; margin: 0; }
   ```
   This tells the browser/driver the correct orientation before the print dialog opens, preventing rotation on label printers.

---

## Screenshots

**Before** (zoom bar prints as dark stripe above label):

![before](https://raw.githubusercontent.com/akira69/filaman-system/fork/meta/_pr/label-print-fix/before-zoom-bar-prints.png)

**After** (zoom bar absent; only label content):

![after](https://raw.githubusercontent.com/akira69/filaman-system/fork/meta/_pr/label-print-fix/after-zoom-bar-hidden.png)

---

## Code Quality / Validation

- `npm run lint` — 0 errors (107 pre-existing `any` warnings, unchanged)
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — clean build
- Compatibility with PR #80 advanced label designer (clickable tab buttons, extra fields) confirmed in browser — zero conflicts

---

## Test Checklist

- [x] Zoom bar hidden in `@media print` — verified by browser print-emulation screenshot
- [x] `@page { size: 60mm 40mm landscape; }` generated for default 60×40 label
- [x] `@page { size: 40mm 60mm portrait; }` generated for portrait label (width < height)
- [x] Label Designer tab `@page` rule updated identically
- [x] On-screen zoom bar still visible and functional (fix is print-media only)
- [x] `Print Settings` and `Label Designer` tabs (PR #80) render correctly on fix branch
- [x] Frontend build clean
- [ ] Physical print on Brother QL-800 — manual verification needed by reporter
- [ ] Safari fallback path (no `@page { size }`) — no regression possible; Safari code path unchanged