### PR TITLE
feat(spool-log): show filament context on global event log

### DIFF
--- a/backend/app/api/v1/schemas_spool.py
+++ b/backend/app/api/v1/schemas_spool.py
@@ -165,6 +165,11 @@ class MoveLocationRequest(BaseModel):
     note: str | None = None
 
 
+class SpoolEventColor(BaseModel):
+    hex_code: str
+    name: str | None = None
+
+
 class SpoolEventResponse(BaseModel):
     id: int
     spool_id: int
@@ -181,6 +186,12 @@ class SpoolEventResponse(BaseModel):
     to_location_id: int | None
     note: str | None
     meta: dict[str, Any] | None
+    # Enriched filament context (populated by the all-events listing); may be
+    # null when the spool or its filament has since been deleted.
+    manufacturer_name: str | None = None
+    manufacturer_color_name: str | None = None
+    material_type: str | None = None
+    colors: list[SpoolEventColor] | None = None
 
     class Config:
         from_attributes = True

--- a/backend/app/api/v1/spools.py
+++ b/backend/app/api/v1/spools.py
@@ -23,6 +23,7 @@ from app.api.v1.schemas_spool import (
     MoveLocationRequest,
     SpoolBulkCreate,
     SpoolCreate,
+    SpoolEventColor,
     SpoolEventResponse,
     SpoolResponse,
     SpoolStatusResponse,
@@ -596,11 +597,43 @@ async def list_all_spool_events(
 ):
     result = await db.execute(
         select(SpoolEvent)
+        .options(
+            selectinload(SpoolEvent.spool)
+            .selectinload(Spool.filament)
+            .options(
+                selectinload(Filament.manufacturer),
+                selectinload(Filament.filament_colors).selectinload(
+                    FilamentColor.color
+                ),
+            )
+        )
         .order_by(SpoolEvent.event_at.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
     )
-    items = list(result.scalars().all())
+    events = list(result.scalars().all())
+
+    items: list[SpoolEventResponse] = []
+    for ev in events:
+        resp = SpoolEventResponse.model_validate(ev)
+        filament = ev.spool.filament if ev.spool else None
+        if filament is not None:
+            resp.manufacturer_name = (
+                filament.manufacturer.name if filament.manufacturer else None
+            )
+            resp.manufacturer_color_name = filament.manufacturer_color_name
+            resp.material_type = filament.material_type
+            resp.colors = [
+                SpoolEventColor(
+                    hex_code=fc.color.hex_code,
+                    name=fc.display_name_override or fc.color.name,
+                )
+                for fc in sorted(
+                    filament.filament_colors, key=lambda c: c.position
+                )
+                if fc.color is not None
+            ]
+        items.append(resp)
 
     count_result = await db.execute(select(func.count()).select_from(SpoolEvent))
     total = count_result.scalar() or 0

--- a/frontend/src/pages/spool-log.astro
+++ b/frontend/src/pages/spool-log.astro
@@ -10,6 +10,7 @@ import Layout from '../layouts/Layout.astro'
     .pagination-pages a:hover { text-decoration: underline; background: color-mix(in srgb, var(--accent) 10%, transparent); }
     .pagination-pages .page-current { font-weight: 700; color: var(--accent); padding: 2px 8px; background: color-mix(in srgb, var(--accent) 15%, transparent); border-radius: 3px; }
     .pagination-pages .page-ellipsis { color: var(--text-muted); padding: 0 2px; }
+    .fm-table .col-spool-id { width: 6ch; max-width: 6ch; white-space: nowrap; padding: 10px 4px 10px 8px; }
   </style>
   <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
     <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0; font-family: var(--font-serif);" data-i18n="spoolLog.title">Spool Log</h1>
@@ -23,7 +24,10 @@ import Layout from '../layouts/Layout.astro'
     <table class="fm-table">
       <thead>
         <tr style="background: var(--bg-soft);">
-          <th data-i18n="spoolLog.spool">Spool</th>
+          <th class="col-spool-id" data-i18n="spoolLog.spool">Spool</th>
+          <th data-i18n="spools.colMfrColor">Mfr. Color</th>
+          <th data-i18n="spools.manufacturer">Manufacturer</th>
+          <th data-i18n="spools.material">Material</th>
           <th data-i18n="spoolLog.eventType">Type</th>
           <th data-i18n="spoolLog.eventDate">Date</th>
           <th data-i18n="spoolLog.eventWeight">Weight</th>
@@ -32,7 +36,7 @@ import Layout from '../layouts/Layout.astro'
       </thead>
       <tbody id="events-table">
         <tr>
-          <td colspan="5" style="text-align: center; color: var(--text-muted);" data-i18n="common.loading">Loading...</td>
+          <td colspan="8" style="text-align: center; color: var(--text-muted);" data-i18n="common.loading">Loading...</td>
         </tr>
       </tbody>
     </table>
@@ -67,7 +71,7 @@ import Layout from '../layouts/Layout.astro'
         if (isAbortError(error)) return
         console.error('Failed to load events:', error)
         const tbody = document.getElementById('events-table')!
-        tbody.innerHTML = `<tr><td colspan="5" style="text-align: center; color: var(--error-text);">${t('spoolLog.failedLoad')}</td></tr>`
+        tbody.innerHTML = `<tr><td colspan="8" style="text-align: center; color: var(--error-text);">${t('spoolLog.failedLoad')}</td></tr>`
       }
     }
 
@@ -77,7 +81,7 @@ import Layout from '../layouts/Layout.astro'
       if (events.length === 0) {
         tbody.innerHTML = `
           <tr>
-            <td colspan="5" style="text-align: center; color: var(--text-muted);">${t('spoolLog.noEvents')}</td>
+            <td colspan="8" style="text-align: center; color: var(--text-muted);">${t('spoolLog.noEvents')}</td>
           </tr>
         `
         return
@@ -85,9 +89,14 @@ import Layout from '../layouts/Layout.astro'
 
       tbody.innerHTML = events.map(e => `
         <tr>
-          <td style="padding: 12px;">
+          <td class="col-spool-id">
             <a href="/spools/${e.spool_id}" style="color: var(--accent); text-decoration: none; font-weight: 500;">#${e.spool_id}</a>
           </td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text); white-space: nowrap;">
+            <span style="display: inline-flex; align-items: center; gap: 6px;">${renderMfrColorCell(e.colors, e.manufacturer_color_name)}</span>
+          </td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${escapeHtml(e.manufacturer_name) || '-'}</td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${escapeHtml(e.material_type) || '-'}</td>
           <td style="padding: 12px;">
             <span class="fm-pill" style="${getEventTypeStyle(e.event_type)}">${e.event_type}</span>
           </td>
@@ -101,6 +110,45 @@ import Layout from '../layouts/Layout.astro'
           <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${e.note || '-'}</td>
         </tr>
       `).join('')
+    }
+
+    function escapeHtml(value: any): string {
+      if (value === null || value === undefined) return ''
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+    }
+
+    function normalizeHexColor(hex: string | null | undefined): string {
+      const value = (hex || '').trim()
+      if (!value) return ''
+      return value.startsWith('#') ? value : `#${value}`
+    }
+
+    function renderColorDots(colors: any[] | null | undefined): string {
+      if (!colors || colors.length === 0) return ''
+      return colors.map(c => {
+        if (!c) return ''
+        const hex = normalizeHexColor(c.hex_code)
+        if (!hex) return ''
+        const title = escapeHtml(c.name || '')
+        return `<span title="${title}" style="display: inline-block; width: 18px; height: 18px; border-radius: 50%; background-color: ${hex}; border: 2px solid var(--border); vertical-align: middle; margin-right: 6px;"></span>`
+      }).join('')
+    }
+
+    function renderMfrColorCell(
+      colors: any[] | null | undefined,
+      manufacturerColorName: string | null | undefined
+    ): string {
+      const dots = renderColorDots(colors)
+      const label = escapeHtml(manufacturerColorName)
+      if (!dots && !label) return '<span style="color: var(--text-muted);">-</span>'
+      if (!label) return dots
+      if (!dots) return label
+      return `${dots}<span>${label}</span>`
     }
 
     function getEventTypeStyle(type: string): string {


### PR DESCRIPTION
## Summary
Add Color and filament type to the Spool Log display to make it easier to distinguish what spool/filament is what

<img width="2448" height="866" alt="image" src="https://github.com/user-attachments/assets/191aac9c-457d-455e-b73e-36837e5e63b6" />

- Enrich `GET /api/v1/spools/all-events` with filament context (manufacturer name, mfr. color, material type, color swatches) via eager-loaded spool → filament relations
- Expand the Spool Log table to match the Spools list: compact spool ID column, combined mfr. color (icon + name), manufacturer, material, then existing event columns

## Test plan
- [ ] Open Spool Log and confirm columns: Spool, Mfr. Color, Manufacturer, Material, Type, Date, Weight, Note
- [ ] Verify mfr. color shows dot + label (e.g. Orange, Blue)
- [ ] Verify manufacturer and material populate for events with active spools/filaments
- [ ] Confirm spool ID column is narrow (~6ch)
- [ ] Hard-refresh after deploy so the latest `_astro/spool-log*.js` bundle loads