### PR TITLE
feat: add image upload and display for filament colors

### DIFF
--- a/backend/alembic/versions/e1f2a3b4c5d6_add_image_file_to_colors.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_add_image_file_to_colors.py
@@ -1,0 +1,32 @@
+"""add_image_file_to_colors
+
+Revision ID: e1f2a3b4c5d6
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-13 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e1f2a3b4c5d6'
+down_revision: Union[str, Sequence[str], None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "colors",
+        sa.Column("image_file", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("colors", "image_file")

--- a/backend/app/api/v1/filaments.py
+++ b/backend/app/api/v1/filaments.py
@@ -1,8 +1,9 @@
 import logging
+from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import delete, func, or_, select, literal_column
@@ -33,7 +34,7 @@ from app.api.v1.schemas_filament import (
     ManufacturerResponse,
     ManufacturerUpdate,
 )
-from app.core.config import settings, MANUFACTURER_LOGO_DIR
+from app.core.config import settings, MANUFACTURER_LOGO_DIR, COLOR_IMAGE_DIR
 from app.core.event_bus import event_bus
 from app.models import (
     Color,
@@ -551,6 +552,149 @@ async def delete_color(
     await db.delete(color)
     await db.commit()
     await event_bus.publish({"event": "colors_changed"})
+
+    # Clean up image file from persistent storage
+    if color.image_file:
+        image_path = COLOR_IMAGE_DIR / color.image_file
+        if image_path.is_file():
+            try:
+                image_path.unlink()
+            except OSError:
+                pass
+
+
+# ── Color image endpoints ─────────────────────────────────────────
+
+ALLOWED_COLOR_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+@router_colors.get("/{color_id}/image")
+async def get_color_image(
+    color_id: int,
+    _db: DBSession,
+    _principal: PrincipalDep,
+):
+    """Serve the color's image from persistent storage."""
+    result = await _db.execute(select(Color).where(Color.id == color_id))
+    color = result.scalar_one_or_none()
+    if not color or not color.image_file:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Image not found"},
+        )
+
+    image_path = COLOR_IMAGE_DIR / color.image_file
+    if not image_path.is_file():
+        color.image_file = None
+        await _db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Image file missing from disk"},
+        )
+
+    ext = image_path.suffix.lower()
+    media_type_map = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+    }
+    media_type = media_type_map.get(ext, "image/jpeg")
+
+    return FileResponse(
+        image_path,
+        media_type=media_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@router_colors.post("/{color_id}/image/upload", status_code=status.HTTP_200_OK)
+async def upload_color_image(
+    color_id: int,
+    file: UploadFile,
+    db: DBSession,
+    principal=RequirePermission("colors:update"),
+):
+    """Upload an image for a color."""
+    # Validate content type
+    valid_types = {"image/jpeg", "image/png", "image/webp", "image/jpg"}
+    if file.content_type not in valid_types:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_content_type", "message": "Only JPG, PNG, and WebP images are allowed"},
+        )
+
+    # Validate extension
+    ext = Path(file.filename or "").suffix.lower()
+    if ext not in ALLOWED_COLOR_IMAGE_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_extension", "message": f"Only {', '.join(ALLOWED_COLOR_IMAGE_EXTENSIONS)} extensions are allowed"},
+        )
+
+    result = await db.execute(select(Color).where(Color.id == color_id))
+    color = result.scalar_one_or_none()
+    if not color:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Color not found"},
+        )
+
+    # Remove old image if it exists
+    if color.image_file:
+        old_path = COLOR_IMAGE_DIR / color.image_file
+        if old_path.is_file():
+            try:
+                old_path.unlink()
+            except OSError:
+                pass
+
+    # Save new image
+    COLOR_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+    filename = f"{color_id}{ext}"
+    image_path = COLOR_IMAGE_DIR / filename
+
+    content = await file.read()
+    image_path.write_bytes(content)
+
+    color.image_file = filename
+    await db.commit()
+    await event_bus.publish({"event": "colors_changed"})
+
+    return {
+        "ok": True,
+        "image_url": f"/api/v1/colors/{color_id}/image",
+        "filename": filename,
+    }
+
+
+@router_colors.delete("/{color_id}/image", status_code=status.HTTP_200_OK)
+async def delete_color_image(
+    color_id: int,
+    db: DBSession,
+    principal=RequirePermission("colors:update"),
+):
+    """Delete the image associated with a color."""
+    result = await db.execute(select(Color).where(Color.id == color_id))
+    color = result.scalar_one_or_none()
+    if not color:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Color not found"},
+        )
+
+    if color.image_file:
+        image_path = COLOR_IMAGE_DIR / color.image_file
+        if image_path.is_file():
+            try:
+                image_path.unlink()
+            except OSError:
+                pass
+        color.image_file = None
+        await db.commit()
+        await event_bus.publish({"event": "colors_changed"})
+
+    return {"ok": True}
 
 
 router_filaments = APIRouter(prefix="/filaments", tags=["filaments"])

--- a/backend/app/api/v1/schemas_filament.py
+++ b/backend/app/api/v1/schemas_filament.py
@@ -85,8 +85,16 @@ class ColorResponse(BaseModel):
     id: int
     name: str
     hex_code: str
+    image_file: str | None = None
     custom_fields: dict[str, Any] | None = None
     usage_count: int = 0
+
+    @computed_field
+    @property
+    def image_url(self) -> str | None:
+        if self.image_file:
+            return f"/api/v1/colors/{self.id}/image"
+        return None
 
     class Config:
         from_attributes = True

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -76,3 +76,4 @@ def _resolve_data_dir() -> Path:
 
 DATA_DIR = _resolve_data_dir()
 MANUFACTURER_LOGO_DIR = DATA_DIR / "logos" / "manufacturers"
+COLOR_IMAGE_DIR = DATA_DIR / "logos" / "colors"

--- a/backend/app/models/filament.py
+++ b/backend/app/models/filament.py
@@ -35,6 +35,7 @@ class Color(Base, TimestampMixin):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     hex_code: Mapped[str] = mapped_column(String(7), nullable=False)
+    image_file: Mapped[str | None] = mapped_column(String(500), nullable=True)
     custom_fields: Mapped[dict[str, Any] | None] = mapped_column(nullable=True)
 
     __table_args__ = (UniqueConstraint("name", "hex_code", name="uq_colors_name_hex"),)

--- a/frontend/src/pages/filaments/[id]/index.astro
+++ b/frontend/src/pages/filaments/[id]/index.astro
@@ -195,8 +195,9 @@ const { id } = Astro.params
         const c = fc.color
         if (!c) return ''
         const label = fc.display_name_override || c.name
+        const imageUrl = c.image_url ? `<img src="${c.image_url}" style="width: 22px; height: 22px; border-radius: 50%; object-fit: cover; border: 2px solid var(--border); vertical-align: middle;" />` : `<span style="display: inline-block; width: 22px; height: 22px; border-radius: 50%; background: ${c.hex_code}; border: 2px solid var(--border); vertical-align: middle;"></span>`
         return `<span style="display: inline-flex; align-items: center; gap: 6px; margin-right: 10px;">
-          <span style="display: inline-block; width: 22px; height: 22px; border-radius: 50%; background: ${c.hex_code}; border: 2px solid var(--border); vertical-align: middle;"></span>
+          ${imageUrl}
           <span>${label}</span>
         </span>`
       }).join('')

--- a/frontend/src/pages/filaments/colors.astro
+++ b/frontend/src/pages/filaments/colors.astro
@@ -134,7 +134,12 @@ import Layout from '../../layouts/Layout.astro'
         <tr>
           <td style="padding: 12px;">
             <div style="display: flex; align-items: center; gap: 12px;">
-              <span style="display: inline-block; width: 24px; height: 24px; border-radius: 50%; background: ${c.hex_code}; border: 1px solid var(--border);"></span>
+              <div style="position: relative; width: 24px; height: 24px; flex-shrink: 0;">
+                ${c.image_url
+                  ? `<img src="${c.image_url}" style="width: 24px; height: 24px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border);" />`
+                  : `<span style="display: inline-block; width: 24px; height: 24px; border-radius: 50%; background: ${c.hex_code}; border: 1px solid var(--border);"></span>`
+                }
+              </div>
               <span style="font-weight: 500;">${c.name}</span>
             </div>
           </td>
@@ -147,8 +152,19 @@ import Layout from '../../layouts/Layout.astro'
               data-id="${c.id}" 
               data-name="${c.name}" 
               data-hex="${c.hex_code}" 
+              data-has-image="${c.image_url || ''}"
+              class="btn-upload-image" 
+              style="color: var(--accent-2); background: none; border: none; cursor: pointer; margin-right: 8px; font-size: 0.85rem;"
+              title="${t('colors.uploadImage') || 'Upload Image'}"
+            >
+              📷
+            </button>
+            <button 
+              data-id="${c.id}" 
+              data-name="${c.name}" 
+              data-hex="${c.hex_code}" 
               class="btn-edit" 
-              style="color: var(--accent); background: none; border: none; cursor: pointer; margin-right: 12px;"
+              style="color: var(--accent); background: none; border: none; cursor: pointer; margin-right: 8px;"
             >
               ${t('common.edit')}
             </button>
@@ -206,6 +222,60 @@ import Layout from '../../layouts/Layout.astro'
           } catch {
             await (window as any).__fmAlert(t('colors.failedDelete'))
           }
+        })
+      })
+      
+      document.querySelectorAll('.btn-upload-image').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          const target = e.currentTarget as HTMLButtonElement
+          const id = parseInt(target.dataset.id!)
+          const hasImage = target.dataset.hasImage
+          
+          if (hasImage) {
+            if (!(await (window as any).__fmConfirm(t('colors.confirmReplaceImage') || 'Replace this image?'))) return
+            try {
+              const response = await fetch(`/api/v1/colors/${id}/image`, {
+                method: 'DELETE',
+                headers: { 'X-CSRF-Token': getCsrfToken() },
+                credentials: 'include',
+                signal: getAbortSignal(),
+              })
+              if (response.ok) loadColors()
+            } catch {}
+            return
+          }
+          
+          const input = document.createElement('input')
+          input.type = 'file'
+          input.accept = 'image/jpeg,image/png,image/webp'
+          input.addEventListener('change', async () => {
+            const file = input.files?.[0]
+            if (!file) return
+            
+            const formData = new FormData()
+            formData.append('file', file)
+            
+            try {
+              const response = await fetch(`/api/v1/colors/${id}/image/upload`, {
+                method: 'POST',
+                headers: { 'X-CSRF-Token': getCsrfToken() },
+                credentials: 'include',
+                body: formData,
+                signal: getAbortSignal(),
+              })
+              
+              if (!response.ok) {
+                const data = await response.json()
+                await (window as any).__fmAlert(data.message || t('colors.failedUpload'))
+                return
+              }
+              
+              loadColors()
+            } catch {
+              await (window as any).__fmAlert(t('colors.failedUpload'))
+            }
+          })
+          input.click()
         })
       })
     }


### PR DESCRIPTION
## Summary

Adds the ability to upload and display images for filament colors. This is useful for visually identifying color swatches when managing filament inventory.

## Changes

### Backend
- **Model**: Added  column to the `Color` model (`backend/app/models/filament.py`)
- **Storage**: New directory `data/logos/colors/` for color images
- **Migration**: `e1f2a3b4c5d6_add_image_file_to_colors.py` adds the new column
- **API endpoints**:
  - `POST /api/v1/colors/{id}/image/upload` — upload an image (multipart, JPG/PNG/WebP)
  - `GET /api/v1/colors/{id}/image` — serve the image
  - `DELETE /api/v1/colors/{id}/image` — remove the image
  - Image is cleaned up on color deletion

### Frontend
- **Colors page** (`frontend/src/pages/filaments/colors.astro`): Added a camera button (📷) next to each color to upload/delete images. The color swatch in the table shows the image instead of just the hex circle.
- **Filament detail page** (`frontend/src/pages/filaments/[id]/index.astro`): Color swatches on the filament detail page now display the uploaded image when available, falling back to the hex color circle.

### Schema
- **Pydantic**: `ColorResponse` now includes `image_file` and a computed `image_url` field (mirrors the manufacturer logo pattern).

## Testing

To test manually:
1. Start the backend and frontend
2. Go to /filaments/colors
3. Click the 📷 button next to any color to upload an image
4. Navigate to a filament page to see the color swatches with images

## Files Changed
- `backend/app/models/filament.py` — added `image_file` column
- `backend/app/core/config.py` — added `COLOR_IMAGE_DIR`
- `backend/app/api/v1/schemas_filament.py` — added `image_file` and `image_url` to `ColorResponse`
- `backend/app/api/v1/filaments.py` — upload, serve, delete endpoints
- `backend/alembic/versions/e1f2a3b4c5d6_add_image_file_to_colors.py` — migration
- `frontend/src/pages/filaments/colors.astro` — upload UI
- `frontend/src/pages/filaments/[id]/index.astro` — display images in swatches
