### PR TITLE
feat(oidc): opt-in JIT auto-provisioning on first SSO login

### DIFF
--- a/backend/alembic/versions/add_oidc_auto_provision.py
+++ b/backend/alembic/versions/add_oidc_auto_provision.py
@@ -1,0 +1,46 @@
+"""add oidc auto_provision + default_role to oidc_settings
+
+Opt-in JIT auto-provisioning knobs for OIDC login:
+- auto_provision (bool, default false): on a first OIDC login with a verified
+  email and no matching local user, CREATE the user instead of rejecting with
+  oidc_no_user. Default false preserves the existing link-only behavior.
+- default_role (str, nullable): role key (e.g. "viewer") assigned to a
+  JIT-created user; null = no role (login works, zero permissions until an
+  admin grants) — privilege is never auto-granted.
+
+Revision ID: add_oidc_auto_provision
+Revises: add_bambu_unmatched_fallback
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_oidc_auto_provision'
+down_revision: Union[str, Sequence[str], None] = 'add_bambu_unmatched_fallback'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'auto_provision',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column('default_role', sa.String(length=50), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.drop_column('default_role')
+        batch_op.drop_column('auto_provision')

--- a/backend/app/api/auth_oidc.py
+++ b/backend/app/api/auth_oidc.py
@@ -14,6 +14,7 @@ from app.core.config import settings
 from app.core.oidc_crypto import decrypt_secret
 from app.core.security import generate_token_secret, hash_password_async, hash_token
 from app.models import OIDCAuthState, OIDCSettings, OAuthIdentity, User, UserSession
+from app.models.rbac import Role, UserRole
 
 router = APIRouter(prefix="/auth/oidc", tags=["auth"])
 
@@ -219,6 +220,7 @@ async def oidc_callback(request: Request, db: DBSession):
     subject = claims.get("sub")
     email = claims.get("email")
     email_verified = bool(claims.get("email_verified"))
+    display_name = claims.get("name") or claims.get("preferred_username")
     if not subject:
         return RedirectResponse("/login?error=oidc_failed", status_code=302)
 
@@ -240,7 +242,30 @@ async def oidc_callback(request: Request, db: DBSession):
         result = await db.execute(select(User).where(User.email == email))
         user = result.scalar_one_or_none()
         if user is None:
-            return RedirectResponse("/login?error=oidc_no_user", status_code=302)
+            # No local user for this verified email. JIT-provision one ONLY if the
+            # admin opted in (auto_provision); otherwise preserve the link-only
+            # behavior (a pre-existing account is required).
+            if not settings_row.auto_provision:
+                return RedirectResponse("/login?error=oidc_no_user", status_code=302)
+            user = User(
+                email=email,
+                email_verified=True,  # gated by the verified-email check above
+                display_name=display_name,
+                is_active=True,
+            )
+            db.add(user)
+            await db.flush()  # assign user.id before linking role/identity
+            # Optional admin-configured default role. Unset => no role (the user can
+            # log in but has zero permissions until an admin grants) — we never
+            # auto-grant privilege on JIT-create.
+            if settings_row.default_role:
+                role = (
+                    await db.execute(
+                        select(Role).where(Role.key == settings_row.default_role)
+                    )
+                ).scalar_one_or_none()
+                if role is not None:
+                    db.add(UserRole(user_id=user.id, role_id=role.id))
         identity = OAuthIdentity(
             user_id=user.id,
             provider=settings_row.issuer_url,

--- a/backend/app/api/v1/oidc_admin.py
+++ b/backend/app/api/v1/oidc_admin.py
@@ -17,6 +17,8 @@ class OIDCSettingsResponse(BaseModel):
     has_client_secret: bool
     scopes: str
     button_text: str
+    auto_provision: bool
+    default_role: str | None
 
 
 class OIDCSettingsUpdate(BaseModel):
@@ -26,6 +28,8 @@ class OIDCSettingsUpdate(BaseModel):
     client_secret: str | None = None
     scopes: str | None = None
     button_text: str | None = None
+    auto_provision: bool | None = None
+    default_role: str | None = None
 
 
 @router.get("/", response_model=OIDCSettingsResponse)
@@ -43,6 +47,8 @@ async def get_oidc_settings(
             has_client_secret=False,
             scopes="openid email profile",
             button_text="Login with SSO",
+            auto_provision=False,
+            default_role=None,
         )
 
     return OIDCSettingsResponse(
@@ -52,6 +58,8 @@ async def get_oidc_settings(
         has_client_secret=bool(settings_row.client_secret_enc),
         scopes=settings_row.scopes,
         button_text=settings_row.button_text,
+        auto_provision=settings_row.auto_provision,
+        default_role=settings_row.default_role,
     )
 
 
@@ -97,6 +105,8 @@ async def update_oidc_settings(
         has_client_secret=bool(settings_row.client_secret_enc),
         scopes=settings_row.scopes,
         button_text=settings_row.button_text,
+        auto_provision=settings_row.auto_provision,
+        default_role=settings_row.default_role,
     )
 
 

--- a/backend/app/models/oidc_settings.py
+++ b/backend/app/models/oidc_settings.py
@@ -30,6 +30,14 @@ class OIDCSettings(Base, TimestampMixin):
     # Display: configurable button text on the login page
     button_text: Mapped[str] = mapped_column(String(100), default="Login with SSO", nullable=False)
 
+    # JIT provisioning: when true, a first-time OIDC login with a verified email and
+    # no matching local user CREATES the user instead of rejecting it. Default off
+    # (upstream-safe: preserves the link-only behavior). default_role is the role key
+    # (e.g. "viewer") assigned to a JIT-created user; null = no role (login works,
+    # zero permissions until an admin grants) — never auto-grant privilege.
+    auto_provision: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    default_role: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
 
 class OIDCAuthState(Base):
     """Server-side OIDC auth state for PKCE flow.


### PR DESCRIPTION
## Motivation

Today, a first-time OIDC login with a verified email but **no matching local user** returns `oidc_no_user` — the callback only *links* to a pre-existing account (matched by email). So a new IdP user can't get in until an admin hand-creates their FilaMan account first. This adds an **opt-in** just-in-time (JIT) provisioning path.

## Change

- **`models/oidc_settings.py`** — two new columns:
  - `auto_provision` (bool, **default `false`**) — off by default, so behavior is unchanged unless an admin enables it (upstream-safe).
  - `default_role` (str, nullable) — role key assigned to a JIT-created user.
- **`api/auth_oidc.py`** — in the no-local-user branch, when `auto_provision` is on, **create** the user instead of returning `oidc_no_user`:
  - Behind the **existing verified-email gate** (the `if not email_verified or not email: return` a few lines up) — a user is never provisioned on `email_verified=false`.
  - `display_name` from the `name` / `preferred_username` claim; `password_hash` left `null` (SSO-only account, can't password-login).
  - If `default_role` is set, assign that role by `key`; if unset, the user is created **role-less** (can log in, zero permissions until an admin grants) — privilege is never auto-granted.
- **`api/v1/oidc_admin.py`** — surface `auto_provision` + `default_role` on the admin get/update DTOs (the update path applies them via its existing `setattr` loop).
- **alembic** — `add_oidc_auto_provision` migration (`batch_alter_table` adds both columns; `auto_provision` NOT NULL `server_default false`).

## Security notes

Gated behind admin opt-in **and** the pre-existing verified-email check; `email` is `unique` so it maps to a real identity; no default privilege on create. If your IdP doesn't truly verify emails but returns `email_verified:true`, only enable `auto_provision` for issuers you trust.

## Caveats

- 🔀 **Migration heads:** this migration and my sibling PR (`widen oauth_identities.provider`) both revise the current head `add_bambu_unmatched_fallback`. If both land, alembic will have two heads — resolve with an `alembic merge` (or re-parent one). Kept independent so each PR reviews standalone.
- **Tests:** the repo currently has no OIDC test harness (only password auth is covered in `tests/test_auth.py`), and exercising the callback needs full OIDC-flow mocking. This is a small gated branch; happy to add a callback test if you'd like a mocking pattern established.

`python -m py_compile` clean on all four files.