### PR TITLE
fix(oidc): widen oauth_identities.provider to String(255) — issuer-URL truncation → 500 on OIDC callback

### DIFF
--- a/backend/alembic/versions/widen_oauth_provider_column.py
+++ b/backend/alembic/versions/widen_oauth_provider_column.py
@@ -1,0 +1,46 @@
+"""widen_oauth_identities_provider_to_255
+
+oauth_identities.provider stores the OIDC issuer URL (e.g. an Authentik issuer
+like "https://auth.example.com/application/o/<app-slug>/", commonly 50-60+
+chars), but the column was String(50). A real issuer URL overflows it, raising
+StringDataRightTruncationError on the OIDC callback (auth_oidc.py, at the
+identity upsert) → HTTP 500 at /auth/oidc/callback, blocking SSO login on a
+fresh DB. Widen provider to String(255) to match provider_subject/provider_email.
+
+Revision ID: widen_oauth_provider
+Revises: add_bambu_unmatched_fallback
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'widen_oauth_provider'
+down_revision: Union[str, Sequence[str], None] = 'add_bambu_unmatched_fallback'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('oauth_identities') as batch_op:
+        batch_op.alter_column(
+            'provider',
+            existing_type=sa.String(length=50),
+            type_=sa.String(length=255),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    # Note: only safe if no stored provider value exceeds 50 chars (a real OIDC
+    # issuer URL does), so this is best-effort — kept for chain symmetry.
+    with op.batch_alter_table('oauth_identities') as batch_op:
+        batch_op.alter_column(
+            'provider',
+            existing_type=sa.String(length=255),
+            type_=sa.String(length=50),
+            existing_nullable=False,
+        )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -71,7 +71,7 @@ class OAuthIdentity(Base, TimestampMixin):
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
-    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    provider: Mapped[str] = mapped_column(String(255), nullable=False)
     provider_subject: Mapped[str] = mapped_column(String(255), nullable=False)
     provider_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     provider_email_verified: Mapped[bool] = mapped_column(default=False)


### PR DESCRIPTION
## Bug

OIDC login 500s on a fresh database. `oauth_identities.provider` is declared `String(50)`, but the value written is the **OIDC issuer URL**, which for a typical IdP (e.g. an Authentik issuer like `https://auth.<domain>/application/o/<app-slug>/`) is commonly **50–60+ characters**. It overflows the column and raises:

```
sqlalchemy ... StringDataRightTruncationError: value too long for type character varying(50)
```

…on the identity upsert in the OIDC callback → **HTTP 500 at `/auth/oidc/callback`**, so first-time (and every) SSO login fails.

An already-provisioned DB whose column was widened by hand won't hit this, so it only bites **clean deploys / fresh installs** — which is exactly why it's worth fixing in the schema rather than by a manual `ALTER`.

## Fix

- **`backend/app/models/user.py`** — `OAuthIdentity.provider`: `String(50)` → `String(255)`, matching the sibling `provider_subject` / `provider_email` columns (both already `String(255)`).
- **`backend/alembic/versions/widen_oauth_provider_column.py`** — new migration (`widen_oauth_provider`, revises current head `add_bambu_unmatched_fallback`) that `batch_alter_table`-widens the column to 255. `batch_alter_table` keeps it portable across SQLite/Postgres, matching the repo's existing migration style.

Smallest of a few OIDC fixes I'm proposing (JIT auto-provisioning + a force-SSO option are separate PRs); this one is standalone and unblocks a clean reinstall, so it's first.

`python -m py_compile` clean on both files; migration chains as a single new head.