### PR TITLE
fix: prevent trailing blank label print pages

### DIFF
--- a/frontend/src/components/LabelDesignerEditor.astro
+++ b/frontend/src/components/LabelDesignerEditor.astro
@@ -144,7 +144,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
       </div>
       <div>
         <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-title-tpl">Title Format</label><button class="ds-syntax-btn" id="ds-title-syntax-btn" type="button" title="Template syntax help">?</button></div>
-        <textarea id="ds-title-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.name}"></textarea>
+        <textarea id="ds-title-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.name}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
         <div class="ds-token-area" id="ds-title-token-area"></div>
       </div>
 
@@ -181,7 +181,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
         </div>
         <div>
           <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-title2-tpl">Subtitle Format</label><button class="ds-syntax-btn" id="ds-title2-syntax-btn" type="button" title="Template syntax help">?</button></div>
-          <textarea id="ds-title2-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.type}"></textarea>
+          <textarea id="ds-title2-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.type}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
           <div class="ds-token-area" id="ds-title2-token-area"></div>
         </div>
       </div>
@@ -284,7 +284,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
       </div>
       <div>
         <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-info-tpl">Information Format</label><button class="ds-syntax-btn" id="ds-info-syntax-btn" type="button" title="Template syntax help">?</button></div>
-        <textarea id="ds-info-tpl" class="fm-input ds-tpl-input" rows="7" placeholder="{filament.type}&#10;{filament.color}&#10;Ext: {filament.extruder_temp}C&#10;Bed: {filament.bed_temp}C"></textarea>
+        <textarea id="ds-info-tpl" class="fm-input ds-tpl-input" rows="7" placeholder="{filament.type}&#10;{filament.color}&#10;Ext: {filament.extruder_temp}C&#10;Bed: {filament.bed_temp}C" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
         <div class="ds-token-area" id="ds-info-token-area"></div>
       </div>
       <div class="ds-secondary-toggle" id="ds-info2-toggle"><label class="fm-checkbox-group ds-secondary-check"><input type="checkbox" id="ds-info2-show"><span id="dsl-info2-show">Side Column</span></label></div>
@@ -313,7 +313,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
         </div>
         <div>
           <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-info2-tpl">Side Column Format</label><button class="ds-syntax-btn" id="ds-info2-syntax-btn" type="button" title="Template syntax help">?</button></div>
-          <textarea id="ds-info2-tpl" class="fm-input ds-tpl-input" rows="5" placeholder="{filament.raw_material_weight_g}g&#10;{filament.color_hex}"></textarea>
+          <textarea id="ds-info2-tpl" class="fm-input ds-tpl-input" rows="5" placeholder="{filament.raw_material_weight_g}g&#10;{filament.color_hex}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
           <div class="ds-token-area" id="ds-info2-token-area"></div>
         </div>
       </div>

--- a/frontend/src/components/LabelDesignerEditor.astro
+++ b/frontend/src/components/LabelDesignerEditor.astro
@@ -20,6 +20,13 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
   valign.map(item => ({ ...item, id: `${prefix}-${item.id}` })),
   active,
 )
+
+const templateInputAttributes = {
+  spellcheck: false,
+  autocomplete: 'off',
+  autocapitalize: 'off',
+  autocorrect: 'off',
+}
 ---
 
 <div id="tab-panel-designer" class="settings-section" style="display: none;">
@@ -144,7 +151,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
       </div>
       <div>
         <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-title-tpl">Title Format</label><button class="ds-syntax-btn" id="ds-title-syntax-btn" type="button" title="Template syntax help">?</button></div>
-        <textarea id="ds-title-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.name}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
+        <textarea id="ds-title-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.name}" {...templateInputAttributes}></textarea>
         <div class="ds-token-area" id="ds-title-token-area"></div>
       </div>
 
@@ -181,7 +188,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
         </div>
         <div>
           <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-title2-tpl">Subtitle Format</label><button class="ds-syntax-btn" id="ds-title2-syntax-btn" type="button" title="Template syntax help">?</button></div>
-          <textarea id="ds-title2-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.type}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
+          <textarea id="ds-title2-tpl" class="fm-input ds-tpl-input ds-tpl-textarea" rows="1" placeholder="{filament.type}" {...templateInputAttributes}></textarea>
           <div class="ds-token-area" id="ds-title2-token-area"></div>
         </div>
       </div>
@@ -227,7 +234,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
       <div><label class="fm-label" id="dsl-qr-link">Link mode</label><div class="ds-pill-group" id="ds-qr-link-group" data-value="spool">
         {pill([{ value: 'url', id: 'dsp-qr-url', label: 'Custom URL' }, { value: 'spool', id: 'dsp-qr-spool', label: 'Spool URL' }], 'spool').map(item => <button class:list={['ds-pill-btn', item.active && 'active']} data-val={item.value} id={item.id} type="button">{item.label}</button>)}
       </div></div>
-      <div id="ds-qr-url-wrap" style="display:none;"><label class="fm-label" id="dsl-qr-url-tpl">Custom URL base</label><input type="text" id="ds-qr-url-tpl" class="fm-input ds-tpl-input" placeholder="https://example.com"></div>
+      <div id="ds-qr-url-wrap" style="display:none;"><label class="fm-label" id="dsl-qr-url-tpl">Custom URL base</label><input type="text" id="ds-qr-url-tpl" class="fm-input ds-tpl-input" placeholder="https://example.com" {...templateInputAttributes}></div>
       <div class="ds-two-col-row">
         <div class="ds-field-col"><label class="fm-label" id="dsl-qr-pos">Position</label><div class="ds-pill-group" id="ds-qr-pos-group" data-value="right">
           {pill([{ value: 'left', id: 'dsp-qr-left', label: 'Left' }, { value: 'right', id: 'dsp-qr-right', label: 'Right' }], 'right').map(item => <button class:list={['ds-pill-btn', 'ds-icon-pill-btn', item.active && 'active']} data-val={item.value} id={item.id} type="button" title={item.label} aria-label={item.label}>
@@ -284,7 +291,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
       </div>
       <div>
         <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-info-tpl">Information Format</label><button class="ds-syntax-btn" id="ds-info-syntax-btn" type="button" title="Template syntax help">?</button></div>
-        <textarea id="ds-info-tpl" class="fm-input ds-tpl-input" rows="7" placeholder="{filament.type}&#10;{filament.color}&#10;Ext: {filament.extruder_temp}C&#10;Bed: {filament.bed_temp}C" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
+        <textarea id="ds-info-tpl" class="fm-input ds-tpl-input" rows="7" placeholder="{filament.type}&#10;{filament.color}&#10;Ext: {filament.extruder_temp}C&#10;Bed: {filament.bed_temp}C" {...templateInputAttributes}></textarea>
         <div class="ds-token-area" id="ds-info-token-area"></div>
       </div>
       <div class="ds-secondary-toggle" id="ds-info2-toggle"><label class="fm-checkbox-group ds-secondary-check"><input type="checkbox" id="ds-info2-show"><span id="dsl-info2-show">Side Column</span></label></div>
@@ -313,7 +320,7 @@ const verticalAlignButtons = (prefix: string, active = 'bottom') => pill(
         </div>
         <div>
           <div class="ds-tpl-label-row"><label class="fm-label" id="dsl-info2-tpl">Side Column Format</label><button class="ds-syntax-btn" id="ds-info2-syntax-btn" type="button" title="Template syntax help">?</button></div>
-          <textarea id="ds-info2-tpl" class="fm-input ds-tpl-input" rows="5" placeholder="{filament.raw_material_weight_g}g&#10;{filament.color_hex}" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off"></textarea>
+          <textarea id="ds-info2-tpl" class="fm-input ds-tpl-input" rows="5" placeholder="{filament.raw_material_weight_g}g&#10;{filament.color_hex}" {...templateInputAttributes}></textarea>
           <div class="ds-token-area" id="ds-info2-token-area"></div>
         </div>
       </div>

--- a/frontend/src/components/PrintActionFooter.astro
+++ b/frontend/src/components/PrintActionFooter.astro
@@ -20,11 +20,141 @@ const {
 } = Astro.props
 ---
 
-<div class="action-buttons">
-  <div class="export-buttons">
-    <button id="btn-export-png" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPngI18n}>Export PNG</button>
-    <button id="btn-export-pdf" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPdfI18n}>Export PDF</button>
+<div class="print-footer">
+  <div class="action-buttons">
+    <div class="export-buttons">
+      <button id="btn-export-png" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPngI18n}>Export PNG</button>
+      <button id="btn-export-pdf" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPdfI18n}>Export PDF</button>
+    </div>
+    <button id={printButtonId} class="fm-btn fm-btn-primary" type="button" onclick="filamanPrint()" data-i18n={printI18n}>{printLabel}</button>
+    <button id="btn-reset" class="fm-btn fm-btn-outline" type="button" data-i18n={resetI18n}>{resetLabel}</button>
   </div>
-  <button id={printButtonId} class="fm-btn fm-btn-primary" type="button" onclick="filamanPrint()" data-i18n={printI18n}>{printLabel}</button>
-  <button id="btn-reset" class="fm-btn fm-btn-outline" type="button" data-i18n={resetI18n}>{resetLabel}</button>
+
+  <details class="print-help" id="print-help">
+    <summary id="print-help-toggle" class="print-help-toggle">
+      <span class="print-help-title">
+        <span class="print-help-icon" aria-hidden="true">i</span>
+        <span data-i18n="labelPrint.printHelpTitle">Printing issues?</span>
+      </span>
+      <span class="print-help-chevron" aria-hidden="true">
+        <svg viewBox="0 0 20 20" width="16" height="16" focusable="false">
+          <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </span>
+    </summary>
+    <div id="print-help-panel" class="print-help-panel">
+      <p data-i18n="labelPrint.printHelpIntro">Use 100% scale and a matching paper size for small labels.</p>
+      <ul>
+        <li data-i18n="labelPrint.printHelpBrave">Brave: if output is blank or offset, use the system dialog or Export PDF.</li>
+        <li data-i18n="labelPrint.printHelpFirefox">Firefox: if the top is clipped, turn off headers and footers.</li>
+      </ul>
+    </div>
+  </details>
 </div>
+
+<style is:global>
+  .print-footer {
+    flex-shrink: 0;
+    padding: 12px 24px 20px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-elevated);
+    box-shadow: 0 -12px 24px rgba(0, 0, 0, 0.08);
+  }
+
+  .print-help {
+    margin: 12px 0 0;
+    font-size: 0.78rem;
+    line-height: 1.4;
+    color: var(--text);
+  }
+
+  .print-help-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-soft));
+    color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+    list-style: none;
+    transition: border-color var(--transition), background var(--transition), color var(--transition);
+  }
+
+  .print-help-toggle::-webkit-details-marker { display: none; }
+
+  .print-help-toggle:hover {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: color-mix(in srgb, var(--accent) 12%, var(--bg-soft));
+  }
+
+  .print-help-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+  }
+
+  .print-help-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px solid currentColor;
+    font-size: 0.68rem;
+    line-height: 1;
+    color: #dc2626;
+  }
+
+  .print-help-chevron {
+    display: inline-flex;
+    color: var(--text-muted);
+    transition: transform var(--transition), color var(--transition);
+  }
+
+  .print-help[open] .print-help-toggle {
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    border-bottom-color: transparent;
+  }
+
+  .print-help[open] .print-help-chevron {
+    transform: rotate(180deg);
+    color: var(--accent);
+  }
+
+  .print-help-panel {
+    margin-top: 0;
+    padding: 9px 11px;
+    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+    background: color-mix(in srgb, var(--accent) 6%, var(--bg-elevated));
+    border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
+    border-top-color: color-mix(in srgb, var(--accent) 16%, var(--border));
+  }
+
+  .print-help[open] .print-help-panel { display: block; }
+
+  .print-help-panel p { margin: 0 0 6px; }
+
+  .print-help-panel ul {
+    margin: 0;
+    padding-left: 16px;
+  }
+
+  .print-help-panel li + li { margin-top: 4px; }
+
+  .print-footer .action-buttons {
+    padding: 0;
+    border-top: 0;
+  }
+
+  @media print {
+    .print-footer { display: none !important; }
+  }
+</style>

--- a/frontend/src/components/PrintActionFooter.astro
+++ b/frontend/src/components/PrintActionFooter.astro
@@ -20,84 +20,60 @@ const {
 } = Astro.props
 ---
 
-<div class="print-footer">
-  <div class="action-buttons">
-    <div class="export-buttons">
-      <button id="btn-export-png" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPngI18n}>Export PNG</button>
-      <button id="btn-export-pdf" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPdfI18n}>Export PDF</button>
-    </div>
-    <button id={printButtonId} class="fm-btn fm-btn-primary" type="button" onclick="filamanPrint()" data-i18n={printI18n}>{printLabel}</button>
-    <button id="btn-reset" class="fm-btn fm-btn-outline" type="button" data-i18n={resetI18n}>{resetLabel}</button>
+<div class="action-buttons">
+  <div class="export-buttons">
+    <button id="btn-export-png" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPngI18n}>Export PNG</button>
+    <button id="btn-export-pdf" class="fm-btn fm-btn-outline" type="button" data-i18n={exportPdfI18n}>Export PDF</button>
   </div>
+  <button id={printButtonId} class="fm-btn fm-btn-primary" type="button" onclick="filamanPrint()" data-i18n={printI18n}>{printLabel}</button>
+  <button id="btn-reset" class="fm-btn fm-btn-outline" type="button" data-i18n={resetI18n}>{resetLabel}</button>
 
-  <details class="print-help" id="print-help">
-    <summary id="print-help-toggle" class="print-help-toggle">
-      <span class="print-help-title">
-        <span class="print-help-icon" aria-hidden="true">i</span>
-        <span data-i18n="labelPrint.printHelpTitle">Printing issues?</span>
-      </span>
-      <span class="print-help-chevron" aria-hidden="true">
-        <svg viewBox="0 0 20 20" width="16" height="16" focusable="false">
-          <path d="M5 7.5 10 12.5 15 7.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-        </svg>
-      </span>
-    </summary>
-    <div id="print-help-panel" class="print-help-panel">
+  <div class="print-help">
+    <button class="print-help-trigger" type="button" aria-describedby="print-help-content">
+      <span class="print-help-icon" aria-hidden="true">i</span>
+      <span data-i18n="labelPrint.printHelpTitle">Printing issues?</span>
+    </button>
+    <div class="print-help-content" id="print-help-content" role="tooltip">
       <p data-i18n="labelPrint.printHelpIntro">Use 100% scale and a matching paper size for small labels.</p>
       <ul>
         <li data-i18n="labelPrint.printHelpBrave">Brave: if output is blank or offset, use the system dialog or Export PDF.</li>
         <li data-i18n="labelPrint.printHelpFirefox">Firefox: if the top is clipped, turn off headers and footers.</li>
       </ul>
     </div>
-  </details>
+  </div>
 </div>
 
 <style is:global>
-  .print-footer {
-    flex-shrink: 0;
-    padding: 12px 24px 20px;
-    border-top: 1px solid var(--border);
-    background: var(--bg-elevated);
-    box-shadow: 0 -12px 24px rgba(0, 0, 0, 0.08);
-  }
-
   .print-help {
-    margin: 12px 0 0;
-    font-size: 0.78rem;
+    position: relative;
+    align-self: flex-start;
+    color: var(--text-muted);
+    font-size: 0.75rem;
     line-height: 1.4;
-    color: var(--text);
   }
 
-  .print-help-toggle {
+  .print-help-trigger {
     display: inline-flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    width: 100%;
-    padding: 8px 10px;
-    border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
-    border-radius: var(--radius-sm);
-    background: color-mix(in srgb, var(--accent) 8%, var(--bg-soft));
-    color: var(--text);
+    gap: 6px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--text-muted);
     font: inherit;
     font-weight: 600;
     cursor: pointer;
-    list-style: none;
-    transition: border-color var(--transition), background var(--transition), color var(--transition);
   }
 
-  .print-help-toggle::-webkit-details-marker { display: none; }
-
-  .print-help-toggle:hover {
-    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
-    background: color-mix(in srgb, var(--accent) 12%, var(--bg-soft));
+  .print-help-trigger:hover,
+  .print-help-trigger:focus-visible {
+    color: var(--text);
   }
 
-  .print-help-title {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    min-width: 0;
+  .print-help-trigger:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 2px;
   }
 
   .print-help-icon {
@@ -106,55 +82,40 @@ const {
     justify-content: center;
     width: 16px;
     height: 16px;
-    border-radius: 50%;
     border: 1px solid currentColor;
+    border-radius: 50%;
+    color: #dc2626;
     font-size: 0.68rem;
     line-height: 1;
-    color: #dc2626;
   }
 
-  .print-help-chevron {
-    display: inline-flex;
-    color: var(--text-muted);
-    transition: transform var(--transition), color var(--transition);
+  .print-help-content {
+    position: absolute;
+    z-index: 20;
+    bottom: calc(100% + 8px);
+    left: 0;
+    display: none;
+    width: 272px;
+    box-sizing: border-box;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated);
+    box-shadow: var(--shadow-md);
+    color: var(--text);
   }
 
-  .print-help[open] .print-help-toggle {
-    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-    border-bottom-color: transparent;
+  .print-help:hover .print-help-content,
+  .print-help:focus-within .print-help-content {
+    display: block;
   }
 
-  .print-help[open] .print-help-chevron {
-    transform: rotate(180deg);
-    color: var(--accent);
-  }
+  .print-help-content p { margin: 0 0 6px; }
 
-  .print-help-panel {
-    margin-top: 0;
-    padding: 9px 11px;
-    border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-    background: color-mix(in srgb, var(--accent) 6%, var(--bg-elevated));
-    border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
-    border-top-color: color-mix(in srgb, var(--accent) 16%, var(--border));
-  }
-
-  .print-help[open] .print-help-panel { display: block; }
-
-  .print-help-panel p { margin: 0 0 6px; }
-
-  .print-help-panel ul {
-    margin: 0;
+  .print-help-content ul {
+    margin: 0 0 0 2px;
     padding-left: 16px;
   }
 
-  .print-help-panel li + li { margin-top: 4px; }
-
-  .print-footer .action-buttons {
-    padding: 0;
-    border-top: 0;
-  }
-
-  @media print {
-    .print-footer { display: none !important; }
-  }
+  .print-help-content li + li { margin-top: 4px; }
 </style>

--- a/frontend/src/components/SingleLabelPrintStyles.astro
+++ b/frontend/src/components/SingleLabelPrintStyles.astro
@@ -16,8 +16,6 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    position: relative;
-    z-index: 2;
   }
 
   .print-sidebar-scroll {
@@ -69,30 +67,21 @@
 
   .preview-container {
     flex: 1;
-    min-width: 0;
+    min-width: 320px;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     background: var(--bg-soft);
-    position: relative;
-    z-index: 1;
   }
 
   .preview-zoom-bar {
     display: flex;
     align-items: center;
     gap: 8px;
-    align-self: center;
-    width: min(520px, calc(100% - 32px));
-    margin: 12px 16px 0;
-    padding: 8px 12px;
-    background: color-mix(in srgb, var(--bg-elevated) 94%, var(--accent));
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    box-shadow: var(--shadow-md);
+    padding: 8px 20px 6px;
+    background: var(--bg-elevated);
+    border-bottom: 1px solid var(--border);
     flex-shrink: 0;
-    position: relative;
-    z-index: 1;
   }
 
   .preview-zoom-btn {
@@ -140,7 +129,7 @@
     display: flex;
     align-items: safe center;
     justify-content: safe center;
-    padding: 28px 40px 40px;
+    padding: 40px;
     overflow: auto;
   }
 

--- a/frontend/src/components/SingleLabelPrintStyles.astro
+++ b/frontend/src/components/SingleLabelPrintStyles.astro
@@ -16,6 +16,8 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    position: relative;
+    z-index: 2;
   }
 
   .print-sidebar-scroll {
@@ -67,21 +69,30 @@
 
   .preview-container {
     flex: 1;
-    min-width: 320px;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     background: var(--bg-soft);
+    position: relative;
+    z-index: 1;
   }
 
   .preview-zoom-bar {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 8px 20px 6px;
-    background: var(--bg-elevated);
-    border-bottom: 1px solid var(--border);
+    align-self: center;
+    width: min(520px, calc(100% - 32px));
+    margin: 12px 16px 0;
+    padding: 8px 12px;
+    background: color-mix(in srgb, var(--bg-elevated) 94%, var(--accent));
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    box-shadow: var(--shadow-md);
     flex-shrink: 0;
+    position: relative;
+    z-index: 1;
   }
 
   .preview-zoom-btn {
@@ -129,7 +140,7 @@
     display: flex;
     align-items: safe center;
     justify-content: safe center;
-    padding: 40px;
+    padding: 28px 40px 40px;
     overflow: auto;
   }
 
@@ -506,6 +517,8 @@
       transform-origin: unset !important;
       break-inside: avoid !important;
       page-break-inside: avoid !important;
+      break-after: avoid !important;
+      page-break-after: avoid !important;
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
     }

--- a/frontend/src/components/SingleLabelPrintStyles.astro
+++ b/frontend/src/components/SingleLabelPrintStyles.astro
@@ -465,6 +465,7 @@
       margin: 0 !important;
       height: auto !important;
       display: block !important;
+      overflow: visible !important;
     }
 
     .preview-container {
@@ -506,8 +507,6 @@
       transform-origin: unset !important;
       break-inside: avoid !important;
       page-break-inside: avoid !important;
-      break-after: avoid !important;
-      page-break-after: avoid !important;
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
     }

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1315,6 +1315,10 @@
     "suffixFilament": "Filament",
     "exporting": "Exportiere…",
     "pngExportFailed": "PNG-Export fehlgeschlagen. Bitte prüfen, ob alle Label-Bilder und Logos korrekt geladen wurden.",
-    "pdfExportFailed": "PDF-Export fehlgeschlagen. Bitte prüfen, ob alle Label-Bilder und Logos korrekt geladen wurden."
+    "pdfExportFailed": "PDF-Export fehlgeschlagen. Bitte prüfen, ob alle Label-Bilder und Logos korrekt geladen wurden.",
+    "printHelpTitle": "Druckprobleme?",
+    "printHelpIntro": "F\u00fcr kleine Etiketten 100 % Skalierung und die exakt passende Papiergr\u00f6\u00dfe verwenden.",
+    "printHelpBrave": "Brave: Wenn die Ausgabe leer, versetzt oder abgeschnitten ist, PDF exportieren oder eine etwas kleinere passende Labelgr\u00f6\u00dfe verwenden.",
+    "printHelpFirefox": "Firefox: Wenn der Systemdialog ein leeres Blatt hinzuf\u00fcgt, den Firefox-Druckdialog verwenden oder PDF exportieren."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1314,6 +1314,10 @@
     "suffixFilament": "Filament",
     "exporting": "Exporting...",
     "pngExportFailed": "PNG export failed. Please check that all label images and logos loaded correctly.",
-    "pdfExportFailed": "PDF export failed. Please check that all label images and logos loaded correctly."
+    "pdfExportFailed": "PDF export failed. Please check that all label images and logos loaded correctly.",
+    "printHelpTitle": "Printing issues?",
+    "printHelpIntro": "For small labels, use 100% scale and the exact matching paper size.",
+    "printHelpBrave": "Brave: if output is blank, offset, or clipped, use Export PDF or a slightly smaller matching label size.",
+    "printHelpFirefox": "Firefox: if the system dialog adds a blank page, use Firefox's print dialog or Export PDF."
   }
 }


### PR DESCRIPTION
## Summary

- Prevents Chromium-family browsers from adding a trailing blank page to CSS-sized single-label print jobs by removing screen-only horizontal overflow in print media.
- Adds a compact **Printing issues?** control with detailed browser guidance hidden until hover or keyboard focus and omitted from print output.
- Disables spellcheck, autocomplete, autocorrect, and automatic capitalization consistently across all five Label Designer template inputs, including the custom QR URL template.
- Provides the new print-help text in English and German.

## Root cause and printing behavior

The single-label preview container retained `overflow-x: auto` in print media. Chromium could treat that scrollable screen container as additional printable overflow, producing a trailing blank page even when the label itself fit the configured CSS page size. The shared single-label print stylesheet now restores visible overflow for print output.

The change is shared by spool and filament single-label pages and applies to both Standard Label and Label Designer. Existing PNG/PDF export logic, batch rendering, zoom controls, and persisted label settings are unchanged.

## API and persistence compatibility

This is a frontend-only change. Native FilaMan API routes and schemas, Spoolman-compatible adapters, plugin registration, importers, backup/restore, database models and migrations, authentication, status codes, and stored JSON shapes are unchanged.

## Validation

- Rebased onto upstream `main` version `1.2.28` (`9724702`).
- Backend: 334 tests passed.
- Frontend: direct ESLint passed on all changed component files; `astro check` completed with 0 errors and 36 existing hints; production Astro build passed.
- Upstream `1.2.28` does not define a frontend unit-test script.
- Browser smoke used isolated seeded data on the exact rebased tree: login, spool detail, Standard Label, Label Designer, collapsed help, hover tooltip, and version display were verified.
- CSS-sized PDF verification on the exact rebased tree produced one page for both single-spool Standard Label and Label Designer.
- The broader review matrix also covered spool/filament, single/batch, and Standard/Designer output; all eight representative jobs produced one page without `[object Object]` or internal flattened-key leakage.
- `git diff --check` passed.

There is no database migration in this PR, so upgrade/downgrade and database-engine migration testing are not applicable.

## Screenshots

### Standard Label — compact help control in its normal collapsed state

<img width="1280" height="900" alt="Standard Label page with compact Printing issues control on upstream 1.2.28" src="https://github.com/user-attachments/assets/3d658118-2367-42f9-9954-d3cc9a444bc7" />

### Label Designer — troubleshooting tooltip on hover or keyboard focus

<img width="1280" height="900" alt="Label Designer page with print troubleshooting tooltip on upstream 1.2.28" src="https://github.com/user-attachments/assets/773445f4-51df-4fd9-a735-7aab3f5744b7" />

## Known constraint

Very small labels can still become crowded when many long fields are selected. The existing renderer clips or ellipsizes those values; changing field prioritization or layout policy is outside this focused pagination/help fix.
