### PR TITLE
fix(print): prevent browser single-label pagination

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -30,6 +30,7 @@ Damit lässt sich das FilaMan System mit wenigen Klicks direkt in deiner Home As
 - **Spulen-Verwaltung:** Tracking von Restgewicht, Lagerort und Status.
 - **Mandantenfähigkeit:** Multi-User-Unterstützung mit Rollensystem.
 - **Drucker-Integration:** Plugin-System zur Anbindung von 3D-Druckern und AMS-Einheiten.
+- **Druckbare Labels:** Spulen- und Filament-Labels mit QR-Codes, eigenem Label-Designer und Etikettenbogen-Ausgabe drucken und exportieren.
 - **Datenbank-Support:** Kompatibel mit SQLite (Standard), MySQL und PostgreSQL.
 - **Responsive UI:** Modernes Design (Hell, Dunkel und Brand-Theme).
 - **OIDC (OAuth2) Login:** Single Sign-On (SSO) über OpenID Connect für bestehende Benutzer.
@@ -38,7 +39,6 @@ Damit lässt sich das FilaMan System mit wenigen Klicks direkt in deiner Home As
 Wir haben spannende Pläne für die Zukunft von FilaMan:
 - **Drucker-Plugins:** Entwicklung von Plugins für die Verbindung zu verschiedenen 3D-Druckern (Beiträge durch die Community sind sehr willkommen!).
 - **Mobile Apps:** Native Apps für iOS und Android.
-- **Spulen-Labels:** Generieren und Drucken von Etiketten/Labels für Spulen.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This allows you to install and run the FilaMan System directly within your Home 
 - **Spool Management:** Track remaining weight, location, and status.
 - **Multi-User:** Role-based access control and tenant support.
 - **Printer Integration:** Plugin system to connect with 3D printers and AMS units.
+- **Printable Labels:** Print and export spool or filament labels with QR codes, custom label designer layouts, and label-paper sheet output.
 - **Database Support:** Works with SQLite (default), MySQL, and PostgreSQL.
 - **Responsive UI:** Modern design with light, dark, and brand themes.
 - **OIDC (OAuth2) Login:** Single Sign-On (SSO) via OpenID Connect for existing users.
@@ -38,7 +39,6 @@ This allows you to install and run the FilaMan System directly within your Home 
 We have exciting plans for the future of FilaMan:
 - **Printer Plugins:** Develop plugins to connect with various 3D printers (community contributions are highly welcome!).
 - **Mobile Apps:** Dedicated apps for iOS and Android.
-- **Printable Labels:** Generate and print custom labels for your spools.
 
 ## Installation
 

--- a/frontend/src/components/SingleLabelPrintStyles.astro
+++ b/frontend/src/components/SingleLabelPrintStyles.astro
@@ -475,6 +475,20 @@
       background: white !important;
     }
 
+    /* Screen preview padding must not enter print layout; small label pages can paginate otherwise. */
+    .preview-scroll-area {
+      padding: 0 !important;
+      margin: 0 !important;
+      display: block !important;
+      width: auto !important;
+      min-width: 0 !important;
+      height: auto !important;
+      min-height: 0 !important;
+      overflow: visible !important;
+      align-items: stretch !important;
+      justify-content: flex-start !important;
+    }
+
     .preview-zoom-bar { display: none !important; }
 
     .label-preview {
@@ -488,6 +502,8 @@
       margin: 0 !important;
       padding: var(--print-label-padding, 2mm) !important;
       overflow: hidden !important;
+      transform: none !important;
+      transform-origin: unset !important;
       break-inside: avoid !important;
       page-break-inside: avoid !important;
       -webkit-print-color-adjust: exact;


### PR DESCRIPTION
## Summary

Fixes single-label browser print pagination in browsers for small label-printer paper sizes such as `62 x 29 mm`.

After the v1.2.22 label print merge, single-label print pages wrap the rendered label in `.preview-scroll-area` for on-screen zoom/scroll behavior. That wrapper still had `40px` preview padding in print media. On a short `29mm` label page, that extra top/bottom print height can make browsers paginate one label across two sheets even when the app preview and browser paper size are correct.

## Fix

- Reset `.preview-scroll-area` in print media so preview-only padding, flex centering, and scroll sizing do not contribute to printed page geometry.
- Explicitly reset `.label-preview` transform/transform-origin in the static print stylesheet as a Firefox-safe fallback alongside the existing dynamic label-sized print style.

## README Updates

- Update `README.md` and `README.de.md` so printable spool/filament labels are documented as a current feature.
- Remove stale roadmap wording that still described spool labels as future/planned work.
- Mention label printing/export support, QR codes, custom label designer layouts, and label-paper sheet output in the feature list.

## Temporary Workaround

Until this fix is released, use **Export PDF** from the label print page and print that PDF at actual size / 100% scale with printer margins disabled. PDF export uses the configured label dimensions directly and avoids the affected browser print preview wrapper.

Reducing browser print scale can sometimes force the preview back to one page, but it also changes the physical label size, so it should only be used as an emergency workaround.

## Validation

- `git diff --check`
- `npm run lint` passes with existing warnings only
- `npm run check` passes with existing project hints
- `npm run build` passes
- Direct installed Google Chrome print-to-PDF reproduction: pre-fix `62 x 29 mm` fixture generated 2 pages; fixed fixture generated 1 page with the same media box.

Note: local builds still log the existing `frontend/version.txt` warning and temporarily regenerate `src/version.js`; generated version changes were restored and not committed.
