### PR TITLE
feat: per-model slicer profiles, spool log context, and driver enrichment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ package.json
 package-lock.json
 filaman.db*
 uploads/
+frontend/version.txt

--- a/Auto-Profile-Info.md
+++ b/Auto-Profile-Info.md
@@ -1,0 +1,238 @@
+# Bambu Slicer Profiles — How FilaMan Handles Them
+
+This document describes how FilaMan assigns Bambu cloud slicer profiles to filament
+and spools, resolves them per printer model, and pushes the correct settings to AMS
+slots when you assign a spool.
+
+Requires the **Bambuddy driver plugin** installed and connected. The profile picker
+appears on **Filament** and **Spool** detail pages when at least one Bambuddy
+printer driver is healthy.
+
+---
+
+## Quick summary
+
+1. Pick a **default profile** (logical name, e.g. `SUNLU PLA HS PLUS GEN2`) on the
+   filament or spool page.
+2. FilaMan resolves the correct **cloud variant** (PFUS code) for each connected
+   printer **model** (P2S, H2C, …) and **nozzle size** automatically.
+3. When you assign the spool to an AMS slot, the driver sends **color**, **temps**,
+   **material code**, and **slicer preset** to the printer.
+4. If no variant exists for a model, behavior depends on **Admin → App Settings →
+   Slicer Profile Fallback** (Generic vs Bambu system profile).
+
+---
+
+## Concepts
+
+| Term | Meaning |
+|------|---------|
+| **Base name** | Human-readable profile name without model/nozzle suffix, e.g. `SUNLU PLA HS PLUS GEN2`. This is what you pick in the UI. |
+| **PFUS / `setting_id`** | Full Bambu cloud preset ID (e.g. `PFUScaa4e95f092eef`). Model- and nozzle-specific. Sent to the printer as `setting_id`. |
+| **Material code / `tray_info_idx`** | AMS filament index (e.g. `SUN20009`, `GFL99`, `GFA00`). Identifies the material family on the slot. |
+| **Model** | Printer family token from Bambuddy (e.g. `P2S`, `H2C`). Variants are resolved per model, not per individual printer. |
+| **Coverage** | Whether a cloud variant exists for each connected model for the chosen base name. |
+
+Cloud presets in Bambu Studio often look like:
+
+`SUNLU PLA HS PLUS GEN2 @BBL P2S 0.4 nozzle`
+
+FilaMan stores the **base name** and resolves the `@BBL <model> <nozzle>` variant at
+runtime.
+
+---
+
+## Where profiles are stored
+
+### Filament level
+- **Default base name** in `custom_fields.bambu_profile_base_name`
+- Optional **per-model map** in `custom_fields.bambu_profiles_by_model`
+- Per-printer params: `bambu_slicer_setting_id`, `bambu_idx`, etc.
+
+New spools **inherit** the filament default unless the spool overrides it.
+
+### Spool level
+Same fields as filament. Spool values **override** filament for that spool.
+
+### Per-model map shape
+```json
+{
+  "P2S": { "base_name": "SUNLU PLA HS PLUS GEN2", "source": "linked" },
+  "H2C": { "base_name": "OTHER PROFILE", "source": "override" }
+}
+```
+
+**Source values:**
+| Source | Meaning |
+|--------|---------|
+| `linked` | Uses the default base name; variant resolved from cloud. |
+| `override` / `manual` | User picked a different profile for this model only. Never auto-deleted. |
+| `reflect` | Learned from Bambuddy inventory sync (last-writer-wins with local edits). |
+| `auto` | Resolved automatically during mirroring. |
+
+---
+
+## The profile picker (Filament / Spool pages)
+
+### Default profile
+- Searchable dropdown of cloud presets available on **at least one** of your
+  connected models.
+- Pick **one name**; FilaMan fans out variants to every connected model.
+- **Variants strip** shows ✓ or ✕ per model (e.g. `H2C ✕  P2S ✓`).
+
+### Per-model overrides (optional)
+- Expand a model card to override only that model when it needs a different profile
+  than the default.
+- Nozzle badges (0.2, 0.4, 0.6, 0.8) show which sizes exist in the cloud; the
+  highlighted badge is the nozzle used for resolution.
+
+### Coverage states
+| Badge / status | Meaning |
+|----------------|---------|
+| **Linked profile** (green) | Cloud variant found; exact or closest nozzle match. |
+| **Partial coverage** (yellow) | Default is set but one or more models have no cloud variant. |
+| **No cloud preset** (red) | No variant for this model — create in Bambu Studio or override. |
+| **Fallback nozzle** | Requested nozzle not in cloud; nearest available size used. |
+
+### Refresh cloud presets
+- Picker options are cached **~10 minutes** on the driver (shared across requests).
+- The picker also caches per model **for the current page session**.
+- Click **Refresh cloud presets** after creating new variants in Bambu Studio to
+  reload immediately.
+
+---
+
+## Variant resolution (model + nozzle)
+
+For each assign or save, FilaMan:
+
+1. Determines the printer **model** and **nozzle** (live from Bambuddy, or
+   `bambu_default_nozzle_mm` on the spool/filament printer params if unknown).
+2. Looks up the **base name** for that model (per-model row → default base name).
+3. Queries the cloud variant index for `(base_name, model, nozzle)`.
+4. Uses **closest nozzle** in cloud if exact size is missing (shown as fallback).
+
+**New printer model connected:** If you already have a default base name but no
+per-model row yet, the driver resolves from the default on **first assign** and may
+lazily persist the PFUS for that printer — no manual re-save required.
+
+---
+
+## What happens when you assign a spool to an AMS slot
+
+The Bambuddy driver calls the slot `configure` endpoint with:
+
+| Field | Source |
+|-------|--------|
+| `tray_color` | Spool / filament color |
+| `tray_type` | Material type (PLA, PETG, …) |
+| `tray_sub_brands` | Filament name / subgroup |
+| `nozzle_temp_min` / `max` | Printer params or filament defaults |
+| `setting_id` | Resolved PFUS for this model + nozzle |
+| `tray_info_idx` | AMS material code (see below) |
+
+### Resolution order for `setting_id`
+1. Per-printer `bambu_slicer_setting_id` (if already mirrored).
+2. Per-model profile + cloud variant lookup.
+3. Default base name + cloud variant lookup (including new-model fallback).
+4. Empty if no variant exists.
+
+### Resolution order for `tray_info_idx` (material code)
+1. Learned `bambu_idx` on spool/filament printer params.
+2. Resolved from `bambu_slicer_setting_id` / PFUS via cloud map.
+3. Bambuddy inventory spool preset (if synced).
+4. **If `setting_id` is still empty** → **Slicer Profile Fallback** (admin setting).
+
+### Assign-time warning
+If coverage for the target printer's model is `missing` or `not_set`, the spool page
+asks for confirmation before assigning. You can still proceed; the driver applies the
+configured fallback (see below).
+
+---
+
+## Slicer Profile Fallback (Admin → App Settings)
+
+When **no model-specific slicer preset** resolves (`setting_id` empty), FilaMan pins
+the AMS material code to a **built-in system profile** so Bambu Studio does not show
+a blank/unrecognized profile (which would skip proper flow, cooling, and volumetric
+settings).
+
+| Setting | Material code sent | Studio shows |
+|---------|-------------------|--------------|
+| **Generic profile** (default) | `GFL99`, `GFG99`, … | Generic PLA, Generic PETG, … |
+| **Bambu profile** | `GFA00`, `GFG00`, … | Bambu PLA Basic, Bambu PETG Basic, … |
+
+Materials without a Bambu-brand basic (e.g. PA/NYLON, HIPS, PP) fall back to Generic
+even when **Bambu profile** is selected.
+
+**Important:**
+- Color and nozzle temps are **always** sent regardless of fallback.
+- The fallback is **not persisted** — it is applied only for that configure call.
+- When a real cloud variant is added later (picker save or new Studio preset +
+  refresh), the next assign uses the **real profile** automatically.
+
+---
+
+## Example: one profile on P2S, missing on H2C
+
+**Setup:** Default `SUNLU PLA HS PLUS GEN2`. P2S has a cloud variant; H2C does not.
+
+**Picker shows:** Partial coverage — `P2S ✓`, `H2C ✕`.
+
+**Assign to P2S:** Full SUNLU PFUS + SUNLU material code.
+
+**Assign to H2C (fallback = Bambu):**
+- `setting_id` = empty (no H2C variant)
+- `tray_info_idx` = `GFA00` (Bambu PLA Basic) — overrides any learned SUNLU code
+- Color and temps still from the spool
+- Slot uses a valid named profile instead of a blank Studio entry
+
+**After creating** `SUNLU PLA HS PLUS GEN2 @BBL H2C 0.4 nozzle` in Studio and
+clicking **Refresh cloud presets**, the picker shows `H2C ✓` and assigns use the
+real SUNLU variant on the next load/assign.
+
+---
+
+## Sync with Bambuddy
+
+When inventory sync is enabled, spool profiles can be **reflected** from Bambuddy
+(`source: reflect`). Local picker changes are debounced so a reflect sync does not
+immediately overwrite a profile you just saved.
+
+Profiles set in FilaMan are mirrored to Bambuddy inventory (`slicer_filament`) across
+the fleet when sync runs.
+
+---
+
+## Plugin configuration
+
+On each Bambuddy printer driver:
+
+| Setting | Effect |
+|---------|--------|
+| **Per-Model Slicer Profiles** (`enabled`, default) | Full behavior described here. |
+| **Per-Model Slicer Profiles** (`disabled`) | Legacy single-profile mode; no per-model resolution or fallback logic. |
+
+---
+
+## Troubleshooting
+
+| Symptom | What to check |
+|---------|----------------|
+| Picker empty or stale | Driver health; click **Refresh cloud presets**. |
+| Model shows ✕ | Create `\<base name\> @BBL \<model\> \<nozzle\> nozzle` in Bambu Studio, sync cloud, refresh. |
+| Wrong nozzle variant | Nozzle reported by Bambuddy; or set **Default Nozzle Diameter** on spool/filament printer params. |
+| Assign uses Generic/Bambu instead of brand profile | No variant for that model — expected until cloud preset exists or you override. |
+| Override disappeared | Should not happen for `override`/`manual` sources; report if it does. |
+
+---
+
+## Related files (developers)
+
+| Area | Location |
+|------|----------|
+| Profile picker UI | `frontend/src/lib/cloud-profile-picker.ts` |
+| Spool / filament pages | `frontend/src/pages/spools/[id]/index.astro`, `filaments/[id]/index.astro` |
+| API routes | `backend/app/api/v1/printers.py`, `spools.py`, `filaments.py` |
+| Fallback setting | `backend/app/models/app_settings.py`, `admin/app-settings.astro` |
+| Driver logic | `filaman-bambuddy-plugin/bambuddy/driver.py`, `profile_variants.py` |

--- a/backend/alembic/versions/add_bambu_unmatched_profile_fallback.py
+++ b/backend/alembic/versions/add_bambu_unmatched_profile_fallback.py
@@ -1,0 +1,38 @@
+"""add_bambu_unmatched_profile_fallback
+
+Add bambu_unmatched_profile_fallback column to app_settings table.
+Controls whether an unmatched filament falls back to the Generic profile
+for its material type ("generic") or to the Bambu-brand basic profile ("bambu").
+
+Revision ID: add_bambu_unmatched_fallback
+Revises: add_default_spool_core_weight
+Create Date: 2026-06-29 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_bambu_unmatched_fallback'
+down_revision: Union[str, Sequence[str], None] = 'add_default_spool_core_weight'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('app_settings') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'bambu_unmatched_profile_fallback',
+                sa.String(length=20),
+                nullable=False,
+                server_default='generic',
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('app_settings') as batch_op:
+        batch_op.drop_column('bambu_unmatched_profile_fallback')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -119,3 +119,47 @@ def RequirePermission(permission_key: str):
         return principal
 
     return Depends(dependency)
+
+
+async def ensure_any_permission(
+    db: AsyncSession,
+    principal: Principal,
+    *permission_keys: str,
+) -> None:
+    """Raise 403 unless the principal has at least one of the given permissions."""
+    if principal.is_superadmin:
+        return
+
+    if principal.auth_type == "device":
+        if principal.scopes is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "forbidden",
+                    "message": "Device has no scopes assigned",
+                },
+            )
+        if not any(key in principal.scopes for key in permission_keys):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "forbidden",
+                    "message": f"One of {permission_keys} required",
+                },
+            )
+        return
+
+    rbac_permissions = await resolve_user_permissions(db, principal.user_id)
+    if principal.scopes is not None:
+        effective = rbac_permissions.intersection(set(principal.scopes))
+    else:
+        effective = rbac_permissions
+
+    if not any(key in effective for key in permission_keys):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "forbidden",
+                "message": f"One of {permission_keys} required",
+            },
+        )

--- a/backend/app/api/v1/app_settings_admin.py
+++ b/backend/app/api/v1/app_settings_admin.py
@@ -17,6 +17,7 @@ class AppSettingsResponse(BaseModel):
     rfid_extended_data_enabled: bool
     rfid_protocol: str
     default_spool_core_weight_g: float | None = None
+    bambu_unmatched_profile_fallback: str = "generic"
 
 
 class AppSettingsUpdate(BaseModel):
@@ -41,6 +42,7 @@ class AppSettingsUpdate(BaseModel):
     rfid_extended_data_enabled: bool | None = None
     rfid_protocol: Literal["openspool", "filaman"] | None = None
     default_spool_core_weight_g: float | None = None
+    bambu_unmatched_profile_fallback: Literal["generic", "bambu"] | None = None
 
 
 @router.get("/", response_model=AppSettingsResponse)
@@ -59,6 +61,7 @@ async def get_app_settings(
         rfid_extended_data_enabled=settings_row.rfid_extended_data_enabled,
         rfid_protocol=settings_row.rfid_protocol,
         default_spool_core_weight_g=settings_row.default_spool_core_weight_g,
+        bambu_unmatched_profile_fallback=settings_row.bambu_unmatched_profile_fallback,
     )
 
 
@@ -91,6 +94,7 @@ async def update_app_settings(
         rfid_extended_data_enabled=settings_row.rfid_extended_data_enabled,
         rfid_protocol=settings_row.rfid_protocol,
         default_spool_core_weight_g=settings_row.default_spool_core_weight_g,
+        bambu_unmatched_profile_fallback=settings_row.bambu_unmatched_profile_fallback,
     )
 
 
@@ -114,6 +118,7 @@ async def get_public_app_settings(db: DBSession):
             rfid_extended_data_enabled=settings_row.rfid_extended_data_enabled,
             rfid_protocol=settings_row.rfid_protocol,
             default_spool_core_weight_g=settings_row.default_spool_core_weight_g,
+            bambu_unmatched_profile_fallback=settings_row.bambu_unmatched_profile_fallback,
         )
 
     response_cache.set("app_settings_public", resp, ttl=300)

--- a/backend/app/api/v1/devices.py
+++ b/backend/app/api/v1/devices.py
@@ -4,7 +4,7 @@ import httpx
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Header, Request, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DBSession
@@ -377,13 +377,16 @@ async def device_rfid_result(
         return RfidResultResponse(status="error", message="No tag_uuid provided")
 
     # Duplicate check and cleanup - clear rfid_uid from ALL spools (incl. archived)
-    # to prevent UNIQUE constraint violation on spools.rfid_uid
+    # to prevent UNIQUE constraint violation on spools.rfid_uid.
+    # Case-insensitive: the weigh lookup matches UIDs via lower(), so a UID stored
+    # with different casing would otherwise survive cleanup and later cause
+    # MultipleResultsFound on weigh.
     removed_info = []
     
     # Check spools - all spools regardless of status
     spool_query = (
         select(Spool)
-        .where(Spool.rfid_uid == data.tag_uuid)
+        .where(func.lower(Spool.rfid_uid) == data.tag_uuid.lower())
     )
     if data.spool_id:
         spool_query = spool_query.where(Spool.id != data.spool_id)

--- a/backend/app/api/v1/filaments.py
+++ b/backend/app/api/v1/filaments.py
@@ -2,14 +2,15 @@ import logging
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import delete, func, or_, select, literal_column
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DBSession, PrincipalDep, RequirePermission
+from app.api.v1.printers import pick_bambuddy_driver, _is_primary_worker, _proxy_to_primary
 from app.core.cache import response_cache
 from app.core.db_utils import get_next_available_id
 from app.api.v1.schemas import PaginatedResponse
@@ -1191,3 +1192,110 @@ async def delete_filament(
     await db.commit()
     await event_bus.publish({"event": "filaments_changed"})
     response_cache.delete("filament_types")
+
+
+class DefaultFilamentSlicerProfileBody(BaseModel):
+    base_name: str = Field(..., min_length=1)
+    apply_to_existing: bool = False
+
+
+class ModelFilamentSlicerProfileBody(BaseModel):
+    base_name: str | None = None
+    clear_override: bool = False
+
+
+@router_filaments.post("/{filament_id}/slicer-profile/default")
+@router_filaments.put("/{filament_id}/slicer-profile/default")
+async def set_filament_default_slicer_profile(
+    filament_id: int,
+    body: DefaultFilamentSlicerProfileBody,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+):
+    """Set default Bambu cloud slicer profile for a filament."""
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="POST",
+            path=f"/api/v1/filaments/{filament_id}/slicer-profile/default",
+            json_body=body.model_dump(),
+        )
+    filament = await db.get(Filament, filament_id)
+    if not filament:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Filament not found"},
+        )
+    _printer_id, driver = await pick_bambuddy_driver(db)
+    method = getattr(driver, "set_default_filament_profile", None)
+    if not callable(method):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported",
+                "message": "Driver does not support default slicer profiles",
+            },
+        )
+    result = await method(
+        int(filament_id),
+        base_name=body.base_name.strip(),
+        apply_to_existing=body.apply_to_existing,
+    )
+    return result
+
+
+@router_filaments.post("/{filament_id}/slicer-profile/models/{model}")
+@router_filaments.put("/{filament_id}/slicer-profile/models/{model}")
+async def set_filament_model_slicer_profile(
+    filament_id: int,
+    model: str,
+    body: ModelFilamentSlicerProfileBody,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+):
+    """Set or clear a per-model slicer profile override on a filament."""
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="POST",
+            path=f"/api/v1/filaments/{filament_id}/slicer-profile/models/{model}",
+            json_body=body.model_dump(),
+        )
+    filament = await db.get(Filament, filament_id)
+    if not filament:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Filament not found"},
+        )
+    _printer_id, driver = await pick_bambuddy_driver(db)
+    method = getattr(driver, "set_filament_profile_for_model", None)
+    if not callable(method):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported",
+                "message": "Driver does not support per-model slicer profiles",
+            },
+        )
+    if body.clear_override:
+        result = await method(
+            int(filament_id), model.strip().upper(), clear_override=True
+        )
+    else:
+        if not body.base_name or not body.base_name.strip():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_params",
+                    "message": "base_name is required",
+                },
+            )
+        result = await method(
+            int(filament_id),
+            model.strip().upper(),
+            base_name=body.base_name.strip(),
+            link_others=False,
+        )
+    return result

--- a/backend/app/api/v1/me.py
+++ b/backend/app/api/v1/me.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DBSession, PrincipalDep
+from app.core.csrf import maybe_attach_csrf_cookie
 from app.core.security import hash_password_async, verify_password_async
 from app.models import User, Role, Permission, UserRole, RolePermission
 
@@ -36,6 +39,7 @@ class ChangePasswordRequest(BaseModel):
 
 @router.get("", response_model=MeResponse)
 async def get_me(
+    request: Request,
     principal: PrincipalDep,
     db: DBSession,
 ):
@@ -57,7 +61,7 @@ async def get_me(
         p.key for r in user.roles for p in r.permissions
     ))
 
-    return MeResponse(
+    payload = MeResponse(
         id=user.id,
         email=user.email,
         display_name=user.display_name,
@@ -66,6 +70,9 @@ async def get_me(
         roles=roles,
         permissions=permissions,
     )
+    response = JSONResponse(content=jsonable_encoder(payload))
+    maybe_attach_csrf_cookie(request, response)
+    return response
 
 
 @router.patch("", response_model=MeResponse)

--- a/backend/app/api/v1/printers.py
+++ b/backend/app/api/v1/printers.py
@@ -9,7 +9,8 @@ from pydantic import BaseModel
 from sqlalchemy import delete as sa_delete, func, select
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import DBSession, PrincipalDep, RequirePermission
+from app.core.security import Principal
+from app.api.deps import DBSession, PrincipalDep, RequirePermission, ensure_any_permission
 from app.api.v1.schemas import PaginatedResponse
 from app.models import (
     Location,
@@ -553,14 +554,100 @@ class DriverActionResponse(BaseModel):
     data: dict | None = None
 
 
+_READ_ONLY_DRIVER_ACTIONS = frozenset(
+    {"list_connected_models", "get_profile_coverage"}
+)
+_SPOOL_PROFILE_DRIVER_ACTIONS = frozenset(
+    {"set_spool_profile_for_model", "set_default_spool_profile"}
+)
+_FILAMENT_PROFILE_DRIVER_ACTIONS = frozenset(
+    {"set_filament_profile_for_model", "set_default_filament_profile"}
+)
+
+
+async def _ensure_driver_action_permission(
+    db: DBSession, principal: Principal, action: str
+) -> None:
+    if action in _READ_ONLY_DRIVER_ACTIONS:
+        await ensure_any_permission(
+            db, principal, "printers:read", "printers:update"
+        )
+    elif action in _SPOOL_PROFILE_DRIVER_ACTIONS:
+        await ensure_slicer_profile_write_permission(db, principal, entity="spool")
+    elif action in _FILAMENT_PROFILE_DRIVER_ACTIONS:
+        await ensure_slicer_profile_write_permission(db, principal, entity="filament")
+    else:
+        await ensure_any_permission(db, principal, "printers:update")
+
+
+async def ensure_slicer_profile_write_permission(
+    db: DBSession, principal: Principal, *, entity: str = "spool"
+) -> None:
+    """Profile picker is visible to read-only users; allow matching write access."""
+    if entity == "filament":
+        await ensure_any_permission(
+            db,
+            principal,
+            "filaments:update",
+            "printers:update",
+            "filaments:read",
+        )
+    else:
+        await ensure_any_permission(
+            db,
+            principal,
+            "spools:update",
+            "printers:update",
+            "spools:read",
+        )
+
+
+async def pick_bambuddy_driver(db: DBSession) -> tuple[int, Any]:
+    """Return (printer_id, driver) for the first running Bambuddy driver."""
+    result = await db.execute(
+        select(Printer).where(
+            Printer.driver_key == "bambuddy",
+            Printer.deleted_at.is_(None),
+        )
+    )
+    for printer in result.scalars().all():
+        driver = plugin_manager.drivers.get(printer.id)
+        if driver is not None:
+            return printer.id, driver
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail={
+            "code": "driver_not_running",
+            "message": "No Bambuddy driver is running",
+        },
+    )
+
+
+async def _invoke_driver_method(driver: Any, method_name: str, **kwargs: Any) -> Any:
+    method = getattr(driver, method_name, None)
+    if not callable(method):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported",
+                "message": f"Driver does not support '{method_name}'",
+            },
+        )
+    result = method(**kwargs)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
 @router.post("/{printer_id}/driver/action", response_model=DriverActionResponse)
 async def driver_action(
     printer_id: int,
     data: DriverActionRequest,
     request: Request,
     db: DBSession,
-    principal=RequirePermission("printers:update"),
+    principal: PrincipalDep,
 ):
+    await _ensure_driver_action_permission(db, principal, data.action)
     if not _is_primary_worker():
         payload = await _proxy_to_primary(
             request,
@@ -650,6 +737,91 @@ async def driver_action(
         )
 
 
+@router.get("/{printer_id}/driver/connected-models")
+async def driver_connected_models(
+    printer_id: int,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+):
+    """List distinct Bambu printer models connected via this driver URL."""
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="GET",
+            path=f"/api/v1/printers/{printer_id}/driver/connected-models",
+        )
+
+    driver = plugin_manager.drivers.get(printer_id)
+    if not driver:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "driver_not_running",
+                "message": "Driver is not running for this printer",
+            },
+        )
+
+    try:
+        return await _invoke_driver_method(driver, "list_connected_models")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": "action_failed", "message": str(e)},
+        )
+
+
+@router.get("/{printer_id}/driver/profile-coverage")
+async def driver_profile_coverage(
+    printer_id: int,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+    spool_id: int | None = Query(None),
+    filament_id: int | None = Query(None),
+):
+    """Read-only per-model profile resolution for the slicer profile picker."""
+    if not _is_primary_worker():
+        qs_parts = []
+        if spool_id is not None:
+            qs_parts.append(f"spool_id={spool_id}")
+        if filament_id is not None:
+            qs_parts.append(f"filament_id={filament_id}")
+        qs = ("?" + "&".join(qs_parts)) if qs_parts else ""
+        return await _proxy_to_primary(
+            request,
+            method="GET",
+            path=f"/api/v1/printers/{printer_id}/driver/profile-coverage{qs}",
+        )
+
+    driver = plugin_manager.drivers.get(printer_id)
+    if not driver:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "driver_not_running",
+                "message": "Driver is not running for this printer",
+            },
+        )
+
+    try:
+        return await _invoke_driver_method(
+            driver,
+            "get_profile_coverage",
+            spool_id=spool_id,
+            filament_id=filament_id,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": "action_failed", "message": str(e)},
+        )
+
+
 @router.get("/{printer_id}/driver/health")
 async def driver_health(
     printer_id: int,
@@ -711,18 +883,28 @@ async def driver_cloud_presets(
     db: DBSession,
     principal: PrincipalDep,
     refresh: int | None = Query(None),
+    model: str | None = Query(None),
+    group: str | None = Query(None),
 ):
     """Returns the driver's cloud slicer-profile catalog for the FilaMan picker.
 
     Read-only. Proxies to the primary worker (where the driver runs).
+    Optional ``model`` filters presets; ``group=base`` dedupes by logical base name.
     Response shape: {"presets": [{code, name, displayName, isCustom}], "count": N}.
     """
     if not _is_primary_worker():
+        qs_parts = []
+        if refresh:
+            qs_parts.append("refresh=1")
+        if model:
+            qs_parts.append(f"model={model}")
+        if group:
+            qs_parts.append(f"group={group}")
+        qs = ("?" + "&".join(qs_parts)) if qs_parts else ""
         payload = await _proxy_to_primary(
             request,
             method="GET",
-            path=f"/api/v1/printers/{printer_id}/driver/cloud-presets"
-            + ("?refresh=1" if refresh else ""),
+            path=f"/api/v1/printers/{printer_id}/driver/cloud-presets{qs}",
         )
         if isinstance(payload, dict):
             return payload
@@ -749,7 +931,12 @@ async def driver_cloud_presets(
         )
 
     try:
-        result = method(force=bool(refresh))
+        kwargs: dict[str, Any] = {"force": bool(refresh)}
+        if model is not None:
+            kwargs["model"] = model
+        if group is not None:
+            kwargs["group"] = group
+        result = method(**kwargs)
         if inspect.isawaitable(result):
             result = await result
         if isinstance(result, dict):

--- a/backend/app/api/v1/schemas_spool.py
+++ b/backend/app/api/v1/schemas_spool.py
@@ -165,6 +165,11 @@ class MoveLocationRequest(BaseModel):
     note: str | None = None
 
 
+class SpoolEventColor(BaseModel):
+    hex_code: str
+    name: str | None = None
+
+
 class SpoolEventResponse(BaseModel):
     id: int
     spool_id: int
@@ -181,6 +186,12 @@ class SpoolEventResponse(BaseModel):
     to_location_id: int | None
     note: str | None
     meta: dict[str, Any] | None
+    # Enriched filament context (populated by the all-events listing); may be
+    # null when the spool or its filament has since been deleted.
+    manufacturer_name: str | None = None
+    manufacturer_color_name: str | None = None
+    material_type: str | None = None
+    colors: list[SpoolEventColor] | None = None
 
     class Config:
         from_attributes = True

--- a/backend/app/api/v1/spools.py
+++ b/backend/app/api/v1/spools.py
@@ -1,11 +1,13 @@
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
 from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, joinedload
 
 from app.api.deps import DBSession, PrincipalDep, RequirePermission
+from app.api.v1.printers import pick_bambuddy_driver, _is_primary_worker, _proxy_to_primary
 from app.core.cache import response_cache
 from app.core.db_utils import get_next_available_id, get_next_available_ids
 from app.api.v1.schemas import PaginatedResponse
@@ -1003,3 +1005,105 @@ async def device_measurement(
     )
     await event_bus.publish({"event": "spools_changed"})
     return event
+
+
+class DefaultSlicerProfileBody(BaseModel):
+    base_name: str = Field(..., min_length=1)
+
+
+class ModelSlicerProfileBody(BaseModel):
+    base_name: str | None = None
+    clear_override: bool = False
+
+
+@router_spools.post("/{spool_id}/slicer-profile/default")
+@router_spools.put("/{spool_id}/slicer-profile/default")
+async def set_spool_default_slicer_profile(
+    spool_id: int,
+    body: DefaultSlicerProfileBody,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+):
+    """Set default Bambu cloud slicer profile for a spool (all connected models)."""
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="POST",
+            path=f"/api/v1/spools/{spool_id}/slicer-profile/default",
+            json_body=body.model_dump(),
+        )
+    spool = await db.get(Spool, spool_id)
+    if not spool:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Spool not found"},
+        )
+    _printer_id, driver = await pick_bambuddy_driver(db)
+    method = getattr(driver, "set_default_spool_profile", None)
+    if not callable(method):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported",
+                "message": "Driver does not support default slicer profiles",
+            },
+        )
+    result = await method(int(spool_id), base_name=body.base_name.strip())
+    return result
+
+
+@router_spools.post("/{spool_id}/slicer-profile/models/{model}")
+@router_spools.put("/{spool_id}/slicer-profile/models/{model}")
+async def set_spool_model_slicer_profile(
+    spool_id: int,
+    model: str,
+    body: ModelSlicerProfileBody,
+    request: Request,
+    db: DBSession,
+    principal: PrincipalDep,
+):
+    """Set or clear a per-model slicer profile override on a spool."""
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="POST",
+            path=f"/api/v1/spools/{spool_id}/slicer-profile/models/{model}",
+            json_body=body.model_dump(),
+        )
+    spool = await db.get(Spool, spool_id)
+    if not spool:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Spool not found"},
+        )
+    _printer_id, driver = await pick_bambuddy_driver(db)
+    method = getattr(driver, "set_spool_profile_for_model", None)
+    if not callable(method):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "unsupported",
+                "message": "Driver does not support per-model slicer profiles",
+            },
+        )
+    if body.clear_override:
+        result = await method(
+            int(spool_id), model.strip().upper(), clear_override=True
+        )
+    else:
+        if not body.base_name or not body.base_name.strip():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_params",
+                    "message": "base_name is required",
+                },
+            )
+        result = await method(
+            int(spool_id),
+            model.strip().upper(),
+            base_name=body.base_name.strip(),
+            link_others=False,
+        )
+    return result

--- a/backend/app/api/v1/spools.py
+++ b/backend/app/api/v1/spools.py
@@ -25,6 +25,7 @@ from app.api.v1.schemas_spool import (
     MoveLocationRequest,
     SpoolBulkCreate,
     SpoolCreate,
+    SpoolEventColor,
     SpoolEventResponse,
     SpoolResponse,
     SpoolStatusResponse,
@@ -598,11 +599,43 @@ async def list_all_spool_events(
 ):
     result = await db.execute(
         select(SpoolEvent)
+        .options(
+            selectinload(SpoolEvent.spool)
+            .selectinload(Spool.filament)
+            .options(
+                selectinload(Filament.manufacturer),
+                selectinload(Filament.filament_colors).selectinload(
+                    FilamentColor.color
+                ),
+            )
+        )
         .order_by(SpoolEvent.event_at.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
     )
-    items = list(result.scalars().all())
+    events = list(result.scalars().all())
+
+    items: list[SpoolEventResponse] = []
+    for ev in events:
+        resp = SpoolEventResponse.model_validate(ev)
+        filament = ev.spool.filament if ev.spool else None
+        if filament is not None:
+            resp.manufacturer_name = (
+                filament.manufacturer.name if filament.manufacturer else None
+            )
+            resp.manufacturer_color_name = filament.manufacturer_color_name
+            resp.material_type = filament.material_type
+            resp.colors = [
+                SpoolEventColor(
+                    hex_code=fc.color.hex_code,
+                    name=fc.display_name_override or fc.color.name,
+                )
+                for fc in sorted(
+                    filament.filament_colors, key=lambda c: c.position
+                )
+                if fc.color is not None
+            ]
+        items.append(resp)
 
     count_result = await db.execute(select(func.count()).select_from(SpoolEvent))
     total = count_result.scalar() or 0

--- a/backend/app/core/csrf.py
+++ b/backend/app/core/csrf.py
@@ -1,0 +1,45 @@
+"""CSRF cookie helpers for session-authenticated browser clients."""
+
+from __future__ import annotations
+
+from fastapi import Request
+from starlette.responses import Response
+
+from app.core.config import settings
+from app.core.security import generate_token_secret
+
+_CSRF_MAX_AGE = 60 * 60 * 24 * 30  # 30 days, aligned with session cookie
+
+
+def cookie_secure(request: Request) -> bool:
+    secure = not settings.debug
+    if secure:
+        is_ssl = (
+            request.url.scheme == "https"
+            or request.headers.get("x-forwarded-proto") == "https"
+        )
+        if not is_ssl:
+            secure = False
+    return secure
+
+
+def attach_csrf_cookie(request: Request, response: Response, token: str) -> None:
+    response.set_cookie(
+        key="csrf_token",
+        value=token,
+        path="/",
+        httponly=False,
+        secure=cookie_secure(request),
+        samesite="lax",
+        max_age=_CSRF_MAX_AGE,
+    )
+
+
+def maybe_attach_csrf_cookie(request: Request, response: Response) -> None:
+    """Issue a CSRF cookie when a session user has none (legacy sessions, partial clears)."""
+    principal = getattr(request.state, "principal", None)
+    if not principal or principal.auth_type != "session":
+        return
+    if request.cookies.get("csrf_token"):
+        return
+    attach_csrf_cookie(request, response, generate_token_secret())

--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -121,6 +121,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 response = await call_next(request)
 
                 # Check if session needs extension and update the cookie
+                from app.core.csrf import maybe_attach_csrf_cookie
+
+                maybe_attach_csrf_cookie(request, response)
+
                 if getattr(principal, "needs_cookie_extension", False):
                     secure_cookie = not settings.debug
                     if secure_cookie:
@@ -463,11 +467,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return principal
 
 
+_PRIMARY_PROXY_HEADER = "x-filaman-primary-hop"
+
+
 class CsrfMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         if request.method in ("POST", "PUT", "PATCH", "DELETE"):
             path = request.url.path
             if path.startswith("/api/v1/") or path == "/auth/logout":
+                hop_header = request.headers.get(_PRIMARY_PROXY_HEADER, "0")
+                if hop_header.isdigit() and int(hop_header) > 0:
+                    return await call_next(request)
+
                 principal = getattr(request.state, "principal", None)
                 if principal and principal.auth_type == "session":
                     csrf_cookie = request.cookies.get("csrf_token")

--- a/backend/app/models/app_settings.py
+++ b/backend/app/models/app_settings.py
@@ -21,3 +21,8 @@ class AppSettings(Base, TimestampMixin):
     rfid_extended_data_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     rfid_protocol: Mapped[str] = mapped_column(String(20), default="openspool", nullable=False)
     default_spool_core_weight_g: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # Fallback when no slicer profile resolves for a filament/model: "generic"
+    # (Generic <material>) or "bambu" (Bambu-brand basic profile for the material).
+    bambu_unmatched_profile_fallback: Mapped[str] = mapped_column(
+        String(20), default="generic", nullable=False
+    )

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -1160,8 +1160,11 @@ class PluginManager:
             if value is not None and value != "":
                 enriched[key] = value
 
-        # 6. Inject the FilaMan spool ID so plugin drivers can use it
+        # 6. Inject the FilaMan spool and filament IDs so plugin drivers can
+        # resolve spool- AND filament-level config (e.g. per-model slicer
+        # profiles stored in Filament.custom_fields) at assign time.
         enriched["id"] = spool_id
+        enriched["filament_id"] = filament_id
 
         return enriched
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,10 +3,12 @@ import { getAbortSignal } from './abort'
 const API_BASE = '/api/v1'
 const AUTH_BASE = '/auth'
 
-function getCsrfToken(): string | null {
+export function getCsrfToken(): string | null {
   const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)
   return match ? decodeURIComponent(match[1]) : null
 }
+
+type ApiRequestOptions = RequestInit & { csrfToken?: string | null }
 
 export class ApiError extends Error {
   status: number
@@ -30,7 +32,7 @@ interface ApiErrorResponse {
   detail?: Record<string, string[]>
 }
 
-export async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+export async function request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
   let url: string
   if (path.startsWith('/auth')) {
     url = AUTH_BASE + path.slice(5)
@@ -38,29 +40,38 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
     url = API_BASE + path
   }
 
+  const { csrfToken: csrfOverride, ...fetchOptions } = options
+
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    ...options.headers as Record<string, string>,
+    ...fetchOptions.headers as Record<string, string>,
   }
 
-  const csrfToken = getCsrfToken()
+  const csrfToken = csrfOverride ?? getCsrfToken()
   if (csrfToken) {
     headers['X-CSRF-Token'] = csrfToken
   }
 
   const response = await fetch(url, {
-    ...options,
+    ...fetchOptions,
     headers,
     credentials: 'include',
-    signal: options.signal ?? getAbortSignal(),
+    signal: fetchOptions.signal ?? getAbortSignal(),
   })
 
   if (!response.ok) {
-    const errorData: ApiErrorResponse = await response.json().catch(() => ({
-      code: 'unknown_error',
-      message: `HTTP ${response.status}`,
-    }))
-    throw new ApiError(response.status, errorData.code, errorData.message)
+    const errorBody: any = await response.json().catch(() => ({}))
+    const detail = errorBody?.detail
+    const code =
+      (typeof detail === 'object' && detail?.code) ||
+      errorBody?.code ||
+      'unknown_error'
+    const message =
+      (typeof detail === 'object' && detail?.message) ||
+      (typeof detail === 'string' ? detail : '') ||
+      errorBody?.message ||
+      `HTTP ${response.status}`
+    throw new ApiError(response.status, code, message)
   }
 
   if (response.status === 204) {
@@ -71,23 +82,28 @@ export async function request<T>(path: string, options: RequestInit = {}): Promi
 }
 
 export const api = {
-  get: <T>(path: string) => request<T>(path, { method: 'GET' }),
-  post: <T>(path: string, body?: unknown) =>
+  get: <T>(path: string, options?: Omit<ApiRequestOptions, 'method'>) =>
+    request<T>(path, { ...options, method: 'GET' }),
+  post: <T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
     request<T>(path, {
+      ...options,
       method: 'POST',
       body: body ? JSON.stringify(body) : undefined,
     }),
-  put: <T>(path: string, body?: unknown) =>
+  put: <T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
     request<T>(path, {
+      ...options,
       method: 'PUT',
       body: body ? JSON.stringify(body) : undefined,
     }),
-  patch: <T>(path: string, body?: unknown) =>
+  patch: <T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'method' | 'body'>) =>
     request<T>(path, {
+      ...options,
       method: 'PATCH',
       body: body ? JSON.stringify(body) : undefined,
     }),
-  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+  delete: <T>(path: string, options?: Omit<ApiRequestOptions, 'method'>) =>
+    request<T>(path, { ...options, method: 'DELETE' }),
 }
 
 /**

--- a/frontend/src/lib/cloud-profile-picker.ts
+++ b/frontend/src/lib/cloud-profile-picker.ts
@@ -1,0 +1,1390 @@
+/** Per-model Bambu cloud profile picker (shared by spool + filament pages). */
+
+import { api, ApiError, getCsrfToken } from './api'
+
+export type ConnectedModel = {
+  model: string
+  printer_ids: number[]
+  representative_printer_id: number
+}
+
+export type ProfileCoverage = {
+  model?: string
+  mapped?: boolean
+  status?: 'not_set' | 'ok' | 'fallback' | 'missing'
+  code?: string
+  base_name?: string
+  source?: string
+  nozzle_requested?: number
+  nozzle_resolved?: number
+  exact_nozzle?: boolean
+  fallback_nozzle?: boolean
+  expected_name?: string
+  standard_nozzles?: Record<string, boolean>
+  requested_nozzle_in_cloud?: boolean
+}
+
+const STANDARD_NOZZLE_SIZES = [0.2, 0.4, 0.6, 0.8] as const
+
+export type InitPerModelPickerOptions = {
+  entityType: 'spool' | 'filament'
+  entityId: number
+  t: (key: string) => string
+  getCsrfToken: () => string
+  getAbortSignal: () => AbortSignal | undefined
+  isAbortError: (e: unknown) => boolean
+  onSaved?: () => void
+}
+
+type SelectionVisual =
+  | 'empty'
+  | 'draft'
+  | 'saving'
+  | 'valid'
+  | 'fallback'
+  | 'invalid'
+  | 'linked'
+
+type VisualMeta = {
+  border: string
+  bg: string
+  icon: string
+  iconColor: string
+  label: string
+  hint: string
+}
+
+function escapeHtml(s: string): string {
+  return (s || '').replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string)
+  )
+}
+
+function presetBases(presets: any[]): Set<string> {
+  const bases = new Set<string>()
+  for (const p of presets) {
+    const b = p.baseName || p.displayName || ''
+    if (b) bases.add(b)
+  }
+  return bases
+}
+
+function formatNozzleLine(cov: ProfileCoverage | undefined, model: string): string {
+  const st = coverageStatus(cov)
+  const req = cov?.nozzle_requested
+  const res = cov?.nozzle_resolved
+  const reqLabel =
+    req != null ? `${req} mm` : '0.4 mm (default if printer offline)'
+
+  if (st === 'ok' && res != null) {
+    return `Nozzle on ${model}: ${reqLabel} → ${res} mm cloud variant (exact match)`
+  }
+  if (st === 'fallback' && res != null) {
+    return `Nozzle on ${model}: ${reqLabel} → ${res} mm cloud variant (closest available; no exact ${reqLabel} preset)`
+  }
+  if (st === 'missing') {
+    return `Nozzle on ${model}: ${reqLabel} — no cloud preset for this model (see red nozzle badges)`
+  }
+  return `Nozzle on ${model}: ${reqLabel} (from live printer, or spool/filament default)`
+}
+
+function formatCloudNameLine(
+  cov: ProfileCoverage | undefined,
+  baseName: string,
+  model: string
+): string {
+  const st = coverageStatus(cov)
+  const nozzle = cov?.nozzle_requested ?? 0.4
+  const expected =
+    cov?.expected_name ||
+    (baseName ? `${baseName} @BBL ${model} ${nozzle}g nozzle` : '')
+
+  if (!baseName) {
+    return `Selectable profiles must exist in Bambu cloud with an @BBL ${model} or @Bambu Lab ${model} suffix and nozzle size.`
+  }
+  if (st === 'ok' || st === 'fallback') {
+    const code = cov?.code ? ` (${cov.code})` : ''
+    const resolved = cov?.nozzle_resolved ?? nozzle
+    const suffix =
+      resolved === 0.4
+        ? `@BBL ${model} or @BBL ${model} 0.4 nozzle (stock on any model often omits 0.4)`
+        : `@BBL ${model} ${resolved}g nozzle`
+    return `Matched cloud preset${code}. Studio name ends with ${suffix}.`
+  }
+  if (st === 'missing') {
+    if (nozzle === 0.4) {
+      return `To make "${baseName}" work on ${model}, create/sync as ${expected} — stock 0.4 mm may use @BBL ${model} only.`
+    }
+    return `To make "${baseName}" work on ${model}, create/sync in Bambu Studio as: ${expected}`
+  }
+  if (nozzle === 0.4) {
+    return `Stock ${model} 0.4 mm presets are often named @BBL ${model} only (all models); other sizes include the nozzle (0.2, 0.6, 0.8 …).`
+  }
+  return `In Bambu Studio, ${model} presets are named like: Your Profile Name @BBL ${model} ${nozzle}g nozzle`
+}
+
+function renderPickerMeta(
+  cov: ProfileCoverage | undefined,
+  baseName: string,
+  model: string
+): string {
+  const cloudLine = formatCloudNameLine(cov, baseName, model)
+  const st = coverageStatus(cov)
+  const cloudStyle =
+    st === 'missing'
+      ? 'color:var(--warning-text, #b8860b); font-weight:500;'
+      : ''
+  return `<div class="profile-picker-meta" style="margin-top:8px; padding-top:8px; border-top:1px solid var(--border,#333); font-size:0.72rem; color:var(--text-muted); line-height:1.45;">
+    ${baseName ? `<div style="margin-bottom:6px;display:flex;align-items:center;flex-wrap:wrap;gap:4px;"><span style="font-size:0.7rem;">Cloud variants:</span>${renderStandardNozzleBadges(cov, baseName)}</div>` : ''}
+    <div class="profile-picker-nozzle-line">${escapeHtml(formatNozzleLine(cov, model))}</div>
+    <div class="profile-picker-cloud-line" style="margin-top:4px; ${cloudStyle}">${escapeHtml(cloudLine)}</div>
+  </div>`
+}
+
+function stdNozzleAvailable(
+  std: Record<string, boolean> | undefined,
+  n: number
+): boolean {
+  if (!std) return false
+  return std[`${n}`] === true || std[`${n.toFixed(1)}`] === true
+}
+
+function renderStandardNozzleBadges(
+  cov: ProfileCoverage | undefined,
+  baseName: string
+): string {
+  if (!baseName) return ''
+  const std = cov?.standard_nozzles
+  const req = cov?.nozzle_requested ?? 0.4
+  const parts = STANDARD_NOZZLE_SIZES.map((n) => {
+    const available = stdNozzleAvailable(std, n)
+    const requested = Math.abs(n - req) < 0.06
+    const color = available ? 'var(--success-text)' : 'var(--error-text)'
+    const border = available ? 'var(--success-border)' : 'var(--error-border)'
+    const bg = available ? 'var(--success-bg)' : 'var(--error-bg)'
+    const ring = requested
+      ? 'outline:2px solid var(--accent,#3b82f6); outline-offset:1px;'
+      : ''
+    const title = available
+      ? `${n} mm cloud variant exists`
+      : `${n} mm cloud variant missing — create in Bambu Studio and sync`
+    return `<span title="${escapeHtml(title)}" style="font-size:0.65rem;padding:1px 7px;border-radius:999px;border:1px solid ${border};color:${color};background:${bg};${ring}">${n}</span>`
+  })
+  return `<span class="profile-std-nozzles" style="display:inline-flex;flex-wrap:wrap;gap:4px;align-items:center;margin-left:4px;" title="Green = in cloud for this profile/model; red = missing; ring = printer nozzle">${parts.join('')}</span>`
+}
+
+function rowNozzleBadge(cov?: ProfileCoverage, baseName = ''): string {
+  return renderStandardNozzleBadges(cov, baseName)
+}
+
+function coverageStatus(c?: ProfileCoverage): ProfileCoverage['status'] {
+  if (!c) return 'not_set'
+  if (c.status) return c.status
+  if (c.mapped) return c.fallback_nozzle ? 'fallback' : 'ok'
+  return c.base_name ? 'missing' : 'not_set'
+}
+
+function visualMeta(
+  visual: SelectionVisual,
+  cov?: ProfileCoverage,
+  linked = false
+): VisualMeta {
+  const nozzle =
+    cov?.nozzle_resolved != null ? `${cov.nozzle_resolved} mm nozzle` : ''
+  const code = cov?.code ? ` · ${cov.code}` : ''
+
+  switch (visual) {
+    case 'saving':
+      return {
+        border: 'var(--accent, #3b82f6)',
+        bg: 'rgba(59, 130, 246, 0.08)',
+        icon: '…',
+        iconColor: 'var(--accent, #3b82f6)',
+        label: 'Saving…',
+        hint: '',
+      }
+    case 'draft':
+      return {
+        border: 'var(--warning-text, #b8860b)',
+        bg: 'rgba(247, 200, 106, 0.1)',
+        icon: '!',
+        iconColor: 'var(--warning-text, #b8860b)',
+        label: 'Not saved',
+        hint: 'Pick a profile from the dropdown — typed text alone is not saved',
+      }
+    case 'valid':
+      return {
+        border: 'var(--success-border)',
+        bg: 'var(--success-bg)',
+        icon: '✓',
+        iconColor: 'var(--success-text)',
+        label: linked ? 'Linked profile' : 'Profile saved',
+        hint: nozzle
+          ? `Resolves for this printer${code}`
+          : `Saved in FilaMan${code}`,
+      }
+    case 'fallback':
+      return {
+        border: 'var(--warning-text, #b8860b)',
+        bg: 'rgba(247, 200, 106, 0.12)',
+        icon: '≈',
+        iconColor: 'var(--warning-text, #b8860b)',
+        label: linked ? 'Linked (closest nozzle)' : 'Closest nozzle used',
+        hint:
+          (cov?.expected_name
+            ? `Expected ${cov.expected_name}. `
+            : '') +
+          (nozzle ? `Using ${nozzle}${code}` : 'Exact nozzle variant not in cloud'),
+      }
+    case 'invalid':
+      return {
+        border: 'var(--error-border)',
+        bg: 'var(--error-bg)',
+        icon: '✕',
+        iconColor: 'var(--error-text)',
+        label: 'No cloud preset for this model',
+        hint:
+          cov?.expected_name ||
+          'This name is not available for this printer model — pick another profile or create it in Bambu Studio',
+      }
+    case 'linked':
+      return {
+        border: 'var(--border, #444)',
+        bg: 'transparent',
+        icon: '↪',
+        iconColor: 'var(--text-muted)',
+        label: 'Using default profile',
+        hint: 'Matches the default profile above unless you override for this model',
+      }
+    case 'empty':
+    default:
+      return {
+        border: 'var(--border, #444)',
+        bg: 'transparent',
+        icon: '○',
+        iconColor: 'var(--text-muted)',
+        label: 'No profile selected',
+        hint: 'Search and choose a profile from the list',
+      }
+  }
+}
+
+function isProfileInvalid(
+  cov: ProfileCoverage | undefined,
+  selectedBase: string
+): boolean {
+  if (!selectedBase) return false
+  if (cov?.mapped === false) return true
+  return coverageStatus(cov) === 'missing'
+}
+
+function displayBaseForPicker(
+  selectedBase: string,
+  cov: ProfileCoverage | undefined,
+  presets: any[]
+): string {
+  if (!selectedBase) return ''
+  if (isProfileInvalid(cov, selectedBase)) return ''
+  if (presets.length > 0 && !presetBases(presets).has(selectedBase)) return ''
+  return selectedBase
+}
+
+function renderStaleNotice(staleBase: string, model: string): string {
+  if (!staleBase) return ''
+  return `<p class="profile-stale-notice" style="margin:0 0 8px;font-size:0.8rem;color:var(--warning-text,#b8860b);">Previously saved <strong>${escapeHtml(staleBase)}</strong> is not available for ${escapeHtml(model)} in Bambu cloud — pick a compatible profile below.</p>`
+}
+
+function committedVisual(
+  baseName: string,
+  presets: any[],
+  cov?: ProfileCoverage
+): SelectionVisual {
+  if (!baseName) return 'empty'
+  if (cov?.mapped === true) return cov.fallback_nozzle ? 'fallback' : 'valid'
+  if (cov?.mapped === false) return 'invalid'
+  const st = coverageStatus(cov)
+  if (st === 'ok') return 'valid'
+  if (st === 'fallback') return 'fallback'
+  if (st === 'missing') return 'invalid'
+  if (presets.length > 0 && !presetBases(presets).has(baseName)) return 'invalid'
+  return 'empty'
+}
+
+function applyShellState(
+  shell: HTMLElement,
+  visual: SelectionVisual,
+  meta: VisualMeta,
+  cov?: ProfileCoverage,
+  baseName = '',
+  model = ''
+) {
+  shell.dataset.state = visual
+  shell.style.borderColor = meta.border
+  shell.style.background = meta.bg
+
+  const icon = shell.querySelector('.profile-picker-icon') as HTMLElement | null
+  const statusLabel = shell.querySelector('.profile-picker-status-label') as HTMLElement | null
+  const hint = shell.querySelector('.profile-picker-hint') as HTMLElement | null
+  const metaEl = shell.querySelector('.profile-picker-meta') as HTMLElement | null
+
+  if (icon) {
+    icon.textContent = meta.icon
+    icon.style.color = meta.iconColor
+  }
+  if (statusLabel) {
+    statusLabel.textContent = meta.label
+    statusLabel.style.color = meta.iconColor
+  }
+  if (hint) {
+    hint.textContent = meta.hint
+    hint.style.display = meta.hint ? 'block' : 'none'
+  }
+  if (metaEl && model) {
+    metaEl.outerHTML = renderPickerMeta(cov, baseName, model)
+  }
+}
+
+function renderPickerShell(
+  innerHtml: string,
+  visual: SelectionVisual,
+  meta: VisualMeta,
+  cov?: ProfileCoverage,
+  baseName = '',
+  model = ''
+): string {
+  const metaBlock = model ? renderPickerMeta(cov, baseName, model) : ''
+  return `<div class="profile-picker-shell" data-state="${visual}" style="border:1px solid ${meta.border}; background:${meta.bg}; border-radius:8px; padding:10px 12px;">
+    <div style="display:flex; align-items:center; gap:8px; margin-bottom:${meta.hint ? '6px' : '0'};">
+      <span class="profile-picker-icon" style="flex-shrink:0; width:18px; text-align:center; font-weight:700; font-size:0.9rem; color:${meta.iconColor};">${escapeHtml(meta.icon)}</span>
+      <span class="profile-picker-status-label" style="font-size:0.75rem; font-weight:600; color:${meta.iconColor};">${escapeHtml(meta.label)}</span>
+    </div>
+    ${innerHtml}
+    <p class="profile-picker-hint" style="margin:6px 0 0; font-size:0.75rem; color:var(--text-muted); line-height:1.35; display:${meta.hint ? 'block' : 'none'};">${escapeHtml(meta.hint)}</p>
+    ${metaBlock}
+  </div>`
+}
+
+function renderCombo(
+  presets: any[],
+  selectedBase: string,
+  placeholder: string,
+  dataModel: string,
+  cov?: ProfileCoverage
+): string {
+  const visual = committedVisual(selectedBase, presets, cov)
+  const meta = visualMeta(visual, cov)
+  const inner = `<div class="cloud-combo per-model-combo" data-model="${escapeHtml(dataModel)}" style="position:relative;">
+    <input type="hidden" class="slicer-profile-base" value="${escapeHtml(selectedBase)}" />
+    <input type="text" class="fm-input cloud-combo-search" autocomplete="off" spellcheck="false"
+      placeholder="${escapeHtml(placeholder)}" value="${escapeHtml(selectedBase)}" style="width:100%; margin:0;" />
+    <div class="cloud-combo-list" style="display:none; position:absolute; z-index:50; left:0; right:0; max-height:260px; overflow-y:auto; background:var(--surface, #1e1e1e); border:1px solid var(--border, #444); border-radius:6px; margin-top:2px; box-shadow:0 4px 16px rgba(0,0,0,0.3);"></div>
+  </div>`
+  return renderPickerShell(inner, visual, meta, cov, selectedBase, dataModel)
+}
+
+function renderLinkedCard(
+  baseName: string,
+  model: string,
+  cov?: ProfileCoverage,
+  missing = false
+): string {
+  if (missing) {
+    const meta = visualMeta('invalid', cov)
+    const inner = `<p style="margin:0; font-size:0.9rem; color:var(--text);">${escapeHtml(baseName)}</p>`
+    return renderPickerShell(inner, 'invalid', meta, cov, baseName, model)
+  }
+  const visual = committedVisual(baseName, [], cov)
+  const meta = visualMeta(visual, cov, true)
+  const inner = `<p style="margin:0; font-size:0.9rem; font-weight:500; color:var(--text);">${escapeHtml(baseName)}</p>`
+  return renderPickerShell(inner, visual, meta, cov, baseName, model)
+}
+
+function updateComboVisual(
+  mount: HTMLElement,
+  presets: any[],
+  cov?: ProfileCoverage,
+  mode: 'committed' | 'draft' | 'saving' = 'committed',
+  model = ''
+) {
+  const shell = mount.querySelector('.profile-picker-shell') as HTMLElement | null
+  const hidden = mount.querySelector('.slicer-profile-base') as HTMLInputElement | null
+  const search = mount.querySelector('.cloud-combo-search') as HTMLInputElement | null
+  if (!shell || !hidden) return
+
+  let visual: SelectionVisual
+  if (mode === 'saving') {
+    visual = 'saving'
+  } else if (mode === 'draft' && search && search.value.trim() !== hidden.value) {
+    visual = 'draft'
+  } else {
+    visual = committedVisual(hidden.value, presets, cov)
+  }
+  applyShellState(shell, visual, visualMeta(visual, cov), cov, hidden.value, model)
+}
+
+function wireCombo(
+  mount: HTMLElement,
+  presets: any[],
+  cov: ProfileCoverage | undefined,
+  model: string,
+  onSelect: (baseName: string) => void | Promise<void>,
+  onError: (message: string) => void
+) {
+  const combo = mount.querySelector('.cloud-combo') as HTMLElement
+  if (!combo) return
+
+  const hidden = combo.querySelector('.slicer-profile-base') as HTMLInputElement
+  const search = combo.querySelector('.cloud-combo-search') as HTMLInputElement
+  const list = combo.querySelector('.cloud-combo-list') as HTMLElement
+
+  const renderList = (query: string) => {
+    const q = query.trim().toLowerCase()
+    const matches = (q
+      ? presets.filter((p: any) =>
+          (p.displayName || p.baseName || '').toLowerCase().includes(q)
+        )
+      : presets
+    ).slice(0, 200)
+    if (matches.length === 0) {
+      list.innerHTML = `<div style="padding:8px 10px; color:var(--text-muted); font-size:0.85rem;">No matches</div>`
+      return
+    }
+    list.innerHTML = matches
+      .map((p: any) => {
+        const base = p.baseName || p.displayName || ''
+        const sel =
+          base === hidden.value
+            ? ' style="background:var(--accent-muted, rgba(59,130,246,0.15));"'
+            : ''
+        return `<div class="cloud-combo-opt" data-base="${escapeHtml(base)}"${sel}
+          style="padding:7px 10px; cursor:pointer; font-size:0.85rem;">${escapeHtml(base)}</div>`
+      })
+      .join('')
+    list.querySelectorAll('.cloud-combo-opt').forEach((opt: Element) => {
+      opt.addEventListener('mousedown', (ev: Event) => {
+        ev.preventDefault()
+        const base = (opt as HTMLElement).dataset.base || ''
+        hidden.value = base
+        search.value = base
+        list.style.display = 'none'
+        updateComboVisual(mount, presets, cov, 'saving', model)
+        void Promise.resolve(onSelect(base)).catch((e: unknown) => {
+          onError(formatApiError(e))
+          updateComboVisual(mount, presets, cov, 'committed', model)
+        })
+      })
+    })
+  }
+
+  search.addEventListener('focus', () => {
+    renderList('')
+    list.style.display = 'block'
+  })
+  search.addEventListener('input', () => {
+    renderList(search.value)
+    list.style.display = 'block'
+    updateComboVisual(
+      mount,
+      presets,
+      cov,
+      search.value.trim() === hidden.value ? 'committed' : 'draft',
+      model
+    )
+  })
+  search.addEventListener('blur', () => {
+    setTimeout(() => {
+      list.style.display = 'none'
+      search.value = hidden.value
+      updateComboVisual(mount, presets, cov, 'committed', model)
+    }, 150)
+  })
+
+  updateComboVisual(mount, presets, cov, 'committed', model)
+}
+
+async function fetchConnectedModels(
+  printerId: number,
+  opts: InitPerModelPickerOptions
+): Promise<ConnectedModel[]> {
+  const res = await fetch(
+    `/api/v1/printers/${printerId}/driver/connected-models`,
+    { credentials: 'include', signal: opts.getAbortSignal() }
+  )
+  if (!res.ok) throw new Error('connected-models failed')
+  const json = await res.json().catch(() => ({}))
+  return json?.models || []
+}
+
+async function fetchProfileCoverage(
+  printerId: number,
+  params: Record<string, number>,
+  opts: InitPerModelPickerOptions
+): Promise<{
+  default_base_name?: string
+  profiles_by_model?: Record<string, any>
+  coverage?: Record<string, ProfileCoverage>
+}> {
+  const qs = new URLSearchParams()
+  if (params.spool_id != null) qs.set('spool_id', String(params.spool_id))
+  if (params.filament_id != null) qs.set('filament_id', String(params.filament_id))
+  const res = await fetch(
+    `/api/v1/printers/${printerId}/driver/profile-coverage?${qs}`,
+    { credentials: 'include', signal: opts.getAbortSignal() }
+  )
+  if (!res.ok) throw new Error('profile-coverage failed')
+  return res.json().catch(() => ({}))
+}
+
+async function ensureCsrfToken(opts: InitPerModelPickerOptions): Promise<string> {
+  let token = opts.getCsrfToken() || getCsrfToken() || ''
+  if (token) return token
+  await fetch('/api/v1/me', {
+    credentials: 'include',
+    signal: opts.getAbortSignal(),
+  })
+  token = opts.getCsrfToken() || getCsrfToken() || ''
+  return token
+}
+
+async function apiPostWithCsrf(
+  opts: InitPerModelPickerOptions,
+  path: string,
+  body: unknown
+): Promise<any> {
+  const csrfToken = await ensureCsrfToken(opts)
+  return api.post(path, body, { csrfToken })
+}
+
+async function saveDefaultProfile(
+  opts: InitPerModelPickerOptions,
+  baseName: string,
+  applyToExisting = false
+): Promise<any> {
+  if (opts.entityType === 'spool') {
+    return apiPostWithCsrf(opts, `/spools/${opts.entityId}/slicer-profile/default`, {
+      base_name: baseName,
+    })
+  }
+  return apiPostWithCsrf(opts, `/filaments/${opts.entityId}/slicer-profile/default`, {
+    base_name: baseName,
+    apply_to_existing: applyToExisting,
+  })
+}
+
+async function saveModelProfile(
+  opts: InitPerModelPickerOptions,
+  model: string,
+  baseName: string
+): Promise<any> {
+  const body = { base_name: baseName }
+  if (opts.entityType === 'spool') {
+    return apiPostWithCsrf(
+      opts,
+      `/spools/${opts.entityId}/slicer-profile/models/${encodeURIComponent(model)}`,
+      body
+    )
+  }
+  return apiPostWithCsrf(
+    opts,
+    `/filaments/${opts.entityId}/slicer-profile/models/${encodeURIComponent(model)}`,
+    body
+  )
+}
+
+async function clearModelProfileOverride(
+  opts: InitPerModelPickerOptions,
+  model: string
+): Promise<any> {
+  const body = { clear_override: true }
+  if (opts.entityType === 'spool') {
+    return apiPostWithCsrf(
+      opts,
+      `/spools/${opts.entityId}/slicer-profile/models/${encodeURIComponent(model)}`,
+      body
+    )
+  }
+  return apiPostWithCsrf(
+    opts,
+    `/filaments/${opts.entityId}/slicer-profile/models/${encodeURIComponent(model)}`,
+    body
+  )
+}
+
+function formatApiError(e: unknown): string {
+  if (e instanceof ApiError) {
+    if (e.code === 'csrf_failed') {
+      return 'Session expired or CSRF token missing — refresh the page and try again'
+    }
+    return e.message
+  }
+  if (e instanceof Error) return e.message
+  return 'Could not save profile'
+}
+
+async function loadCloudPresetsForModel(
+  printerId: number,
+  model: string,
+  opts: InitPerModelPickerOptions
+): Promise<any[]> {
+  const qs = new URLSearchParams({ group: 'base', model })
+  const res = await fetch(
+    `/api/v1/printers/${printerId}/driver/cloud-presets?${qs}`,
+    { credentials: 'include', signal: opts.getAbortSignal() }
+  )
+  if (!res.ok) return []
+  const data = await res.json()
+  const modelKey = model.trim().toUpperCase()
+  return (data.presets || []).filter(
+    (p: any) => !p.model || String(p.model).toUpperCase() === modelKey
+  )
+}
+
+function rowHeaderBadge(model: string, c?: ProfileCoverage, baseName = ''): string {
+  const raw = baseName || c?.base_name || ''
+  const badges = rowNozzleBadge(c, raw)
+  if (!c) return badges
+  const visual = committedVisual(raw, [], c)
+  if (visual === 'empty' || visual === 'invalid') return badges
+  const meta = visualMeta(visual, c)
+  return `${badges}<span class="profile-row-badge" title="${escapeHtml(meta.hint || meta.label)}" style="font-size:0.7rem;padding:1px 7px;border-radius:999px;border:1px solid ${meta.border};color:${meta.iconColor};">${escapeHtml(meta.label)}</span>`
+}
+
+function renderPickerHelp(connectedModels: ConnectedModel[]): string {
+  const modelList = connectedModels.map((m) => m.model).join(', ') || 'your printers'
+  return `<div class="profile-picker-help" style="margin-bottom:16px; padding:12px 14px; border-radius:8px; border:1px solid var(--border,#333); background:rgba(255,255,255,0.03); font-size:0.78rem; color:var(--text-muted); line-height:1.5;">
+    <strong style="color:var(--text);">Default profile</strong> — pick one profile name; the list includes any preset available on at least one of your connected models (${escapeHtml(modelList)}).
+    FilaMan resolves the correct Bambu cloud variant per model automatically (see badges — ✕ means create that variant or override below).
+    Override a model only when it needs a different profile than the default.
+    Stock 0.4&nbsp;mm presets often use <code style="font-size:0.75rem;color:var(--text);">@BBL &lt;model&gt;</code> without the nozzle size in the name.
+  </div>`
+}
+
+type DefaultVisual = SelectionVisual | 'partial'
+
+function defaultProfileVisual(
+  defaultBase: string,
+  models: ConnectedModel[],
+  coverage: Record<string, ProfileCoverage>
+): DefaultVisual {
+  if (!defaultBase) return 'empty'
+  const statuses = models.map((m) => coverageStatus(coverage[m.model]))
+  const okish = statuses.filter((s) => s === 'ok' || s === 'fallback').length
+  if (okish === models.length) {
+    return statuses.some((s) => s === 'fallback') ? 'fallback' : 'valid'
+  }
+  if (okish > 0) return 'partial'
+  if (statuses.some((s) => s === 'missing')) return 'invalid'
+  return 'empty'
+}
+
+function defaultVisualMeta(
+  visual: DefaultVisual,
+  models: ConnectedModel[],
+  coverage: Record<string, ProfileCoverage>
+): VisualMeta {
+  if (visual === 'partial') {
+    const missing = models
+      .filter((m) => {
+        const st = coverageStatus(coverage[m.model])
+        return st !== 'ok' && st !== 'fallback'
+      })
+      .map((m) => m.model)
+    return {
+      border: 'var(--warning-text, #b8860b)',
+      bg: 'rgba(247, 200, 106, 0.12)',
+      icon: '≈',
+      iconColor: 'var(--warning-text, #b8860b)',
+      label: 'Partial coverage',
+      hint:
+        missing.length > 0
+          ? `No cloud variant on: ${missing.join(', ')} — create in Bambu Studio or override below`
+          : 'Some models need a cloud preset for this profile',
+    }
+  }
+  if (visual === 'valid' || visual === 'fallback' || visual === 'invalid') {
+    return visualMeta(visual)
+  }
+  return visualMeta('empty')
+}
+
+function renderDefaultCoverageStrip(
+  models: ConnectedModel[],
+  defaultBase: string,
+  coverage: Record<string, ProfileCoverage>
+): string {
+  if (!defaultBase) return ''
+  const parts = models.map((m) => {
+    const c = coverage[m.model]
+    const st = coverageStatus(c)
+    const ok = st === 'ok' || st === 'fallback'
+    const icon = ok ? '✓' : '✕'
+    const color = ok ? 'var(--success-text)' : 'var(--error-text)'
+    const title =
+      st === 'missing'
+        ? c?.expected_name || `No ${m.model} variant in cloud`
+        : `${m.model}: ${c?.code || 'resolved'}`
+    return `<span title="${escapeHtml(title)}" style="font-size:0.72rem;padding:2px 8px;border-radius:999px;border:1px solid var(--border,#444);color:${color};">${escapeHtml(m.model)} ${icon}</span>`
+  })
+  return `<div class="default-coverage-strip" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;align-items:center;"><span style="font-size:0.7rem;color:var(--text-muted);">Variants:</span>${parts.join('')}</div>`
+}
+
+function isOverrideSource(source?: string): boolean {
+  return source === 'override' || source === 'manual'
+}
+
+function modelGridTemplateColumns(modelCount: number): string {
+  if (modelCount <= 1) return 'minmax(0, 1fr)'
+  if (modelCount === 2) return 'repeat(2, minmax(0, 1fr))'
+  return 'repeat(auto-fit, minmax(260px, 1fr))'
+}
+
+function mergeDefaultPresets(modelLists: any[][]): any[] {
+  const seen = new Map<string, any>()
+  for (const presets of modelLists) {
+    for (const p of presets) {
+      const b = (p.baseName || p.displayName || '').trim()
+      if (b && !seen.has(b)) {
+        seen.set(b, { ...p, baseName: b, displayName: b })
+      }
+    }
+  }
+  return Array.from(seen.values()).sort((a, b) =>
+    (a.baseName || '').localeCompare(b.baseName || '')
+  )
+}
+
+function renderDefaultCombo(
+  presets: any[],
+  defaultBase: string,
+  models: ConnectedModel[],
+  coverage: Record<string, ProfileCoverage>,
+  placeholder: string
+): string {
+  const visual = defaultProfileVisual(defaultBase, models, coverage)
+  const meta = defaultVisualMeta(visual, models, coverage)
+  const inner = `<div class="cloud-combo default-profile-combo" data-model="default" style="position:relative;">
+    <input type="hidden" class="slicer-profile-base" value="${escapeHtml(defaultBase)}" />
+    <input type="text" class="fm-input cloud-combo-search" autocomplete="off" spellcheck="false"
+      placeholder="${escapeHtml(placeholder)}" value="${escapeHtml(defaultBase)}" style="width:100%; margin:0;" />
+    <div class="cloud-combo-list" style="display:none; position:absolute; z-index:50; left:0; right:0; max-height:260px; overflow-y:auto; background:var(--surface, #1e1e1e); border:1px solid var(--border, #444); border-radius:6px; margin-top:2px; box-shadow:0 4px 16px rgba(0,0,0,0.3);"></div>
+  </div>${renderDefaultCoverageStrip(models, defaultBase, coverage)}`
+  return renderPickerShell(inner, visual === 'partial' ? 'fallback' : visual, meta, undefined, defaultBase, '')
+}
+
+function updateDefaultComboVisual(
+  mount: HTMLElement,
+  presets: any[],
+  defaultBase: string,
+  models: ConnectedModel[],
+  coverage: Record<string, ProfileCoverage>,
+  mode: 'committed' | 'draft' | 'saving' = 'committed'
+) {
+  const shell = mount.querySelector('.profile-picker-shell') as HTMLElement | null
+  const hidden = mount.querySelector('.slicer-profile-base') as HTMLInputElement | null
+  const search = mount.querySelector('.cloud-combo-search') as HTMLInputElement | null
+  if (!shell || !hidden) return
+
+  let visual: DefaultVisual
+  if (mode === 'saving') {
+    visual = 'saving'
+  } else if (mode === 'draft' && search && search.value.trim() !== hidden.value) {
+    visual = 'draft'
+  } else {
+    visual = defaultProfileVisual(hidden.value, models, coverage)
+  }
+  const meta = defaultVisualMeta(visual, models, coverage)
+  applyShellState(
+    shell,
+    visual === 'partial' ? 'fallback' : visual,
+    meta,
+    undefined,
+    hidden.value,
+    ''
+  )
+  const strip = mount.querySelector('.default-coverage-strip')
+  if (strip) {
+    strip.outerHTML = renderDefaultCoverageStrip(models, hidden.value, coverage)
+  }
+}
+
+function wireDefaultCombo(
+  mount: HTMLElement,
+  presets: any[],
+  models: ConnectedModel[],
+  coverage: Record<string, ProfileCoverage>,
+  onSelect: (baseName: string) => void | Promise<void>,
+  onError: (message: string) => void
+) {
+  const combo = mount.querySelector('.cloud-combo') as HTMLElement
+  if (!combo) return
+
+  const hidden = combo.querySelector('.slicer-profile-base') as HTMLInputElement
+  const search = combo.querySelector('.cloud-combo-search') as HTMLInputElement
+  const list = combo.querySelector('.cloud-combo-list') as HTMLElement
+
+  const renderList = (query: string) => {
+    const q = query.trim().toLowerCase()
+    const matches = (q
+      ? presets.filter((p: any) =>
+          (p.displayName || p.baseName || '').toLowerCase().includes(q)
+        )
+      : presets
+    ).slice(0, 200)
+    if (matches.length === 0) {
+      list.innerHTML = `<div style="padding:8px 10px; color:var(--text-muted); font-size:0.85rem;">No matches</div>`
+      return
+    }
+    list.innerHTML = matches
+      .map((p: any) => {
+        const base = p.baseName || p.displayName || ''
+        const sel =
+          base === hidden.value
+            ? ' style="background:var(--accent-muted, rgba(59,130,246,0.15));"'
+            : ''
+        return `<div class="cloud-combo-opt" data-base="${escapeHtml(base)}"${sel}
+          style="padding:7px 10px; cursor:pointer; font-size:0.85rem;">${escapeHtml(base)}</div>`
+      })
+      .join('')
+    list.querySelectorAll('.cloud-combo-opt').forEach((opt: Element) => {
+      opt.addEventListener('mousedown', (ev: Event) => {
+        ev.preventDefault()
+        const base = (opt as HTMLElement).dataset.base || ''
+        hidden.value = base
+        search.value = base
+        list.style.display = 'none'
+        updateDefaultComboVisual(mount, presets, base, models, coverage, 'saving')
+        void Promise.resolve(onSelect(base)).catch((e: unknown) => {
+          onError(formatApiError(e))
+          updateDefaultComboVisual(
+            mount,
+            presets,
+            hidden.value,
+            models,
+            coverage,
+            'committed'
+          )
+        })
+      })
+    })
+  }
+
+  search.addEventListener('focus', () => {
+    renderList('')
+    list.style.display = 'block'
+  })
+  search.addEventListener('input', () => {
+    renderList(search.value)
+    list.style.display = 'block'
+    updateDefaultComboVisual(
+      mount,
+      presets,
+      hidden.value,
+      models,
+      coverage,
+      search.value.trim() === hidden.value ? 'committed' : 'draft'
+    )
+  })
+  search.addEventListener('blur', () => {
+    setTimeout(() => {
+      list.style.display = 'none'
+      search.value = hidden.value
+      updateDefaultComboVisual(mount, presets, hidden.value, models, coverage, 'committed')
+    }, 150)
+  })
+
+  updateDefaultComboVisual(
+    mount,
+    presets,
+    hidden.value,
+    models,
+    coverage,
+    'committed'
+  )
+}
+
+function renderLinkedToDefault(
+  effectiveBase: string,
+  model: string,
+  cov?: ProfileCoverage
+): string {
+  const visual = committedVisual(effectiveBase, [], cov)
+  const meta = visualMeta(visual === 'empty' ? 'linked' : visual, cov, true)
+  const inner = `<p style="margin:0; font-size:0.9rem; color:var(--text);"><span style="color:var(--text-muted);">↪</span> ${escapeHtml(effectiveBase)}</p>`
+  return renderPickerShell(inner, visual === 'empty' ? 'linked' : visual, meta, cov, effectiveBase, model)
+}
+
+export async function initPerModelProfilePicker(
+  opts: InitPerModelPickerOptions
+): Promise<number> {
+  const section = document.getElementById('slicer-profile-section')
+  const picker = document.getElementById('slicer-profile-picker')
+  const coverageEl = document.getElementById('slicer-profile-coverage')
+  const msgEl = document.getElementById('slicer-profile-msg')
+  if (!section || !picker) return 0
+
+  const showMsg = (text: string, isError: boolean) => {
+    if (!msgEl) return
+    msgEl.textContent = text
+    msgEl.style.color = isError ? 'var(--error-text)' : 'var(--success-text)'
+    msgEl.classList.remove('hidden')
+    setTimeout(() => msgEl.classList.add('hidden'), 4000)
+  }
+
+  try {
+    const res = await fetch('/api/v1/printers', {
+      credentials: 'include',
+      signal: opts.getAbortSignal(),
+    })
+    if (!res.ok) return 0
+    const data = await res.json()
+    const bambuPrinters = (data.items || data || []).filter(
+      (p: any) => p.driver_key === 'bambuddy'
+    )
+    if (!bambuPrinters.length) return 0
+
+    let rep = 0
+    for (const p of bambuPrinters) {
+      try {
+        const h = await fetch(`/api/v1/printers/${p.id}/driver/health`, {
+          credentials: 'include',
+          signal: opts.getAbortSignal(),
+        })
+        if (h.ok) {
+          const hj = await h.json()
+          if (hj && (hj.connected || hj.running)) {
+            rep = p.id
+            break
+          }
+        }
+      } catch {}
+    }
+    if (!rep) rep = bambuPrinters[0].id
+
+    const modelsResult = await fetchConnectedModels(rep, opts)
+    const models: ConnectedModel[] = modelsResult || []
+    if (!models.length) {
+      picker.innerHTML = `<p style="color:var(--text-muted);font-size:0.85rem;">No Bambu printer models connected. Check that Bambuddy drivers are running.</p>`
+      section.classList.remove('hidden')
+      return 0
+    }
+
+    const coverageParams =
+      opts.entityType === 'spool'
+        ? { spool_id: opts.entityId }
+        : { filament_id: opts.entityId }
+
+    let profilesByModel: Record<string, { base_name?: string; source?: string }> = {}
+    let coverage: Record<string, ProfileCoverage> = {}
+    let defaultBaseName = ''
+    try {
+      const cov = await fetchProfileCoverage(rep, coverageParams, opts)
+      profilesByModel = cov?.profiles_by_model || {}
+      coverage = cov?.coverage || {}
+      defaultBaseName = cov?.default_base_name || ''
+    } catch (e) {
+      if (!opts.isAbortError(e)) {
+        console.warn('Profile coverage load failed:', e)
+      }
+    }
+
+    const presetsCache: Record<string, any[]> = {}
+    const rowMounts: Record<string, HTMLElement> = {}
+    const rowHeaders: Record<string, HTMLElement> = {}
+    let defaultMount: HTMLElement | null = null
+    let defaultPresets: any[] = []
+    let modelOverrideMode: Record<string, boolean> = {}
+
+    const loadPresets = async (model: string) => {
+      if (!presetsCache[model]) {
+        presetsCache[model] = await loadCloudPresetsForModel(rep, model, opts)
+      }
+      return presetsCache[model]
+    }
+
+    const loadAllDefaultPresets = async () => {
+      const lists = await Promise.all(models.map((m) => loadPresets(m.model)))
+      defaultPresets = mergeDefaultPresets(lists)
+      return defaultPresets
+    }
+
+    const refreshDefaultVisual = () => {
+      if (!defaultMount) return
+      const hidden = defaultMount.querySelector(
+        '.slicer-profile-base'
+      ) as HTMLInputElement | null
+      const search = defaultMount.querySelector(
+        '.cloud-combo-search'
+      ) as HTMLInputElement | null
+      const base = defaultBaseName || hidden?.value || ''
+      if (hidden && hidden.value !== base) hidden.value = base
+      if (search && search.value !== base) search.value = base
+      if (defaultMount.querySelector('.default-profile-combo')) {
+        updateDefaultComboVisual(
+          defaultMount,
+          defaultPresets,
+          base,
+          models,
+          coverage,
+          'committed'
+        )
+      }
+    }
+
+    const refreshRowVisual = (model: string) => {
+      const mount = rowMounts[model]
+      if (!mount) return
+      const presets = presetsCache[model] || []
+      const cov = coverage[model]
+      const entry = profilesByModel[model] || {}
+      const isOverride =
+        modelOverrideMode[model] || isOverrideSource(entry.source)
+      const effectiveBase = isOverride
+        ? entry.base_name || ''
+        : defaultBaseName || entry.base_name || ''
+
+      if (!isOverride && !mount.querySelector('.cloud-combo')) {
+        mount.innerHTML = renderLinkedToDefault(effectiveBase, model, cov)
+      }
+
+      const base = isOverride
+        ? displayBaseForPicker(effectiveBase, cov, presets)
+        : effectiveBase
+      const hidden = mount.querySelector('.slicer-profile-base') as HTMLInputElement | null
+      const search = mount.querySelector('.cloud-combo-search') as HTMLInputElement | null
+      if (hidden && hidden.value !== base) hidden.value = base
+      if (search && search.value !== base) search.value = base
+      if (mount.querySelector('.cloud-combo')) {
+        updateComboVisual(mount, presets, cov, 'committed', model)
+      } else if (mount.querySelector('.profile-picker-shell')) {
+        const shell = mount.querySelector('.profile-picker-shell') as HTMLElement
+        const visual = isOverride
+          ? committedVisual(base, presets, cov)
+          : committedVisual(effectiveBase, [], cov)
+        applyShellState(
+          shell,
+          isOverride && visual === 'empty' ? 'linked' : visual,
+          visualMeta(
+            isOverride && visual === 'empty' ? 'linked' : visual,
+            cov,
+            !isOverride
+          ),
+          cov,
+          base || effectiveBase,
+          model
+        )
+      }
+      const header = rowHeaders[model]
+      if (header) {
+        const badgeBase = isOverride ? base : effectiveBase
+        header.innerHTML = `<div style="display:flex; align-items:center; flex-wrap:wrap; gap:4px;">
+          <span style="font-weight:600; font-size:0.9rem;">${escapeHtml(model)}</span>
+          ${isOverride ? '<span style="font-size:0.68rem;padding:1px 6px;border-radius:999px;border:1px solid var(--border,#444);color:var(--text-muted);">override</span>' : ''}
+          ${rowHeaderBadge(model, cov, badgeBase)}
+        </div>`
+      }
+      const row = mount.closest('.per-model-profile-row')
+      const overrideBtn = row?.querySelector('button.fm-btn-outline') as HTMLButtonElement | null
+      if (overrideBtn) {
+        overrideBtn.textContent = isOverride ? 'Use default' : 'Override'
+      }
+    }
+
+    const refreshAll = () => {
+      refreshDefaultVisual()
+      for (const m of Object.keys(rowMounts)) refreshRowVisual(m)
+    }
+
+    const reloadCoverage = async () => {
+      try {
+        const cov = await fetchProfileCoverage(rep, coverageParams, opts)
+        profilesByModel = cov?.profiles_by_model || profilesByModel
+        coverage = cov?.coverage || coverage
+        defaultBaseName = cov?.default_base_name || defaultBaseName
+      } catch (e) {
+        if (!opts.isAbortError(e)) console.warn('Coverage reload failed:', e)
+      }
+    }
+
+    const refreshModelRowsFromDefault = () => {
+      for (const m of models) {
+        const entry = profilesByModel[m.model] || {}
+        if (isOverrideSource(entry.source)) continue
+        const mount = rowMounts[m.model]
+        if (!mount) continue
+        mount.innerHTML = renderLinkedToDefault(
+          defaultBaseName,
+          m.model,
+          coverage[m.model]
+        )
+      }
+    }
+
+    const saveDefault = async (baseName: string) => {
+      let applyToExisting = false
+      if (opts.entityType === 'filament') {
+        applyToExisting = window.confirm(
+          opts.t('printers.applyProfileToExisting') ||
+            'Apply this default profile to existing spools of this filament?\n\nOK = update all existing spools\nCancel = only new spools'
+        )
+      }
+      const result = await saveDefaultProfile(opts, baseName, applyToExisting)
+      profilesByModel = result?.profiles_by_model || profilesByModel
+      coverage = result?.coverage || coverage
+      defaultBaseName = result?.default_base_name || result?.base_name || baseName
+      await reloadCoverage()
+      refreshModelRowsFromDefault()
+      refreshAll()
+      showMsg((opts.t('common.saved') || 'Saved') + ` — ${baseName}`, false)
+      opts.onSaved?.()
+      return result
+    }
+
+    const saveForModel = async (model: string, baseName: string) => {
+      const result = await saveModelProfile(opts, model, baseName)
+      profilesByModel = result?.profiles_by_model || profilesByModel
+      coverage = result?.coverage || coverage
+      modelOverrideMode[model] = true
+      refreshAll()
+      showMsg(
+        (opts.t('common.saved') || 'Saved') +
+          ` — ${model}: ${result?.base_name || baseName}`,
+        false
+      )
+      opts.onSaved?.()
+      return result
+    }
+
+    const clearModelOverride = async (model: string) => {
+      const result = await clearModelProfileOverride(opts, model)
+      profilesByModel = result?.profiles_by_model || profilesByModel
+      coverage = result?.coverage || coverage
+      modelOverrideMode[model] = false
+      const mount = rowMounts[model]
+      if (mount) {
+        const entry = profilesByModel[model] || {}
+        const cov = coverage[model]
+        const effective = defaultBaseName || entry.base_name || ''
+        mount.innerHTML = renderLinkedToDefault(effective, model, cov)
+      }
+      refreshAll()
+      showMsg((opts.t('common.saved') || 'Saved') + ` — ${model} uses default`, false)
+      opts.onSaved?.()
+    }
+
+    if (!defaultBaseName) {
+      defaultBaseName = Object.values(profilesByModel).find((e) =>
+        !isOverrideSource(e?.source) && e?.base_name
+      )?.base_name || Object.values(profilesByModel).find((e) => e?.base_name)?.base_name || ''
+    }
+
+    picker.innerHTML = renderPickerHelp(models)
+    picker.style.maxWidth = '100%'
+
+    const defaultSection = document.createElement('div')
+    defaultSection.className = 'default-profile-section'
+    defaultSection.style.cssText =
+      'margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border, #333);'
+    defaultSection.innerHTML = `<div style="font-weight:600; font-size:0.95rem; margin-bottom: 8px;">Default profile</div>`
+    defaultMount = document.createElement('div')
+    defaultMount.className = 'default-profile-mount'
+    defaultSection.appendChild(defaultMount)
+    picker.appendChild(defaultSection)
+
+    await loadAllDefaultPresets()
+    if (defaultPresets.length === 0) {
+      defaultMount.innerHTML = `<p style="margin:0;font-size:0.85rem;color:var(--text-muted);line-height:1.45;">No Bambu cloud presets found for your connected models. Sync presets in Bambu Studio and click Refresh below.</p>`
+    } else {
+      defaultMount.innerHTML = renderDefaultCombo(
+        defaultPresets,
+        defaultBaseName,
+        models,
+        coverage,
+        opts.t('printers.searchProfile') || 'Search profile…'
+      )
+      wireDefaultCombo(
+        defaultMount,
+        defaultPresets,
+        models,
+        coverage,
+        saveDefault,
+        (msg) => showMsg(msg, true)
+      )
+    }
+
+    const modelsHeader = document.createElement('div')
+    modelsHeader.style.cssText =
+      'font-weight:600; font-size:0.9rem; margin: 4px 0 12px; color:var(--text-muted);'
+    modelsHeader.textContent = 'Per-model overrides (optional)'
+    picker.appendChild(modelsHeader)
+
+    const modelsGrid = document.createElement('div')
+    modelsGrid.className = 'per-model-profile-grid'
+    modelsGrid.dataset.modelCount = String(models.length)
+    modelsGrid.style.cssText = `display: grid; grid-template-columns: ${modelGridTemplateColumns(models.length)}; gap: 16px; align-items: stretch; width: 100%;`
+    picker.appendChild(modelsGrid)
+
+    for (const m of models) {
+      const entry = profilesByModel[m.model] || {}
+      const cov = coverage[m.model]
+      const isOverride = isOverrideSource(entry.source)
+      modelOverrideMode[m.model] = isOverride
+      const effectiveBase = isOverride
+        ? entry.base_name || ''
+        : defaultBaseName || entry.base_name || ''
+
+      const row = document.createElement('div')
+      row.className = 'per-model-profile-row'
+      row.dataset.model = m.model
+      row.style.cssText =
+        'display: flex; flex-direction: column; min-height: 100%; padding: 12px 14px; border: 1px solid var(--border, #333); border-radius: 8px; background: rgba(255,255,255,0.02);'
+
+      const header = document.createElement('div')
+      header.style.cssText =
+        'display: flex; flex-direction: column; gap: 8px; margin-bottom: 10px;'
+      const headerTitle = document.createElement('div')
+      headerTitle.innerHTML = `<div style="display:flex; align-items:center; flex-wrap:wrap; gap:4px;">
+        <span style="font-weight:600; font-size:0.9rem;">${escapeHtml(m.model)}</span>
+        ${isOverride ? '<span style="font-size:0.68rem;padding:1px 6px;border-radius:999px;border:1px solid var(--border,#444);color:var(--text-muted);">override</span>' : ''}
+        ${rowHeaderBadge(m.model, cov, effectiveBase)}
+      </div>`
+      rowHeaders[m.model] = headerTitle
+      header.appendChild(headerTitle)
+
+      const overrideBtn = document.createElement('button')
+      overrideBtn.type = 'button'
+      overrideBtn.className = 'fm-btn fm-btn-outline'
+      overrideBtn.style.cssText =
+        'font-size: 0.75rem; padding: 2px 8px; align-self: flex-start;'
+      overrideBtn.textContent = isOverride ? 'Use default' : 'Override'
+      overrideBtn.addEventListener('click', async () => {
+        const rowIsOverride =
+          modelOverrideMode[m.model] ||
+          isOverrideSource(profilesByModel[m.model]?.source)
+        if (rowIsOverride) {
+          await clearModelOverride(m.model)
+        } else {
+          modelOverrideMode[m.model] = true
+          const presets = await loadPresets(m.model)
+          const displayBase = displayBaseForPicker(effectiveBase, cov, presets)
+          mount.innerHTML = renderCombo(
+            presets,
+            displayBase,
+            opts.t('printers.searchProfile') || `Search ${m.model} profile…`,
+            m.model,
+            cov
+          )
+          wireCombo(mount, presets, cov, m.model, (baseName) =>
+            saveForModel(m.model, baseName),
+            (msg) => showMsg(msg, true)
+          )
+          overrideBtn.textContent = 'Use default'
+          headerTitle.innerHTML = `<div style="display:flex; align-items:center; flex-wrap:wrap; gap:4px;">
+            <span style="font-weight:600; font-size:0.9rem;">${escapeHtml(m.model)}</span>
+            <span style="font-size:0.68rem;padding:1px 6px;border-radius:999px;border:1px solid var(--border,#444);color:var(--text-muted);">override</span>
+            ${rowHeaderBadge(m.model, cov, displayBase)}
+          </div>`
+        }
+      })
+      header.appendChild(overrideBtn)
+      row.appendChild(header)
+
+      const mount = document.createElement('div')
+      mount.className = 'per-model-picker-mount'
+      mount.style.flex = '1'
+      rowMounts[m.model] = mount
+
+      if (isOverride) {
+        const presets = await loadPresets(m.model)
+        const displayBase = displayBaseForPicker(effectiveBase, cov, presets)
+        mount.innerHTML = renderCombo(
+          presets,
+          displayBase,
+          opts.t('printers.searchProfile') || `Search ${m.model} profile…`,
+          m.model,
+          cov
+        )
+        wireCombo(mount, presets, cov, m.model, (baseName) =>
+          saveForModel(m.model, baseName),
+          (msg) => showMsg(msg, true)
+        )
+      } else {
+        mount.innerHTML = renderLinkedToDefault(effectiveBase, m.model, cov)
+      }
+      row.appendChild(mount)
+      modelsGrid.appendChild(row)
+    }
+
+    const refreshRow = document.createElement('div')
+    refreshRow.style.marginTop = '8px'
+    const refreshBtn = document.createElement('button')
+    refreshBtn.type = 'button'
+    refreshBtn.className = 'fm-btn fm-btn-outline'
+    refreshBtn.style.fontSize = '0.8rem'
+    refreshBtn.textContent = 'Refresh cloud presets'
+    refreshBtn.addEventListener('click', async () => {
+      refreshBtn.disabled = true
+      refreshBtn.textContent = 'Refreshing…'
+      try {
+        await fetch(
+          `/api/v1/printers/${rep}/driver/cloud-presets?refresh=1`,
+          { credentials: 'include', signal: opts.getAbortSignal() }
+        )
+        const cov = await fetchProfileCoverage(rep, coverageParams, opts)
+        coverage = cov?.coverage || coverage
+        profilesByModel = cov?.profiles_by_model || profilesByModel
+        defaultBaseName = cov?.default_base_name || defaultBaseName
+        for (const m of models) {
+          delete presetsCache[m.model]
+        }
+        defaultPresets = await loadAllDefaultPresets()
+        // Re-render any override rows whose combo is already open so they pick up
+        // the refreshed preset list.
+        for (const m of models) {
+          const mount = rowMounts[m.model]
+          if (!mount) continue
+          if (!modelOverrideMode[m.model]) continue
+          if (!mount.querySelector('.cloud-combo')) continue
+          const presets = await loadPresets(m.model)
+          const entry = profilesByModel[m.model] || {}
+          const cov2 = coverage[m.model]
+          const effectiveBase = entry.base_name || defaultBaseName || ''
+          const displayBase = displayBaseForPicker(effectiveBase, cov2, presets)
+          mount.innerHTML = renderCombo(
+            presets,
+            displayBase,
+            opts.t('printers.searchProfile') || `Search ${m.model} profile…`,
+            m.model,
+            cov2
+          )
+          wireCombo(mount, presets, cov2, m.model,
+            (baseName) => saveForModel(m.model, baseName),
+            (msg) => showMsg(msg, true)
+          )
+        }
+        refreshAll()
+      } finally {
+        refreshBtn.disabled = false
+        refreshBtn.textContent = 'Refresh cloud presets'
+      }
+    })
+    refreshRow.appendChild(refreshBtn)
+    picker.appendChild(refreshRow)
+
+    if (coverageEl) {
+      coverageEl.classList.add('hidden')
+      coverageEl.innerHTML = ''
+    }
+
+    section.classList.remove('hidden')
+    return rep
+  } catch (e) {
+    if (!opts.isAbortError(e)) {
+      console.error('Per-model profile picker init failed:', e)
+      if (section && picker) {
+        picker.innerHTML = `<p style="color:var(--error-text);font-size:0.85rem;">Could not load slicer profile picker. Try refreshing the page.</p>`
+        section.classList.remove('hidden')
+      }
+    }
+    return 0
+  }
+}

--- a/frontend/src/pages/admin/app-settings.astro
+++ b/frontend/src/pages/admin/app-settings.astro
@@ -157,6 +157,27 @@ import Layout from '../../layouts/Layout.astro'
       </div>
     </div>
 
+    <!-- Slicer Profile Fallback Card (full width) -->
+    <div class="fm-card" style="padding: 20px;">
+      <h2 style="font-size: 1rem; font-weight: 600; margin: 0 0 4px;">Slicer Profile Fallback</h2>
+      <p style="font-size: 0.78rem; color: var(--text-muted); margin: 0 0 16px;">
+        Determines which profile is sent to a Bambu printer's AMS slot when no specific slicer
+        profile resolves for a filament (e.g. a third-party filament with no matching cloud profile
+        for the connected printer model).
+      </p>
+
+      <label style="font-weight: 500; display: block; margin-bottom: 4px;" for="bambu-unmatched-fallback">Default for unmatched filament</label>
+      <select id="bambu-unmatched-fallback" class="fm-select" style="max-width: 320px;">
+        <option value="generic">Generic profile (Generic PLA, PETG, …)</option>
+        <option value="bambu">Bambu profile (Bambu PLA Basic, PETG Basic, …)</option>
+      </select>
+      <p style="font-size: 0.78rem; color: var(--text-muted); margin: 8px 0 0;">
+        Choose <strong>Bambu profile</strong> if you prefer Bambu's own material profiles for
+        third-party filament instead of the bland Generic ones. Falls back to Generic for materials
+        without a Bambu-brand equivalent.
+      </p>
+    </div>
+
     <!-- Form message AND Save button OUTSIDE the cards, below the grid -->
     <div id="form-message" class="hidden" style="padding: 10px 14px; border-radius: 8px; font-size: 0.85rem;"></div>
     <button type="submit" id="save-btn" class="fm-btn fm-btn-primary" style="justify-self: start; padding: 10px 28px;" data-i18n="admin.appSettingsSave">Save</button>
@@ -186,6 +207,7 @@ import Layout from '../../layouts/Layout.astro'
       const rfidProtocolSelect = document.getElementById('rfid-protocol') as HTMLSelectElement
       const rfidProtocolSection = document.getElementById('rfid-protocol-section')!
       const defaultSpoolCoreWeightInput = document.getElementById('default-spool-core-weight') as HTMLInputElement
+      const bambuUnmatchedFallbackSelect = document.getElementById('bambu-unmatched-fallback') as HTMLSelectElement
 
       function showMessage(text: string, isError: boolean) {
         formMessage.textContent = text
@@ -218,6 +240,7 @@ import Layout from '../../layouts/Layout.astro'
           rfidProtocolSelect.value = data.rfid_protocol || 'openspool'
           updateRfidProtocolVisibility()
           defaultSpoolCoreWeightInput.value = data.default_spool_core_weight_g != null ? String(data.default_spool_core_weight_g) : ''
+          bambuUnmatchedFallbackSelect.value = data.bambu_unmatched_profile_fallback || 'generic'
         } else {
           showMessage(t('admin.appSettingsLoadFailed'), true)
         }
@@ -239,6 +262,7 @@ import Layout from '../../layouts/Layout.astro'
           rfid_extended_data_enabled: rfidExtendedDataInput.checked,
           rfid_protocol: rfidProtocolSelect.value,
           default_spool_core_weight_g: rawCoreWeight !== '' ? parseFloat(rawCoreWeight) : null,
+          bambu_unmatched_profile_fallback: bambuUnmatchedFallbackSelect.value,
         }
 
         try {

--- a/frontend/src/pages/filaments/[id]/index.astro
+++ b/frontend/src/pages/filaments/[id]/index.astro
@@ -23,7 +23,8 @@ const { id } = Astro.params
     <h2 style="font-weight: 600; margin-bottom: 16px;" data-i18n="printers.slicerProfile">Slicer Profile</h2>
     <div class="fm-card" style="padding: 24px;">
       <label class="fm-label" data-i18n="printers.bambuSlicerProfile">Bambu Slicer Profile</label>
-      <div id="slicer-profile-picker" style="max-width: 520px;"></div>
+      <div id="slicer-profile-picker"></div>
+      <div id="slicer-profile-coverage" class="hidden" style="margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px;"></div>
       <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 8px;" data-i18n="printers.slicerProfileHint">Applies to this filament across all Bambu printers and any new spools made from it.</p>
       <span id="slicer-profile-msg" class="hidden" style="font-size: 0.85rem;"></span>
     </div>
@@ -95,6 +96,7 @@ const { id } = Astro.params
     import { cachedFetchAllPages, fetchSequential, CACHE_KEYS } from '../../../lib/cache'
     import { formatPrice, getCurrency, initCurrency } from '../../../lib/format'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
+    import { initPerModelProfilePicker } from '../../../lib/cloud-profile-picker'
     await initI18n()
     await initCurrency()
 
@@ -166,7 +168,14 @@ const { id } = Astro.params
         renderFilament(filament)
         loadSpools(filament.id)
         loadPrinters()
-        initSlicerProfilePicker()
+        initPerModelProfilePicker({
+          entityType: 'filament',
+          entityId: parseInt(id),
+          t,
+          getCsrfToken: getCsrfTokenGlobal,
+          getAbortSignal,
+          isAbortError,
+        })
       } catch (error) {
         if (isAbortError(error)) return
         console.error('Failed to load filament:', error)
@@ -805,39 +814,7 @@ const { id } = Astro.params
       }
     }
 
-    async function initSlicerProfilePicker() {
-      try {
-        const res = await fetch('/api/v1/printers', { credentials: 'include', signal: getAbortSignal() })
-        if (!res.ok) return
-        const data = await res.json()
-        const bambuPrinters = (data.items || data || []).filter((p: any) => p.driver_key === 'bambuddy')
-        if (bambuPrinters.length === 0) return
-        let rep = 0
-        for (const p of bambuPrinters) {
-          try {
-            const h = await fetch(`/api/v1/printers/${p.id}/driver/health`, { credentials: 'include', signal: getAbortSignal() })
-            if (h.ok) { const hj = await h.json(); if (hj && (hj.connected || hj.running)) { rep = p.id; break } }
-          } catch {}
-        }
-        if (!rep) rep = bambuPrinters[0].id
-        slicerRepPrinterId = rep
-        await loadCloudPresets(rep, 'bambuddy')
-        if (cloudPresets.length === 0) return
-        let currentCode = ''
-        try {
-          const pr = await fetch(`/api/v1/filaments/${id}/printer-params?printer_id=${rep}`, { credentials: 'include', signal: getAbortSignal() })
-          if (pr.ok) { const pp = await pr.json(); const sid = (pp || []).find((x: any) => x.param_key === 'bambu_slicer_setting_id'); const m = (pp || []).find((x: any) => x.param_key === 'bambu_idx'); currentCode = (sid && sid.param_value) || (m && m.param_value) || '' }
-        } catch {}
-        await ensureCodeLabel(rep, currentCode)
-        const c = document.getElementById('slicer-profile-picker')!
-        c.innerHTML = renderCloudCombobox('bambu_idx', currentCode, false)
-        const combo = c.querySelector('.cloud-combo')
-        if (combo) wireCombo(combo, applyFilamentProfileFromPicker)
-        document.getElementById('slicer-profile-section')!.classList.remove('hidden')
-      } catch (e) {
-        if (!isAbortError(e)) console.error('Slicer picker init failed:', e)
-      }
-    }
+    /* removed initSlicerProfilePicker — replaced by initPerModelProfilePicker */
 
     function renderPrinterParams() {
       const container = document.getElementById('printer-params-list')!

--- a/frontend/src/pages/spool-log.astro
+++ b/frontend/src/pages/spool-log.astro
@@ -10,6 +10,7 @@ import Layout from '../layouts/Layout.astro'
     .pagination-pages a:hover { text-decoration: underline; background: color-mix(in srgb, var(--accent) 10%, transparent); }
     .pagination-pages .page-current { font-weight: 700; color: var(--accent); padding: 2px 8px; background: color-mix(in srgb, var(--accent) 15%, transparent); border-radius: 3px; }
     .pagination-pages .page-ellipsis { color: var(--text-muted); padding: 0 2px; }
+    .fm-table .col-spool-id { width: 6ch; max-width: 6ch; white-space: nowrap; padding: 10px 4px 10px 8px; }
   </style>
   <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
     <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0; font-family: var(--font-serif);" data-i18n="spoolLog.title">Spool Log</h1>
@@ -23,7 +24,10 @@ import Layout from '../layouts/Layout.astro'
     <table class="fm-table">
       <thead>
         <tr style="background: var(--bg-soft);">
-          <th data-i18n="spoolLog.spool">Spool</th>
+          <th class="col-spool-id" data-i18n="spoolLog.spool">Spool</th>
+          <th data-i18n="spools.colMfrColor">Mfr. Color</th>
+          <th data-i18n="spools.manufacturer">Manufacturer</th>
+          <th data-i18n="spools.material">Material</th>
           <th data-i18n="spoolLog.eventType">Type</th>
           <th data-i18n="spoolLog.eventDate">Date</th>
           <th data-i18n="spoolLog.eventWeight">Weight</th>
@@ -32,7 +36,7 @@ import Layout from '../layouts/Layout.astro'
       </thead>
       <tbody id="events-table">
         <tr>
-          <td colspan="5" style="text-align: center; color: var(--text-muted);" data-i18n="common.loading">Loading...</td>
+          <td colspan="8" style="text-align: center; color: var(--text-muted);" data-i18n="common.loading">Loading...</td>
         </tr>
       </tbody>
     </table>
@@ -67,7 +71,7 @@ import Layout from '../layouts/Layout.astro'
         if (isAbortError(error)) return
         console.error('Failed to load events:', error)
         const tbody = document.getElementById('events-table')!
-        tbody.innerHTML = `<tr><td colspan="5" style="text-align: center; color: var(--error-text);">${t('spoolLog.failedLoad')}</td></tr>`
+        tbody.innerHTML = `<tr><td colspan="8" style="text-align: center; color: var(--error-text);">${t('spoolLog.failedLoad')}</td></tr>`
       }
     }
 
@@ -77,7 +81,7 @@ import Layout from '../layouts/Layout.astro'
       if (events.length === 0) {
         tbody.innerHTML = `
           <tr>
-            <td colspan="5" style="text-align: center; color: var(--text-muted);">${t('spoolLog.noEvents')}</td>
+            <td colspan="8" style="text-align: center; color: var(--text-muted);">${t('spoolLog.noEvents')}</td>
           </tr>
         `
         return
@@ -85,9 +89,14 @@ import Layout from '../layouts/Layout.astro'
 
       tbody.innerHTML = events.map(e => `
         <tr>
-          <td style="padding: 12px;">
+          <td class="col-spool-id">
             <a href="/spools/${e.spool_id}" style="color: var(--accent); text-decoration: none; font-weight: 500;">#${e.spool_id}</a>
           </td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text); white-space: nowrap;">
+            <span style="display: inline-flex; align-items: center; gap: 6px;">${renderMfrColorCell(e.colors, e.manufacturer_color_name)}</span>
+          </td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${escapeHtml(e.manufacturer_name) || '-'}</td>
+          <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${escapeHtml(e.material_type) || '-'}</td>
           <td style="padding: 12px;">
             <span class="fm-pill" style="${getEventTypeStyle(e.event_type)}">${e.event_type}</span>
           </td>
@@ -101,6 +110,45 @@ import Layout from '../layouts/Layout.astro'
           <td style="padding: 12px; font-size: 0.85rem; color: var(--text-muted);">${e.note || '-'}</td>
         </tr>
       `).join('')
+    }
+
+    function escapeHtml(value: any): string {
+      if (value === null || value === undefined) return ''
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+    }
+
+    function normalizeHexColor(hex: string | null | undefined): string {
+      const value = (hex || '').trim()
+      if (!value) return ''
+      return value.startsWith('#') ? value : `#${value}`
+    }
+
+    function renderColorDots(colors: any[] | null | undefined): string {
+      if (!colors || colors.length === 0) return ''
+      return colors.map(c => {
+        if (!c) return ''
+        const hex = normalizeHexColor(c.hex_code)
+        if (!hex) return ''
+        const title = escapeHtml(c.name || '')
+        return `<span title="${title}" style="display: inline-block; width: 18px; height: 18px; border-radius: 50%; background-color: ${hex}; border: 2px solid var(--border); vertical-align: middle; margin-right: 6px;"></span>`
+      }).join('')
+    }
+
+    function renderMfrColorCell(
+      colors: any[] | null | undefined,
+      manufacturerColorName: string | null | undefined
+    ): string {
+      const dots = renderColorDots(colors)
+      const label = escapeHtml(manufacturerColorName)
+      if (!dots && !label) return '<span style="color: var(--text-muted);">-</span>'
+      if (!label) return dots
+      if (!dots) return label
+      return `${dots}<span>${label}</span>`
     }
 
     function getEventTypeStyle(type: string): string {

--- a/frontend/src/pages/spools/[id]/index.astro
+++ b/frontend/src/pages/spools/[id]/index.astro
@@ -105,8 +105,9 @@ const { id } = Astro.params
     <h2 style="font-weight: 600; margin-bottom: 16px;" data-i18n="printers.slicerProfile">Slicer Profile</h2>
     <div class="fm-card" style="padding: 24px;">
       <label class="fm-label" data-i18n="printers.bambuSlicerProfile">Bambu Slicer Profile</label>
-      <div id="slicer-profile-picker" style="max-width: 520px;"></div>
+      <div id="slicer-profile-picker"></div>
       <p style="color: var(--text-muted); font-size: 0.8rem; margin-top: 8px;" data-i18n="printers.slicerProfileSpoolHint">Synced to this spool in Bambuddy across all Bambu printers.</p>
+      <div id="slicer-profile-coverage" class="hidden" style="margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px;"></div>
       <span id="slicer-profile-msg" class="hidden" style="font-size: 0.85rem;"></span>
     </div>
   </div>
@@ -177,6 +178,7 @@ const { id } = Astro.params
     import { t, initI18n } from '../../../lib/i18n'
     import { cachedFetchAllPages, fetchSequential, CACHE_KEYS } from '../../../lib/cache'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
+    import { initPerModelProfilePicker } from '../../../lib/cloud-profile-picker'
     await initI18n()
 
     const id = window.location.pathname.split('/').filter(Boolean).pop()!
@@ -301,7 +303,14 @@ const { id } = Astro.params
         renderSpool()
         loadPrinterSlotOverview()
         loadPrintersForParams()
-        initSlicerProfilePicker()
+        initPerModelProfilePicker({
+          entityType: 'spool',
+          entityId: parseInt(id),
+          t,
+          getCsrfToken,
+          getAbortSignal,
+          isAbortError,
+        })
         loadEvents()
         setupActions()
       } catch (error) {
@@ -1220,7 +1229,42 @@ const { id } = Astro.params
         wireCombo(combo, (code: string) => onCloudProfileSelected(code, currentPrinterId)))
     }
 
-    // Spool-level select: push immediately to Bambuddy so both systems match.
+    // -- Standalone per-model slicer profile picker (see cloud-profile-picker.ts) --
+
+    function showSlicerMsg(text: string, isError: boolean) {
+      const msg = document.getElementById('slicer-profile-msg')
+      if (!msg) return
+      msg.textContent = text
+      msg.style.color = isError ? 'var(--error-text)' : 'var(--success-text)'
+      msg.classList.remove('hidden')
+      setTimeout(() => msg.classList.add('hidden'), 3000)
+    }
+
+    function renderProfileCoverage(result: any) {
+      const el = document.getElementById('slicer-profile-coverage')
+      const data = result?.data ?? result
+      if (!el || !data?.coverage) return
+      const entries = Object.entries(data.coverage) as [string, any][]
+      if (entries.length === 0) { el.classList.add('hidden'); return }
+      el.innerHTML = entries.map(([model, c]) => {
+        const nozzle = c.nozzle_resolved != null ? ` ${c.nozzle_resolved} mm` : ''
+        let color = 'var(--success-text)'
+        let label = `${model}${nozzle} ok`
+        let title = c.code || ''
+        if (!c.mapped) {
+          color = 'var(--error-text, #c44)'
+          label = `${model} missing`
+          title = c.expected_name || 'Create matching variant in Bambu Studio'
+        } else if (c.fallback_nozzle) {
+          color = 'var(--warning-text, #b8860b)'
+          label = `${model}${nozzle} (fallback)`
+          title = (c.expected_name || '') + ' — using closest nozzle variant'
+        }
+        return `<span title="${title}" style="font-size:0.75rem;padding:2px 8px;border-radius:999px;border:1px solid ${color};color:${color}">${label}</span>`
+      }).join('')
+      el.classList.remove('hidden')
+    }
+
     async function onCloudProfileSelected(code: string, printerId: number) {
       if (!code || !printerId) return
       try {
@@ -1232,72 +1276,25 @@ const { id } = Astro.params
           body: JSON.stringify({ action: 'set_spool_profile', params: { spool_id: parseInt(id), code } }),
         })
         if (!res.ok) throw new Error('set_spool_profile failed')
+        const result = await res.json().catch(() => ({}))
+        renderProfileCoverage(result)
         try {
           const pr = await fetch(`/api/v1/spools/${id}/printer-params?printer_id=${printerId}`, { credentials: 'include', signal: getAbortSignal() })
           if (pr.ok) currentPrinterParams = await pr.json()
         } catch {}
-        showSlicerMsg(t('common.saved') || 'Saved', false)
+        const data = result?.data ?? result
+        if (data?.base_name) {
+          showSlicerMsg((t('common.saved') || 'Saved') + ` — ${data.base_name}`, false)
+        } else {
+          showSlicerMsg(t('common.saved') || 'Saved', false)
+        }
         showParamsFeedback(true)
       } catch (e) {
         if (!isAbortError(e)) { console.error('Failed to set spool profile:', e); showSlicerMsg(t('printers.paramsSaveFailed') || 'Failed', true) }
       }
     }
 
-    // -- Standalone (printer-independent) slicer profile picker --
-    let slicerRepPrinterId = 0
-
-    function showSlicerMsg(text: string, isError: boolean) {
-      const msg = document.getElementById('slicer-profile-msg')
-      if (!msg) return
-      msg.textContent = text
-      msg.style.color = isError ? 'var(--error-text)' : 'var(--success-text)'
-      msg.classList.remove('hidden')
-      setTimeout(() => msg.classList.add('hidden'), 3000)
-    }
-
-    async function initSlicerProfilePicker() {
-      try {
-        const res = await fetch('/api/v1/printers', { credentials: 'include', signal: getAbortSignal() })
-        if (!res.ok) return
-        const data = await res.json()
-        const bambuPrinters = (data.items || data || []).filter((p: any) => p.driver_key === 'bambuddy')
-        if (bambuPrinters.length === 0) return
-        let rep = 0
-        for (const p of bambuPrinters) {
-          try {
-            const h = await fetch(`/api/v1/printers/${p.id}/driver/health`, { credentials: 'include', signal: getAbortSignal() })
-            if (h.ok) { const hj = await h.json(); if (hj && (hj.connected || hj.running)) { rep = p.id; break } }
-          } catch {}
-        }
-        if (!rep) rep = bambuPrinters[0].id
-        slicerRepPrinterId = rep
-        await loadCloudPresets(rep, 'bambuddy')
-        if (cloudPresets.length === 0) return
-        // current value: spool-level, fallback to filament-level
-        let currentCode = ''
-        try {
-          const [spRes, flRes] = await Promise.all([
-            fetch(`/api/v1/spools/${id}/printer-params?printer_id=${rep}`, { credentials: 'include', signal: getAbortSignal() }),
-            spool?.filament_id ? fetch(`/api/v1/filaments/${spool.filament_id}/printer-params?printer_id=${rep}`, { credentials: 'include', signal: getAbortSignal() }) : Promise.resolve(null),
-          ])
-          const sp = spRes && spRes.ok ? await spRes.json() : []
-          const fl = flRes && flRes.ok ? await flRes.json() : []
-          const sSid = (sp || []).find((x: any) => x.param_key === 'bambu_slicer_setting_id')
-          const fSid = (fl || []).find((x: any) => x.param_key === 'bambu_slicer_setting_id')
-          const sm = (sp || []).find((x: any) => x.param_key === 'bambu_idx')
-          const fm = (fl || []).find((x: any) => x.param_key === 'bambu_idx')
-          currentCode = (sSid && sSid.param_value) || (fSid && fSid.param_value) || (sm && sm.param_value) || (fm && fm.param_value) || ''
-        } catch {}
-        await ensureCodeLabel(rep, currentCode)
-        const c = document.getElementById('slicer-profile-picker')!
-        c.innerHTML = renderCloudCombobox('bambu_idx', currentCode, '', '', false)
-        const combo = c.querySelector('.cloud-combo')
-        if (combo) wireCombo(combo, (code: string) => onCloudProfileSelected(code, slicerRepPrinterId))
-        document.getElementById('slicer-profile-section')!.classList.remove('hidden')
-      } catch (e) {
-        if (!isAbortError(e)) console.error('Slicer picker init failed:', e)
-      }
-    }
+    /* removed initSlicerProfilePicker — replaced by initPerModelProfilePicker */
 
     function renderPrinterParams() {
       const container = document.getElementById('printer-params-list') as HTMLElement
@@ -1790,6 +1787,31 @@ const { id } = Astro.params
       pendingSlotPollTimer = setTimeout(poll, 3000)
     }
 
+    async function getModelCoverageForPrinter(printerId: any): Promise<{ model: string, status: string } | null> {
+      try {
+        const [cmRes, covRes] = await Promise.all([
+          fetch(`/api/v1/printers/${printerId}/driver/connected-models`, { credentials: 'include', signal: getAbortSignal() }),
+          fetch(`/api/v1/printers/${printerId}/driver/profile-coverage?spool_id=${id}`, { credentials: 'include', signal: getAbortSignal() }),
+        ])
+        if (!cmRes.ok || !covRes.ok) return null
+        const cm = await cmRes.json().catch(() => ({}))
+        const cov = await covRes.json().catch(() => ({}))
+        if (cov?.per_model_profiles_enabled === false) return null
+        const models = cm?.models || []
+        let model: string | null = null
+        for (const m of models) {
+          const pids = (m.printer_ids || m.printerIds || []).map(Number)
+          if (pids.includes(Number(printerId))) { model = m.model; break }
+        }
+        if (!model) return null
+        const c = (cov?.coverage || {})[model]
+        return { model, status: c?.status || 'not_set' }
+      } catch (e) {
+        if (isAbortError(e)) throw e
+        return null
+      }
+    }
+
     async function handleAssignSpoolToTray(slot: any, printerId: any) {
       if (!spool) return
       const idx = slot.slot_index || ''
@@ -1797,6 +1819,22 @@ const { id } = Astro.params
       const amsId = parseInt(parts[0])
       const trayId = parseInt(parts[1])
       const slotIndex = `${amsId}-${trayId}`
+
+      // Warn before assigning when no Bambu cloud profile resolves for this
+      // printer's model — the slot would otherwise get generic settings silently.
+      try {
+        const mc = await getModelCoverageForPrinter(printerId)
+        if (mc && (mc.status === 'missing' || mc.status === 'not_set')) {
+          const proceed = window.confirm(
+            `No Bambu slicer profile resolves for ${mc.model} on this printer ` +
+            `(${mc.status}). The slot will be assigned with generic settings and ` +
+            `may not match in Bambu Studio.\n\nAssign anyway?`
+          )
+          if (!proceed) return
+        }
+      } catch (e) {
+        if (isAbortError(e)) return
+      }
 
       // Clear any previous pending state
       clearPendingSlotAssign()

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1059,3 +1059,33 @@ html.sidebar-collapsed .fm-logo-text {
   color: #dc2626;
   border: 1px solid rgba(239, 68, 68, 0.2);
 }
+
+/* Bambu per-model slicer profile picker */
+#slicer-profile-picker {
+  width: 100%;
+  max-width: none;
+}
+
+.per-model-profile-grid {
+  display: grid;
+  gap: 16px;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.per-model-profile-grid[data-model-count="2"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.per-model-profile-grid[data-model-count="3"],
+.per-model-profile-grid[data-model-count="4"] {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+@media (max-width: 720px) {
+  .per-model-profile-grid[data-model-count="2"],
+  .per-model-profile-grid[data-model-count="3"],
+  .per-model-profile-grid[data-model-count="4"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary

This PR consolidates the remaining `devel` work ahead of upstream into a single reviewable changeset (supersedes #98).

**Companion plugin:** The per-model slicer profile workflow, cloud profile picker, Bambu fallback admin setting, and `filament_id` enrichment at assign time are designed to work with the **Bambuddy driver plugin** ([filaman-bambuddy-plugin PR #5](https://github.com/Fire-Devils/filaman-bambuddy-plugin/pull/5)). Deploy or upgrade that plugin alongside this PR for full AMS auto-assign and profile resolution. Spool log context and RFID duplicate cleanup work without the plugin.

### Per-model slicer profile workflow (requires Bambuddy plugin)
<img width="2885" height="949" alt="image" src="https://github.com/user-attachments/assets/2de8aaed-929a-4f76-97cc-0732e4e3b0d5" />


- Driver APIs for connected models, coverage, and per-model profile saves (proxied to Bambuddy driver)
- Shared cloud-profile picker on spool/filament pages
- Assign-time confirmation when coverage is missing
- Admin setting: Generic vs Bambu fallback when no model-specific profile resolves (read by Bambuddy driver)
- CSRF cookie refresh so browser profile saves stay reliable

### Spool log filament context (from #98)
- Enrich `GET /api/v1/spools/all-events` with filament context (manufacturer name, mfr. color, material type, color swatches) via eager-loaded spool → filament relations
- Expand the Spool Log table to match the Spools list: compact spool ID column, combined mfr. color (icon + name), manufacturer, material, then existing event columns

<img width="2448" height="866" alt="Spool log with filament context columns" src="https://github.com/user-attachments/assets/191aac9c-457d-455e-b73e-36837e5e63b6" />

### Driver enrichment + RFID fixes
- Inject `filament_id` in `enrich_filament_data` so Bambuddy can resolve slicer profiles at assign time
- Case-insensitive UID matching when weighing/cleaning duplicate spools (driver-agnostic)

### Docs
- `Auto-Profile-Info.md` documents the per-model slicer profile workflow end-to-end with Bambuddy

## Test plan

**Spool log** (no plugin required)
- [ ] Open Spool Log and confirm columns: Spool, Mfr. Color, Manufacturer, Material, Type, Date, Weight, Note
- [ ] Verify mfr. color shows dot + label (e.g. Orange, Blue)
- [ ] Verify manufacturer and material populate for events with active spools/filaments
- [ ] Confirm spool ID column is narrow (~6ch)
- [ ] Hard-refresh after deploy so the latest `_astro/spool-log*.js` bundle loads

**Slicer profiles** (requires [bambuddy-plugin PR #5](https://github.com/Fire-Devils/filaman-bambuddy-plugin/pull/5))
- [ ] Configure per-model slicer profiles on a filament and verify assignment on multiple printer models
- [ ] Toggle Bambu unmatched-profile fallback in admin app settings and verify driver behavior

**Workflow fixes**
- [ ] Weigh a spool with RFID; confirm duplicate UIDs differing only by case are merged
- [ ] Assign a spool to an AMS tray via Bambuddy; confirm slicer profile resolves when spool has `filament_id` but payload lacked it