### PR TITLE
[Fix] Browser print sizing for spool labels

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "lint": "eslint 'src/pages/spools/[id]/index.astro' 'src/pages/spools/[id]/print.astro' 'src/pages/spools/print.astro' 'src/components/LabelDesignerEditor.astro' 'src/lib/label-template.ts' 'src/lib/label-export.ts' 'src/lib/label-designer.ts' 'src/lib/label-designer-editor.ts' 'src/lib/label-standard.ts' 'src/lib/qr-code.ts' --no-error-on-unmatched-pattern"
+    "lint": "eslint 'src/pages/spools/[id]/index.astro' 'src/pages/spools/[id]/print.astro' 'src/pages/spools/print.astro' 'src/components/LabelDesignerEditor.astro' 'src/lib/label-template.ts' 'src/lib/label-export.ts' 'src/lib/label-designer.ts' 'src/lib/label-designer-editor.ts' 'src/lib/label-standard.ts' 'src/lib/label-print-style.ts' 'src/lib/qr-code.ts' --no-error-on-unmatched-pattern"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1114,7 +1114,7 @@
     "extraFieldsTitle": "Zusatzfelder",
     "truncateLabel": "Feldname kürzen auf (Zeichen, 0 = aus)",
     "previewTitle": "Vorschau",
-    "zoomLabel": "Zoom (%)",
+    "zoomLabel": "Vorschau-Zoom (%)",
     "zoomOut": "Verkleinern",
     "zoomIn": "Vergrößern",
     "zoomReset": "Zoom zurücksetzen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1112,7 +1112,7 @@
     "extraFieldsTitle": "Extra Fields",
     "truncateLabel": "Truncate field name (chars, 0 = off)",
     "previewTitle": "Preview",
-    "zoomLabel": "Zoom (%)",
+    "zoomLabel": "Preview zoom (%)",
     "zoomOut": "Zoom out",
     "zoomIn": "Zoom in",
     "zoomReset": "Reset zoom",

--- a/frontend/src/lib/label-designer.ts
+++ b/frontend/src/lib/label-designer.ts
@@ -6,6 +6,7 @@ import {
   renderTemplateText,
   type SpoolData,
 } from './label-template'
+import { updateLabelPrintPageStyle } from './label-print-style'
 import { canvasToQrImage, ensureQrCodeLoaded, getQrCodeConstructor } from './qr-code'
 
 export const DESIGNER_KEY = 'filaman-label-designer-v1'
@@ -689,24 +690,5 @@ export async function renderDesignerLabel(options: RenderDesignerLabelOptions) {
 }
 
 export function updateDesignerPageStyle(widthMm: number, heightMm: number, styleId = 'page-style') {
-  const isSafari = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent)
-  const printOrientation = widthMm >= heightMm ? 'landscape' : 'portrait'
-  const pageRule = isSafari ? '' : `@page { size: ${widthMm}mm ${heightMm}mm ${printOrientation}; margin: 0; }`
-  const style = document.createElement('style')
-  style.innerHTML = `
-    ${pageRule}
-    @media print {
-      .label-preview {
-        width: ${widthMm}mm !important; height: ${heightMm}mm !important;
-        min-width: ${widthMm}mm !important; min-height: ${heightMm}mm !important;
-        max-width: ${widthMm}mm !important; max-height: ${heightMm}mm !important;
-        transform: none !important;
-        transform-origin: unset !important;
-      }
-    }
-  `
-  const oldStyle = document.querySelector(`style#${styleId}`)
-  if (oldStyle) oldStyle.remove()
-  style.id = styleId
-  document.head.appendChild(style)
+  updateLabelPrintPageStyle({ widthMm, heightMm, styleId })
 }

--- a/frontend/src/lib/label-print-style.ts
+++ b/frontend/src/lib/label-print-style.ts
@@ -1,0 +1,60 @@
+export interface LabelPrintPageStyleOptions {
+  widthMm: number
+  heightMm: number
+  styleId?: string
+}
+
+export function updateLabelPrintPageStyle({ widthMm, heightMm, styleId = 'page-style' }: LabelPrintPageStyleOptions) {
+  if (!Number.isFinite(widthMm) || !Number.isFinite(heightMm) || widthMm <= 0 || heightMm <= 0) return
+
+  const resolvedStyleId = styleId || 'page-style'
+  let styleEl = document.getElementById(resolvedStyleId)
+  if (!styleEl) {
+    styleEl = document.createElement('style')
+    styleEl.id = resolvedStyleId
+    document.head.appendChild(styleEl)
+  }
+
+  const isSafari = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent)
+  // A two-length custom page size already encodes orientation. Adding an
+  // orientation keyword makes Chromium ignore the rule and fall back to Letter.
+  const pageRule = isSafari ? '' : `@page { size: ${widthMm}mm ${heightMm}mm; margin: 0; }`
+
+  styleEl.innerHTML = `
+    ${pageRule}
+    @media print {
+      html,
+      body {
+        margin: 0 !important;
+        padding: 0 !important;
+      }
+
+      .label-wrapper {
+        width: ${widthMm}mm !important;
+        height: ${heightMm}mm !important;
+        min-width: ${widthMm}mm !important;
+        min-height: ${heightMm}mm !important;
+        max-width: ${widthMm}mm !important;
+        max-height: ${heightMm}mm !important;
+        box-sizing: border-box !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        overflow: hidden !important;
+      }
+
+      .label-preview {
+        width: ${widthMm}mm !important;
+        height: ${heightMm}mm !important;
+        min-width: ${widthMm}mm !important;
+        min-height: ${heightMm}mm !important;
+        max-width: ${widthMm}mm !important;
+        max-height: ${heightMm}mm !important;
+        box-sizing: border-box !important;
+        margin: 0 !important;
+        zoom: 1 !important;
+        transform: none !important;
+        transform-origin: unset !important;
+      }
+    }
+  `
+}

--- a/frontend/src/lib/label-standard.ts
+++ b/frontend/src/lib/label-standard.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { canvasToQrImage, ensureQrCodeLoaded, getQrCodeConstructor } from './qr-code'
+import { updateLabelPrintPageStyle } from './label-print-style'
 
 const QR_PIXEL_SIZE = 400
 
@@ -134,18 +135,7 @@ export function buildStandardLabelDataFromApiSpool(spool: any, extraFields: Stan
 }
 
 export function updateStandardLabelPageStyle(widthMm: number, heightMm: number, pageStyleId = 'page-style') {
-  let styleEl = document.getElementById(pageStyleId)
-  if (!styleEl) {
-    styleEl = document.createElement('style')
-    styleEl.id = pageStyleId
-    document.head.appendChild(styleEl)
-  }
-  const isSafari = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent)
-  const printOrientation = widthMm >= heightMm ? 'landscape' : 'portrait'
-  styleEl.innerHTML = `
-    ${isSafari ? '' : `@page { size: ${widthMm}mm ${heightMm}mm ${printOrientation}; margin: 0; }`}
-    @media print { .label-preview { width:${widthMm}mm !important; height:${heightMm}mm !important; min-width:${widthMm}mm !important; min-height:${heightMm}mm !important; max-width:${widthMm}mm !important; max-height:${heightMm}mm !important; transform: none !important; transform-origin: unset !important; } }
-  `
+  updateLabelPrintPageStyle({ widthMm, heightMm, styleId: pageStyleId })
 }
 
 export async function renderStandardLabel(options: RenderStandardLabelOptions) {

--- a/frontend/src/pages/spools/print.astro
+++ b/frontend/src/pages/spools/print.astro
@@ -169,7 +169,7 @@ import LabelDesignerEditor from '../../components/LabelDesignerEditor.astro'
 
         <h3 data-i18n="labelPrint.previewTitle">Preview</h3>
         <div>
-          <label class="fm-label" data-i18n="labelPrint.zoomLabel">Zoom (%)</label>
+          <label class="fm-label" data-i18n="labelPrint.zoomLabel">Preview zoom (%)</label>
           <input type="range" id="input-zoom" min="25" max="300" value="100" class="fm-input" style="padding: 8px;">
         </div>
       </div>


### PR DESCRIPTION
Fixes browser print sizing for spool labels.

Users with narrow label printers, for example Brother QL-800 labels configured as `62 x 29 mm`, could see the browser print preview overflow onto two pages. PNG export still printed correctly through external image tooling, which made the browser print path look like it was ignoring the configured label size or preview zoom.

The print CSS was mixing preview geometry with print geometry and emitted a custom `@page` rule with an added orientation keyword. Chromium ignores that form for custom page sizes and falls back to a normal paper size, so the label can spill into extra pages even when the app preview looks correct.

Dependency note:
- This is expected to merge after #93 and before #91.
- The follow-up label-paper sheet printing PR will reuse this print CSS principle for paper-sized pages instead of label-sized pages.

Summary:
- Emit exact label-sized print pages for browser printing.
- Reset preview-only zoom, transform, and document margin/padding during print so physical output matches configured label dimensions.
- Centralize print page style generation for reuse by future label print pages.
- Use valid custom `@page` sizing; the width/height pair preserves landscape geometry without the orientation keyword that Chromium ignores for custom sizes.
- Ignore invalid non-finite or non-positive dimensions instead of emitting broken print CSS.
- Rename the zoom label to "Preview zoom" to clarify it does not control printer scale.

Validation:
- `npm run lint`
- `npm run check`
- `npm run build`
- Browser/PDF check: `62 x 29 mm` generated one `62.06 x 28.96 mm` PDF page at preview zoom `50%`, `100%`, and `200%`.
- Browser/PDF check: existing `60 x 40 mm` default generated one `59.94 x 39.88 mm` PDF page.
- Browser check: invalid dimensions do not create a print style tag.
