### PR TITLE
feat(oidc): opt-in force-SSO — skip the local login form (stacks on #104)

### DIFF
--- a/backend/alembic/versions/add_oidc_auto_provision.py
+++ b/backend/alembic/versions/add_oidc_auto_provision.py
@@ -1,0 +1,46 @@
+"""add oidc auto_provision + default_role to oidc_settings
+
+Opt-in JIT auto-provisioning knobs for OIDC login:
+- auto_provision (bool, default false): on a first OIDC login with a verified
+  email and no matching local user, CREATE the user instead of rejecting with
+  oidc_no_user. Default false preserves the existing link-only behavior.
+- default_role (str, nullable): role key (e.g. "viewer") assigned to a
+  JIT-created user; null = no role (login works, zero permissions until an
+  admin grants) — privilege is never auto-granted.
+
+Revision ID: add_oidc_auto_provision
+Revises: add_bambu_unmatched_fallback
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_oidc_auto_provision'
+down_revision: Union[str, Sequence[str], None] = 'add_bambu_unmatched_fallback'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'auto_provision',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch_op.add_column(
+            sa.Column('default_role', sa.String(length=50), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.drop_column('default_role')
+        batch_op.drop_column('auto_provision')

--- a/backend/alembic/versions/add_oidc_force_sso.py
+++ b/backend/alembic/versions/add_oidc_force_sso.py
@@ -1,0 +1,39 @@
+"""add oidc force_sso to oidc_settings
+
+Opt-in force-SSO: when force_sso is true, the login page redirects
+unauthenticated hits straight into the OIDC flow instead of showing the local
+login form. Default false (upstream-safe). Distinct from login_disabled (which
+is a no-auth backdoor) — force_sso still requires a real OIDC login.
+
+Revision ID: add_oidc_force_sso
+Revises: add_oidc_auto_provision
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'add_oidc_force_sso'
+down_revision: Union[str, Sequence[str], None] = 'add_oidc_auto_provision'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'force_sso',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('oidc_settings') as batch_op:
+        batch_op.drop_column('force_sso')

--- a/backend/app/api/auth_oidc.py
+++ b/backend/app/api/auth_oidc.py
@@ -14,6 +14,7 @@ from app.core.config import settings
 from app.core.oidc_crypto import decrypt_secret
 from app.core.security import generate_token_secret, hash_password_async, hash_token
 from app.models import OIDCAuthState, OIDCSettings, OAuthIdentity, User, UserSession
+from app.models.rbac import Role, UserRole
 
 router = APIRouter(prefix="/auth/oidc", tags=["auth"])
 
@@ -219,6 +220,7 @@ async def oidc_callback(request: Request, db: DBSession):
     subject = claims.get("sub")
     email = claims.get("email")
     email_verified = bool(claims.get("email_verified"))
+    display_name = claims.get("name") or claims.get("preferred_username")
     if not subject:
         return RedirectResponse("/login?error=oidc_failed", status_code=302)
 
@@ -240,7 +242,30 @@ async def oidc_callback(request: Request, db: DBSession):
         result = await db.execute(select(User).where(User.email == email))
         user = result.scalar_one_or_none()
         if user is None:
-            return RedirectResponse("/login?error=oidc_no_user", status_code=302)
+            # No local user for this verified email. JIT-provision one ONLY if the
+            # admin opted in (auto_provision); otherwise preserve the link-only
+            # behavior (a pre-existing account is required).
+            if not settings_row.auto_provision:
+                return RedirectResponse("/login?error=oidc_no_user", status_code=302)
+            user = User(
+                email=email,
+                email_verified=True,  # gated by the verified-email check above
+                display_name=display_name,
+                is_active=True,
+            )
+            db.add(user)
+            await db.flush()  # assign user.id before linking role/identity
+            # Optional admin-configured default role. Unset => no role (the user can
+            # log in but has zero permissions until an admin grants) — we never
+            # auto-grant privilege on JIT-create.
+            if settings_row.default_role:
+                role = (
+                    await db.execute(
+                        select(Role).where(Role.key == settings_row.default_role)
+                    )
+                ).scalar_one_or_none()
+                if role is not None:
+                    db.add(UserRole(user_id=user.id, role_id=role.id))
         identity = OAuthIdentity(
             user_id=user.id,
             provider=settings_row.issuer_url,

--- a/backend/app/api/v1/oidc_admin.py
+++ b/backend/app/api/v1/oidc_admin.py
@@ -17,6 +17,8 @@ class OIDCSettingsResponse(BaseModel):
     has_client_secret: bool
     scopes: str
     button_text: str
+    auto_provision: bool
+    default_role: str | None
 
 
 class OIDCSettingsUpdate(BaseModel):
@@ -26,6 +28,8 @@ class OIDCSettingsUpdate(BaseModel):
     client_secret: str | None = None
     scopes: str | None = None
     button_text: str | None = None
+    auto_provision: bool | None = None
+    default_role: str | None = None
 
 
 @router.get("/", response_model=OIDCSettingsResponse)
@@ -43,6 +47,8 @@ async def get_oidc_settings(
             has_client_secret=False,
             scopes="openid email profile",
             button_text="Login with SSO",
+            auto_provision=False,
+            default_role=None,
         )
 
     return OIDCSettingsResponse(
@@ -52,6 +58,8 @@ async def get_oidc_settings(
         has_client_secret=bool(settings_row.client_secret_enc),
         scopes=settings_row.scopes,
         button_text=settings_row.button_text,
+        auto_provision=settings_row.auto_provision,
+        default_role=settings_row.default_role,
     )
 
 
@@ -97,6 +105,8 @@ async def update_oidc_settings(
         has_client_secret=bool(settings_row.client_secret_enc),
         scopes=settings_row.scopes,
         button_text=settings_row.button_text,
+        auto_provision=settings_row.auto_provision,
+        default_role=settings_row.default_role,
     )
 
 

--- a/backend/app/api/v1/oidc_admin.py
+++ b/backend/app/api/v1/oidc_admin.py
@@ -19,6 +19,7 @@ class OIDCSettingsResponse(BaseModel):
     button_text: str
     auto_provision: bool
     default_role: str | None
+    force_sso: bool
 
 
 class OIDCSettingsUpdate(BaseModel):
@@ -30,6 +31,7 @@ class OIDCSettingsUpdate(BaseModel):
     button_text: str | None = None
     auto_provision: bool | None = None
     default_role: str | None = None
+    force_sso: bool | None = None
 
 
 @router.get("/", response_model=OIDCSettingsResponse)
@@ -49,6 +51,7 @@ async def get_oidc_settings(
             button_text="Login with SSO",
             auto_provision=False,
             default_role=None,
+            force_sso=False,
         )
 
     return OIDCSettingsResponse(
@@ -60,6 +63,7 @@ async def get_oidc_settings(
         button_text=settings_row.button_text,
         auto_provision=settings_row.auto_provision,
         default_role=settings_row.default_role,
+        force_sso=settings_row.force_sso,
     )
 
 
@@ -107,6 +111,7 @@ async def update_oidc_settings(
         button_text=settings_row.button_text,
         auto_provision=settings_row.auto_provision,
         default_role=settings_row.default_role,
+        force_sso=settings_row.force_sso,
     )
 
 
@@ -115,5 +120,9 @@ async def get_public_oidc_info(db: DBSession):
     result = await db.execute(select(OIDCSettings).where(OIDCSettings.id == 1))
     settings_row = result.scalar_one_or_none()
     if settings_row is None or not settings_row.enabled:
-        return {"enabled": False, "button_text": ""}
-    return {"enabled": True, "button_text": settings_row.button_text}
+        return {"enabled": False, "button_text": "", "force": False}
+    return {
+        "enabled": True,
+        "button_text": settings_row.button_text,
+        "force": settings_row.force_sso,
+    }

--- a/backend/app/models/oidc_settings.py
+++ b/backend/app/models/oidc_settings.py
@@ -38,6 +38,10 @@ class OIDCSettings(Base, TimestampMixin):
     auto_provision: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     default_role: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
+    # Force-SSO: when true, the login page auto-redirects unauthenticated hits
+    # straight into the OIDC flow (no local login form). Default off.
+    force_sso: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
 
 class OIDCAuthState(Base):
     """Server-side OIDC auth state for PKCE flow.

--- a/backend/app/models/oidc_settings.py
+++ b/backend/app/models/oidc_settings.py
@@ -30,6 +30,14 @@ class OIDCSettings(Base, TimestampMixin):
     # Display: configurable button text on the login page
     button_text: Mapped[str] = mapped_column(String(100), default="Login with SSO", nullable=False)
 
+    # JIT provisioning: when true, a first-time OIDC login with a verified email and
+    # no matching local user CREATES the user instead of rejecting it. Default off
+    # (upstream-safe: preserves the link-only behavior). default_role is the role key
+    # (e.g. "viewer") assigned to a JIT-created user; null = no role (login works,
+    # zero permissions until an admin grants) — never auto-grant privilege.
+    auto_provision: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    default_role: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
 
 class OIDCAuthState(Base):
     """Server-side OIDC auth state for PKCE flow.

--- a/frontend/src/pages/login.astro
+++ b/frontend/src/pages/login.astro
@@ -202,6 +202,15 @@ const { error } = Astro.props
           if (resp.ok) {
             const data = await resp.json()
             if (data.enabled) {
+              // Force-SSO: skip the local form and go straight to the OIDC flow.
+              // Loop-breaker: if we arrived with an ?error (an OIDC soft-fail
+              // redirects back to /login?error=...), do NOT auto-redirect — show
+              // the button + error instead, so a down/misconfigured IdP can't cause
+              // an infinite /login -> /auth/oidc/start -> /login loop.
+              if (data.force && !oidcError) {
+                window.location.href = '/auth/oidc/start'
+                return
+              }
               const ssoSection = document.getElementById('sso-section')
               const ssoBtn = document.getElementById('sso-btn')
               if (ssoSection && ssoBtn) {


### PR DESCRIPTION
## Motivation

For an OIDC-only deployment, an unauthenticated visitor should land straight in the SSO flow rather than at a local login form they can't use. This adds an **opt-in** force-SSO option.

## Change

- **`models/oidc_settings.py`** — new `force_sso` (bool, **default `false`**).
- **`api/v1/oidc_admin.py`** — expose `force_sso` on the admin get/update DTOs, and surface it as `force` on the public `GET /api/v1/oidc/public-info`.
- **alembic** — `add_oidc_force_sso` migration (adds the column).
- **`frontend/src/pages/login.astro`** — when `public-info` reports `enabled && force`, redirect to `/auth/oidc/start` instead of rendering the local form.

**Explicitly NOT `login_disabled`** — that flag is a no-auth backdoor (logs everyone in as the first superadmin). `force_sso` still requires a real OIDC login.

## Lockout / redirect-loop — handled + residual risk

An always-redirect force-SSO has a failure mode: if the IdP is down/misconfigured, `/auth/oidc/start` soft-fails back to `/login?error=oidc_failed`, which would re-redirect → **infinite loop**. This PR breaks that loop: the redirect is **skipped whenever `/login` has an `?error=` param**, so a failed SSO attempt shows the SSO button + the error instead of looping. Per the requested UX bar, there's **no escape-hatch that degrades the normal (working-IdP) flow** — the loop-breaker only engages on an actual error.

Residual risk to weigh: while `force_sso` is on and the IdP is genuinely unreachable, there is no local-form fallback for admins (by design). Operators who want a break-glass path can temporarily flip `force_sso` off in the DB. Flagging so you can decide whether a documented break-glass is worth adding.

## Note — stacks on #104

This builds on #104 (JIT auto-provisioning): both touch `OIDCSettings` and the Alembic chain, so to stay linear and conflict-free the `force_sso` migration **revises `add_oidc_auto_provision`** (from #104). **Please merge #104 first**; the force-SSO-only increment is `oidc_settings.py` (+`force_sso`), the `force`/DTO exposure, its migration, and the `login.astro` redirect. `python -m py_compile` clean on the backend files.