### PR TITLE
[fix] Fix label export with blob logos

### DIFF
--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1128,7 +1128,7 @@
     "suffixSpool": "Spule",
     "suffixFilament": "Filament",
     "exporting": "Exportiere…",
-    "pngExportFailed": "PNG-Export fehlgeschlagen. Bitte Internetverbindung prüfen.",
-    "pdfExportFailed": "PDF-Export fehlgeschlagen. Bitte Internetverbindung prüfen."
+    "pngExportFailed": "PNG-Export fehlgeschlagen. Bitte prüfen, ob alle Label-Bilder und Logos korrekt geladen wurden.",
+    "pdfExportFailed": "PDF-Export fehlgeschlagen. Bitte prüfen, ob alle Label-Bilder und Logos korrekt geladen wurden."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1126,7 +1126,7 @@
     "suffixSpool": "Spool",
     "suffixFilament": "Filament",
     "exporting": "Exporting...",
-    "pngExportFailed": "PNG export failed. Please check your internet connection.",
-    "pdfExportFailed": "PDF export failed. Please check your internet connection."
+    "pngExportFailed": "PNG export failed. Please check that all label images and logos loaded correctly.",
+    "pdfExportFailed": "PDF export failed. Please check that all label images and logos loaded correctly."
   }
 }

--- a/frontend/src/lib/label-export.ts
+++ b/frontend/src/lib/label-export.ts
@@ -41,7 +41,8 @@ export async function captureLabelElement(element: HTMLElement, options: LabelCa
     return await toPng(element, {
       pixelRatio: options.pixelRatio ?? 4,
       backgroundColor: '#ffffff',
-      cacheBust: true,
+      // Manufacturer logos can be object URLs; cache-busting would make blob: URLs invalid.
+      cacheBust: false,
       skipFonts: true,
       filter: (node: Node) => {
         if (node instanceof Element && window.getComputedStyle(node).display === 'none') {

--- a/frontend/src/pages/spools/[id]/print.astro
+++ b/frontend/src/pages/spools/[id]/print.astro
@@ -1363,7 +1363,7 @@ const { id } = Astro.params
       try {
         downloadDataUrl(await captureActiveLabelPng(), `${buildExportBaseName()}.png`)
       } catch (error) {
-        alert(getTranslation('labelPrint.pngExportFailed', 'PNG export failed.'))
+        alert(getTranslation('labelPrint.pngExportFailed', 'PNG export failed. Please check that all label images and logos loaded correctly.'))
         console.error('Failed to export label PNG:', error)
       }
     })
@@ -1378,7 +1378,7 @@ const { id } = Astro.params
           `${buildExportBaseName()}.pdf`,
         )
       } catch (error) {
-        alert(getTranslation('labelPrint.pdfExportFailed', 'PDF export failed.'))
+        alert(getTranslation('labelPrint.pdfExportFailed', 'PDF export failed. Please check that all label images and logos loaded correctly.'))
         console.error('Failed to export label PDF:', error)
       }
     })


### PR DESCRIPTION
Fixes #92.

Summary:
- Prevent label export from cache-busting `blob:` logo URLs, which made manufacturer logos fail during PNG/PDF capture.
- Update PNG/PDF export failure messages so they point to label images/logos instead of internet connectivity.

Dependency note:
- This should merge before #94, #91, and the follow-up label-paper sheet printing PR. Sheet PDF export reuses label image capture with manufacturer logos, so this fix is a prerequisite for reliable sheet exports.

Why this was missed:
- Prior validation covered rendered label screenshots and export proofs, but not the app's PNG/PDF export path with a manufacturer logo loaded as a `blob:` URL. The bug only appears when `html-to-image` cache-busts that `blob:` URL during capture.

Validation:
- `npm run lint`
- `npm run check`
- `npm run build`
