### PR TITLE
feat: add rich extra field types

### DIFF
--- a/backend/alembic/versions/c9f2a1e4b7d3_add_config_to_system_extra_fields.py
+++ b/backend/alembic/versions/c9f2a1e4b7d3_add_config_to_system_extra_fields.py
@@ -1,0 +1,28 @@
+"""add config to system_extra_fields
+
+Revision ID: c9f2a1e4b7d3
+Revises: add_bambu_unmatched_fallback
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c9f2a1e4b7d3"
+down_revision: str | Sequence[str] | None = "add_bambu_unmatched_fallback"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("system_extra_fields", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("config", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("system_extra_fields", schema=None) as batch_op:
+        batch_op.drop_column("config")

--- a/backend/app/api/v1/schemas_system_extra_field.py
+++ b/backend/app/api/v1/schemas_system_extra_field.py
@@ -1,4 +1,75 @@
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+VALID_FIELD_TYPES = frozenset({
+    "text", "number", "range",
+    "dropdown", "checkbox", "formula",
+    "date", "url", "multiselect", "textarea",
+})
+
+CONFIG_KEYS_BY_TYPE = {
+    "number": {"unit", "decimal_places", "min_bound", "max_bound"},
+    "range": {"unit", "decimal_places", "min_bound", "max_bound"},
+    "textarea": {"max_length"},
+}
+
+
+def validate_field_type_config(
+    field_type: str,
+    options: list[str] | None,
+    config: dict[str, Any] | None,
+) -> None:
+    # multiselect is new, so requiring choices does not reject legacy payloads.
+    # Existing field types and option combinations remain accepted as before.
+    if field_type == "multiselect" and not options:
+        raise ValueError(f"options must be provided for field_type={field_type!r}")
+
+    if not config:
+        return
+
+    allowed_keys = CONFIG_KEYS_BY_TYPE.get(field_type, set())
+    unknown_keys = set(config) - allowed_keys
+    if unknown_keys:
+        raise ValueError(
+            f"Unsupported config keys for field_type={field_type!r}: {sorted(unknown_keys)}"
+        )
+
+    unit = config.get("unit")
+    if unit is not None and not isinstance(unit, str):
+        raise ValueError("config.unit must be a string")
+
+    decimal_places = config.get("decimal_places")
+    if decimal_places is not None and (
+        isinstance(decimal_places, bool)
+        or not isinstance(decimal_places, int)
+        or decimal_places < 0
+        or decimal_places > 10
+    ):
+        raise ValueError("config.decimal_places must be an integer from 0 to 10")
+
+    max_length = config.get("max_length")
+    if max_length is not None and (
+        isinstance(max_length, bool) or not isinstance(max_length, int) or max_length < 1
+    ):
+        raise ValueError("config.max_length must be a positive integer")
+
+    bounds: dict[str, int | float] = {}
+    for key in ("min_bound", "max_bound"):
+        value = config.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError(f"config.{key} must be a number")
+        bounds[key] = value
+
+    if (
+        field_type in {"number", "range"}
+        and "min_bound" in bounds
+        and "max_bound" in bounds
+        and bounds["min_bound"] >= bounds["max_bound"]
+    ):
+        raise ValueError("config.min_bound must be less than config.max_bound")
 
 
 class SystemExtraFieldBase(BaseModel):
@@ -7,16 +78,32 @@ class SystemExtraFieldBase(BaseModel):
     label: str = Field(..., description="Display label")
     default_value: str | None = Field(None, description="Default value if any")
     field_type: str = Field(
-        "text", description="Field type: text, number, dropdown, checkbox"
+        "text",
+        description=(
+            "Field type: text, number, range, dropdown, checkbox, "
+            "formula, date, url, multiselect, textarea"
+        ),
     )
-    options: list[str] | None = Field(None, description="Options for dropdown fields")
-
+    options: list[str] | None = Field(None, description="Options for dropdown/multiselect fields")
+    config: dict[str, Any] | None = Field(
+        None,
+        exclude_if=lambda value: value is None,
+        description=(
+            "Type-specific config. Supported keys: unit (str), decimal_places (int|null), "
+            "min_bound (number|null), max_bound (number|null), max_length (int|null)."
+        ),
+    )
 
 class SystemExtraFieldCreate(SystemExtraFieldBase):
     source: str | None = Field(
         None,
         description="Plugin source, e.g. 'bambulab'. Protected from manual deletion.",
     )
+
+    @model_validator(mode="after")
+    def validate_type_and_config(self) -> "SystemExtraFieldCreate":
+        validate_field_type_config(self.field_type, self.options, self.config)
+        return self
 
 
 class SystemExtraFieldUpdate(BaseModel):
@@ -25,14 +112,18 @@ class SystemExtraFieldUpdate(BaseModel):
     label: str | None = Field(None, description="Display label")
     default_value: str | None = Field(None, description="Default value if any")
     field_type: str | None = Field(
-        None, description="Field type: text, number, dropdown, checkbox"
+        None,
+        description=(
+            "Field type: text, number, range, dropdown, checkbox, "
+            "formula, date, url, multiselect, textarea."
+        ),
     )
-    options: list[str] | None = Field(None, description="Options for dropdown fields")
+    options: list[str] | None = Field(None, description="Options for dropdown/multiselect fields")
+    config: dict[str, Any] | None = Field(None, description="Type-specific config")
 
 
 class SystemExtraFieldResponse(SystemExtraFieldBase):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     source: str | None = None
-
-    class Config:
-        from_attributes = True

--- a/backend/app/api/v1/system_extra_fields.py
+++ b/backend/app/api/v1/system_extra_fields.py
@@ -2,15 +2,16 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.cache import response_cache
-from app.core.database import get_db
-from app.api.deps import RequirePermission, PrincipalDep
-from app.models.system_extra_field import SystemExtraField
+from app.api.deps import PrincipalDep, RequirePermission
 from app.api.v1.schemas_system_extra_field import (
     SystemExtraFieldCreate,
     SystemExtraFieldResponse,
     SystemExtraFieldUpdate,
+    validate_field_type_config,
 )
+from app.core.cache import response_cache
+from app.core.database import get_db
+from app.models.system_extra_field import SystemExtraField
 
 router = APIRouter()
 
@@ -115,6 +116,15 @@ async def update_system_extra_field(
 
     # Apply updates (only non-None values)
     update_dict = update_data.model_dump(exclude_unset=True)
+
+    effective_field_type = update_dict.get("field_type", field.field_type)
+    effective_options = update_dict.get("options", field.options)
+    effective_config = update_dict.get("config", field.config)
+    try:
+        validate_field_type_config(effective_field_type, effective_options, effective_config)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
     for key, value in update_dict.items():
         setattr(field, key, value)
 

--- a/backend/app/models/system_extra_field.py
+++ b/backend/app/models/system_extra_field.py
@@ -18,6 +18,8 @@ class SystemExtraField(Base, TimestampMixin):
     key: Mapped[str] = mapped_column(String(100), nullable=False)
     label: Mapped[str] = mapped_column(String(200), nullable=False)
     default_value: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    field_type: Mapped[str] = mapped_column(String(30), nullable=False, default="text")  # text, number, dropdown, checkbox
-    options: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)  # dropdown options
-    source: Mapped[str | None] = mapped_column(String(100), nullable=True)  # plugin ownership, e.g. "bambulab"
+    field_type: Mapped[str] = mapped_column(String(30), nullable=False, default="text")  # text, number, range, dropdown, checkbox, formula, date, url, multiselect, textarea
+    options: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)  # dropdown / multiselect options
+    source: Mapped[str | None] = mapped_column(String(100), nullable=True)  # plugin ownership
+    # Type-specific display/input config (unit, decimal_places, min_bound, max_bound, max_length)
+    config: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.cache import response_cache
 from app.core.database import async_session_maker
-from app.core.shared_health import shared_health_store
 from app.models import Printer
 from app.models.plugin import InstalledPlugin
 from app.models.filament import Filament, FilamentColor
@@ -527,7 +526,7 @@ class PluginManager:
 
             result = await db.execute(
                 select(Printer).where(
-                    Printer.is_active == True,
+                    Printer.is_active.is_(True),
                     Printer.deleted_at.is_(None),
                 )
             )
@@ -551,7 +550,7 @@ class PluginManager:
         async with async_session_maker() as db:
             result = await db.execute(
                 select(Printer).where(
-                    Printer.is_active == True,
+                    Printer.is_active.is_(True),
                     Printer.deleted_at.is_(None),
                 )
             )
@@ -670,6 +669,7 @@ class PluginManager:
                     "label": fdef["label"],
                     "field_type": fdef.get("field_type", "text"),
                     "options": options,
+                    "config": fdef.get("config"),
                 }
             )
 
@@ -710,6 +710,16 @@ class PluginManager:
                         if field.field_type != fdef["field_type"]:
                             field.field_type = fdef["field_type"]
                             changed = True
+                        db_config_json = json.dumps(
+                            field.config or {}, ensure_ascii=False, sort_keys=True
+                        )
+                        new_config_json = json.dumps(
+                            fdef["config"] or {}, ensure_ascii=False, sort_keys=True
+                        )
+                        if db_config_json != new_config_json:
+                            field.config = fdef["config"]
+                            flag_modified(field, "config")
+                            changed = True
                         if changed:
                             logger.info(
                                 f"Updated {target_type}/{fdef['key']} field definition"
@@ -722,6 +732,7 @@ class PluginManager:
                                 label=fdef["label"],
                                 field_type=fdef["field_type"],
                                 options=fdef["options"],
+                                config=fdef["config"],
                                 source=driver_key,
                             )
                         )

--- a/backend/tests/test_system_extra_fields_rich.py
+++ b/backend/tests/test_system_extra_fields_rich.py
@@ -1,0 +1,511 @@
+"""
+Tests for rich field types on SystemExtraField (feat/rich-field-types).
+
+Covers:
+  - Schema / Pydantic validator unit tests (no DB)
+  - API integration tests for all new field types
+  - config column roundtrip
+  - backwards compatibility for existing definition API payloads
+  - plugin-source protection
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.schemas_system_extra_field import (
+    VALID_FIELD_TYPES,
+    SystemExtraFieldCreate,
+    SystemExtraFieldResponse,
+)
+
+# ──────────────────────────────────────────────────────────────
+# Schema / validator unit tests  (pure Pydantic, no DB, no HTTP)
+# ──────────────────────────────────────────────────────────────
+
+
+class TestValidFieldTypes:
+    def test_all_10_types_present(self):
+        expected = {
+            "text", "number", "range",
+            "dropdown", "checkbox", "formula",
+            "date", "url", "multiselect", "textarea",
+        }
+        assert VALID_FIELD_TYPES == expected
+
+    def test_frozenset_immutable(self):
+        with pytest.raises(AttributeError):
+            VALID_FIELD_TYPES.add("invalid")  # type: ignore[attr-defined]
+
+
+class TestSchemaValidation:
+    """Unit tests for SystemExtraFieldCreate model_validator."""
+
+    def _base(self, **overrides):
+        defaults = {
+            "target_type": "filament",
+            "key": "test_field",
+            "label": "Test Field",
+            "field_type": "text",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    # ── valid field types ──
+
+    def test_valid_type_text(self):
+        SystemExtraFieldCreate(**self._base(field_type="text"))
+
+    def test_valid_type_number(self):
+        SystemExtraFieldCreate(**self._base(field_type="number"))
+
+    def test_valid_type_range(self):
+        SystemExtraFieldCreate(**self._base(field_type="range"))
+
+    def test_valid_type_date(self):
+        SystemExtraFieldCreate(**self._base(field_type="date"))
+
+    def test_valid_type_url(self):
+        SystemExtraFieldCreate(**self._base(field_type="url"))
+
+    def test_valid_type_textarea(self):
+        SystemExtraFieldCreate(**self._base(field_type="textarea"))
+
+    def test_valid_type_multiselect_with_options(self):
+        SystemExtraFieldCreate(**self._base(field_type="multiselect", options=["A", "B"]))
+
+    def test_valid_type_dropdown_with_options(self):
+        SystemExtraFieldCreate(**self._base(field_type="dropdown", options=["X", "Y"]))
+
+    # ── legacy API compatibility ──
+
+    def test_spoolman_style_integer_type_remains_accepted(self):
+        field = SystemExtraFieldCreate(**self._base(field_type="integer"))
+        assert field.field_type == "integer"
+
+    def test_unknown_field_type_remains_accepted(self):
+        field = SystemExtraFieldCreate(**self._base(field_type="freetext"))
+        assert field.field_type == "freetext"
+
+    def test_legacy_float_type_remains_accepted(self):
+        field = SystemExtraFieldCreate(**self._base(field_type="float"))
+        assert field.field_type == "float"
+
+    # ── options required for dropdown / multiselect ──
+
+    def test_dropdown_without_options_remains_accepted(self):
+        SystemExtraFieldCreate(**self._base(field_type="dropdown", options=None))
+
+    def test_dropdown_empty_options_remains_accepted(self):
+        SystemExtraFieldCreate(**self._base(field_type="dropdown", options=[]))
+
+    def test_multiselect_without_options_raises(self):
+        with pytest.raises(ValidationError, match="options must be provided"):
+            SystemExtraFieldCreate(**self._base(field_type="multiselect", options=None))
+
+    # ── range config bounds validation ──
+
+    def test_range_valid_bounds(self):
+        SystemExtraFieldCreate(**self._base(
+            field_type="range",
+            config={"min_bound": 0, "max_bound": 100},
+        ))
+
+    def test_range_min_equals_max_raises(self):
+        with pytest.raises(ValidationError, match="min_bound must be less than"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="range",
+                config={"min_bound": 10, "max_bound": 10},
+            ))
+
+    def test_range_min_greater_than_max_raises(self):
+        with pytest.raises(ValidationError, match="min_bound must be less than"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="range",
+                config={"min_bound": 50, "max_bound": 10},
+            ))
+
+    def test_number_min_greater_than_max_raises(self):
+        with pytest.raises(ValidationError, match="min_bound must be less than"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="number",
+                config={"min_bound": 50, "max_bound": 10},
+            ))
+
+    def test_range_config_none_is_valid(self):
+        """Range without config (no bounds) is allowed."""
+        SystemExtraFieldCreate(**self._base(field_type="range", config=None))
+
+    def test_range_partial_bounds_no_validation_error(self):
+        """Only min_bound or only max_bound is fine — both needed to compare."""
+        SystemExtraFieldCreate(**self._base(
+            field_type="range",
+            config={"min_bound": 10, "max_bound": None},
+        ))
+
+    # ── config is optional for scalar types ──
+
+    def test_number_config_with_unit_and_dp(self):
+        SystemExtraFieldCreate(**self._base(
+            field_type="number",
+            config={"unit": "mm", "decimal_places": 2},
+        ))
+
+    def test_text_config_none(self):
+        SystemExtraFieldCreate(**self._base(field_type="text", config=None))
+
+    def test_text_rejects_numeric_config(self):
+        with pytest.raises(ValidationError, match="Unsupported config keys"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="text",
+                config={"min_bound": 0},
+            ))
+
+    def test_text_with_options_remains_accepted(self):
+        SystemExtraFieldCreate(**self._base(
+            field_type="text",
+            options=["unused"],
+        ))
+
+    def test_textarea_with_max_length(self):
+        SystemExtraFieldCreate(**self._base(
+            field_type="textarea",
+            config={"max_length": 500},
+        ))
+
+    def test_number_rejects_non_numeric_bound(self):
+        with pytest.raises(ValidationError, match="min_bound must be a number"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="number",
+                config={"min_bound": "low"},
+            ))
+
+    def test_textarea_rejects_invalid_max_length(self):
+        with pytest.raises(ValidationError, match="max_length must be a positive integer"):
+            SystemExtraFieldCreate(**self._base(
+                field_type="textarea",
+                config={"max_length": 0},
+            ))
+
+    def test_response_allows_legacy_dropdown_without_options(self):
+        """Existing invalid rows must not make the list endpoint fail after migration."""
+        response = SystemExtraFieldResponse.model_validate({
+            **self._base(field_type="dropdown", options=None),
+            "id": 1,
+        })
+        assert response.options is None
+        assert "config" not in response.model_dump()
+
+
+# ──────────────────────────────────────────────────────────────
+# API integration tests
+# ──────────────────────────────────────────────────────────────
+
+_ENDPOINT = "/api/v1/system-extra-fields"
+
+
+async def _create_field(client, csrf_token, **overrides):
+    """Helper: POST a new system extra field and return the response JSON."""
+    payload = {
+        "target_type": "filament",
+        "key": "test_key",
+        "label": "Test Label",
+        "field_type": "text",
+    }
+    payload.update(overrides)
+    resp = await client.post(
+        _ENDPOINT,
+        json=payload,
+        headers={"X-CSRF-Token": csrf_token},
+    )
+    return resp
+
+
+class TestCreateRichFieldTypes:
+    @pytest.mark.asyncio
+    async def test_create_number_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="print_temp", label="Print Temp", field_type="number",
+            config={"unit": "°C", "decimal_places": 1},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["field_type"] == "number"
+        assert data["config"]["unit"] == "°C"
+        assert data["config"]["decimal_places"] == 1
+
+    @pytest.mark.asyncio
+    async def test_create_range_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="temp_range", label="Temp Range", field_type="range",
+            config={"unit": "°C", "min_bound": 0, "max_bound": 300},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["field_type"] == "range"
+        assert data["config"]["min_bound"] == 0
+        assert data["config"]["max_bound"] == 300
+
+    @pytest.mark.asyncio
+    async def test_create_date_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf, key="expire_date", label="Expiry", field_type="date",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["field_type"] == "date"
+
+    @pytest.mark.asyncio
+    async def test_create_url_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf, key="datasheet_url", label="Datasheet", field_type="url",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["field_type"] == "url"
+
+    @pytest.mark.asyncio
+    async def test_create_multiselect_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="tags", label="Tags", field_type="multiselect",
+            options=["PLA", "PETG", "ABS"],
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["field_type"] == "multiselect"
+        assert "PLA" in data["options"]
+
+    @pytest.mark.asyncio
+    async def test_create_textarea_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="notes", label="Notes", field_type="textarea",
+            config={"max_length": 500},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["field_type"] == "textarea"
+        assert data["config"]["max_length"] == 500
+
+    @pytest.mark.asyncio
+    async def test_create_unknown_type_preserves_existing_api_behavior(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf, key="bad_field", label="Bad", field_type="integer",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["field_type"] == "integer"
+
+    @pytest.mark.asyncio
+    async def test_create_multiselect_without_options_returns_422(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="no_opts", label="No Options", field_type="multiselect",
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_range_invalid_bounds_returns_422(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf,
+            key="bad_range", label="Bad Range", field_type="range",
+            config={"min_bound": 100, "max_bound": 10},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_config_null_for_text_field(self, auth_client):
+        client, csrf = auth_client
+        resp = await _create_field(
+            client, csrf, key="plain_text", label="Plain", field_type="text",
+        )
+        assert resp.status_code == 200
+        assert "config" not in resp.json()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_key_returns_400(self, auth_client):
+        client, csrf = auth_client
+        await _create_field(client, csrf, key="dupe_key", label="First", field_type="text")
+        resp = await _create_field(client, csrf, key="dupe_key", label="Second", field_type="text")
+        assert resp.status_code == 400
+
+
+class TestFieldTypeUpdates:
+    @pytest.mark.asyncio
+    async def test_change_field_type_preserves_existing_api_behavior(self, auth_client):
+        client, csrf = auth_client
+        create_resp = await _create_field(
+            client, csrf, key="immutable_type", label="Immut", field_type="text",
+        )
+        assert create_resp.status_code == 200
+        field_id = create_resp.json()["id"]
+
+        patch_resp = await client.put(
+            f"{_ENDPOINT}/{field_id}",
+            json={"field_type": "number"},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["field_type"] == "number"
+
+    @pytest.mark.asyncio
+    async def test_update_same_field_type_is_allowed(self, auth_client):
+        """Sending the same field_type in an update remains supported."""
+        client, csrf = auth_client
+        create_resp = await _create_field(
+            client, csrf, key="same_type", label="Same", field_type="text",
+        )
+        assert create_resp.status_code == 200
+        field_id = create_resp.json()["id"]
+
+        patch_resp = await client.put(
+            f"{_ENDPOINT}/{field_id}",
+            json={"label": "Updated Label", "field_type": "text"},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["label"] == "Updated Label"
+
+    @pytest.mark.asyncio
+    async def test_update_config_without_changing_type(self, auth_client):
+        client, csrf = auth_client
+        create_resp = await _create_field(
+            client, csrf,
+            key="upd_cfg", label="Update Config", field_type="number",
+            config={"unit": "mm", "decimal_places": 1},
+        )
+        assert create_resp.status_code == 200
+        field_id = create_resp.json()["id"]
+
+        patch_resp = await client.put(
+            f"{_ENDPOINT}/{field_id}",
+            json={"config": {"unit": "cm", "decimal_places": 2}},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert patch_resp.status_code == 200
+        updated = patch_resp.json()
+        assert updated["config"]["unit"] == "cm"
+        assert updated["config"]["decimal_places"] == 2
+
+    @pytest.mark.asyncio
+    async def test_update_invalid_range_config_returns_422(self, auth_client):
+        client, csrf = auth_client
+        create_resp = await _create_field(
+            client, csrf,
+            key="upd_range", label="Update Range", field_type="range",
+            config={"min_bound": 0, "max_bound": 100},
+        )
+        assert create_resp.status_code == 200
+        field_id = create_resp.json()["id"]
+
+        patch_resp = await client.put(
+            f"{_ENDPOINT}/{field_id}",
+            json={"config": {"min_bound": 100, "max_bound": 10}},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert patch_resp.status_code == 422
+        assert "min_bound must be less than" in patch_resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_multiselect_options_cannot_be_cleared(self, auth_client):
+        client, csrf = auth_client
+        create_resp = await _create_field(
+            client, csrf,
+            key="upd_multi", label="Update Multi", field_type="multiselect",
+            options=["A", "B"],
+        )
+        assert create_resp.status_code == 200
+        field_id = create_resp.json()["id"]
+
+        patch_resp = await client.put(
+            f"{_ENDPOINT}/{field_id}",
+            json={"options": []},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert patch_resp.status_code == 422
+        assert "options must be provided" in patch_resp.json()["detail"]
+
+
+class TestPluginFieldProtection:
+    @pytest.mark.asyncio
+    async def test_plugin_field_cannot_be_edited(self, auth_client, db_session):
+        """A field with source set must return 403 on PUT."""
+        from app.models.system_extra_field import SystemExtraField
+
+        field = SystemExtraField(
+            target_type="filament",
+            key="plugin_field",
+            label="Plugin Field",
+            field_type="text",
+            source="test_plugin",
+        )
+        db_session.add(field)
+        await db_session.commit()
+        await db_session.refresh(field)
+
+        client, csrf = auth_client
+        resp = await client.put(
+            f"{_ENDPOINT}/{field.id}",
+            json={"label": "Hacked"},
+            headers={"X-CSRF-Token": csrf},
+        )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_plugin_field_can_be_read(self, auth_client, db_session):
+        from app.models.system_extra_field import SystemExtraField
+
+        field = SystemExtraField(
+            target_type="spool",
+            key="plugin_spool_field",
+            label="Plugin Spool",
+            field_type="text",
+            source="test_plugin",
+        )
+        db_session.add(field)
+        await db_session.commit()
+        await db_session.refresh(field)
+
+        client, _ = auth_client
+        resp = await client.get(f"{_ENDPOINT}?target_type=spool")
+        assert resp.status_code == 200
+        keys = [f["key"] for f in resp.json()]
+        assert "plugin_spool_field" in keys
+
+
+class TestGetReturnsConfigField:
+    @pytest.mark.asyncio
+    async def test_get_list_includes_config(self, auth_client):
+        client, csrf = auth_client
+        await _create_field(
+            client, csrf,
+            key="cfg_check", label="Config Check", field_type="number",
+            config={"unit": "kg", "decimal_places": 3},
+        )
+        resp = await client.get(f"{_ENDPOINT}?target_type=filament")
+        assert resp.status_code == 200
+        items = resp.json()
+        match = next((f for f in items if f["key"] == "cfg_check"), None)
+        assert match is not None
+        assert "config" in match
+        assert match["config"]["unit"] == "kg"
+
+    @pytest.mark.asyncio
+    async def test_get_returns_config_none_for_unset(self, auth_client):
+        client, csrf = auth_client
+        await _create_field(
+            client, csrf, key="no_cfg", label="No Config", field_type="text",
+        )
+        resp = await client.get(f"{_ENDPOINT}?target_type=filament")
+        assert resp.status_code == 200
+        match = next((f for f in resp.json() if f["key"] == "no_cfg"), None)
+        assert match is not None
+        assert "config" not in match

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "eslint": "^9.26.0",
         "eslint-plugin-astro": "^1.3.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.32.0"
+        "typescript-eslint": "^8.32.0",
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@astrojs/check": {
@@ -97,14 +98,14 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.8.tgz",
-      "integrity": "sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==",
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
+      "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.13.1",
-        "@astrojs/yaml2ts": "^0.2.3",
+        "@astrojs/yaml2ts": "^0.2.4",
         "@jridgewell/sourcemap-codec": "^1.5.5",
         "@volar/kit": "~2.4.28",
         "@volar/language-core": "~2.4.28",
@@ -212,13 +213,13 @@
       }
     },
     "node_modules/@astrojs/yaml2ts": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
-      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1981,6 +1982,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -2292,6 +2300,17 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2300,6 +2319,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2661,6 +2687,119 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
@@ -2920,6 +3059,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -3213,6 +3362,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3449,6 +3608,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4233,6 +4399,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6402,6 +6578,17 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -6635,6 +6822,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -7372,6 +7566,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7409,6 +7610,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -7427,6 +7635,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -7604,6 +7819,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7627,6 +7849,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8675,6 +8907,103 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
@@ -8963,6 +9292,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
+    "test": "vitest run",
     "lint": "eslint 'src/pages/spools/[id]/index.astro' 'src/pages/spools/[id]/print.astro' 'src/pages/spools/print.astro' 'src/pages/filaments/[id]/index.astro' 'src/pages/filaments/[id]/print.astro' 'src/pages/filaments/print.astro' 'src/components/LabelDesignerEditor.astro' 'src/components/LabelSheetOutputSettings.astro' 'src/components/SingleLabelPrintStyles.astro' 'src/components/StandardLabelSettingsPanel.astro' 'src/components/BatchLabelPrintStyles.astro' 'src/lib/label-template.ts' 'src/lib/label-export.ts' 'src/lib/label-designer.ts' 'src/lib/label-designer-editor.ts' 'src/lib/label-standard.ts' 'src/lib/filament-label-data.ts' 'src/lib/label-extra-fields.ts' 'src/lib/label-print-page.ts' 'src/lib/label-print-style.ts' 'src/lib/label-sheet.ts' 'src/lib/qr-code.ts' --no-error-on-unmatched-pattern"
   },
   "devDependencies": {
@@ -15,7 +16,8 @@
     "eslint": "^9.26.0",
     "eslint-plugin-astro": "^1.3.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.32.0"
+    "typescript-eslint": "^8.32.0",
+    "vitest": "^4.1.6"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.3",

--- a/frontend/src/lib/extra-fields.test.ts
+++ b/frontend/src/lib/extra-fields.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect } from 'vitest'
+import {
+  escapeHtml,
+  dpToStep,
+  collectSystemFieldValues,
+  unflattenFieldValues,
+  renderFieldInput,
+  renderFieldDisplay,
+  renderFieldPlainText,
+  renderUnknownFieldPlainText,
+  type SystemExtraFieldDef,
+} from './extra-fields'
+
+// ── helper factories ─────────────────────────────────────────────────────────
+
+function field(overrides: Partial<SystemExtraFieldDef> & { field_type: string }): SystemExtraFieldDef {
+  return {
+    id: 1,
+    key: 'test_key',
+    label: 'Test Label',
+    ...overrides,
+  }
+}
+
+// ── escapeHtml ───────────────────────────────────────────────────────────────
+
+describe('escapeHtml', () => {
+  it('returns empty string for null', () => {
+    expect(escapeHtml(null)).toBe('')
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(escapeHtml(undefined)).toBe('')
+  })
+
+  it('escapes ampersand', () => {
+    expect(escapeHtml('a & b')).toBe('a &amp; b')
+  })
+
+  it('escapes less-than', () => {
+    expect(escapeHtml('<script>')).toBe('&lt;script&gt;')
+  })
+
+  it('escapes double quotes', () => {
+    expect(escapeHtml('"quoted"')).toBe('&quot;quoted&quot;')
+  })
+
+  it('escapes single quotes', () => {
+    expect(escapeHtml("it's")).toBe('it&#x27;s')
+  })
+
+  it('leaves safe strings unchanged', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123')
+  })
+
+  it('handles all special chars together', () => {
+    const result = escapeHtml('<a href="x" data-y=\'z\'>&</a>')
+    expect(result).not.toContain('<')
+    expect(result).not.toContain('>')
+    expect(result).not.toContain('"')
+    expect(result).not.toContain("'")
+    expect(result).toContain('&amp;')
+    expect(result).toContain('&lt;')
+    expect(result).toContain('&gt;')
+  })
+})
+
+// ── dpToStep ─────────────────────────────────────────────────────────────────
+
+describe('dpToStep', () => {
+  it('returns "any" for null', () => {
+    expect(dpToStep(null)).toBe('any')
+  })
+
+  it('returns "any" for undefined', () => {
+    expect(dpToStep(undefined)).toBe('any')
+  })
+
+  it('returns "1" for 0 decimal places', () => {
+    expect(dpToStep(0)).toBe('1')
+  })
+
+  it('returns "0.1" for 1 decimal place', () => {
+    expect(dpToStep(1)).toBe('0.1')
+  })
+
+  it('returns "0.01" for 2 decimal places', () => {
+    expect(dpToStep(2)).toBe('0.01')
+  })
+
+  it('returns "0.001" for 3 decimal places', () => {
+    expect(dpToStep(3)).toBe('0.001')
+  })
+})
+
+// ── renderFieldInput ─────────────────────────────────────────────────────────
+
+describe('renderFieldInput — number (and legacy float alias)', () => {
+  it('renders number input for type "number"', () => {
+    const html = renderFieldInput(field({ field_type: 'number' }), null)
+    expect(html).toContain('type="number"')
+    expect(html).toContain('data-key="test_key"')
+    expect(html).toContain('data-type="number"')
+  })
+
+  it('still renders correctly for legacy type "float"', () => {
+    const html = renderFieldInput(field({ field_type: 'float' }), null)
+    expect(html).toContain('type="number"')
+    expect(html).toContain('data-type="float"')
+  })
+
+  it('includes unit span when unit is configured', () => {
+    const html = renderFieldInput(field({ field_type: 'number', config: { unit: 'mm' } }), null)
+    expect(html).toContain('mm')
+    expect(html).toContain('display:flex')
+  })
+
+  it('sets step="any" when decimal_places is null', () => {
+    const html = renderFieldInput(field({ field_type: 'number' }), null)
+    expect(html).toContain('step="any"')
+  })
+
+  it('sets step="0.01" for 2 decimal places', () => {
+    const html = renderFieldInput(field({ field_type: 'number', config: { decimal_places: 2 } }), null)
+    expect(html).toContain('step="0.01"')
+  })
+
+  it('includes min attr from config', () => {
+    const html = renderFieldInput(field({ field_type: 'number', config: { min_bound: 10 } }), null)
+    expect(html).toContain('min="10"')
+  })
+
+  it('includes max attr from config', () => {
+    const html = renderFieldInput(field({ field_type: 'number', config: { max_bound: 999 } }), null)
+    expect(html).toContain('max="999"')
+  })
+
+  it('prefills value from rawValue', () => {
+    const html = renderFieldInput(field({ field_type: 'number' }), 42.5)
+    expect(html).toContain('value="42.5"')
+  })
+
+  it('prefills value from flat fallback', () => {
+    const html = renderFieldInput(field({ field_type: 'number' }), null, { test_key: 3.14 })
+    expect(html).toContain('value="3.14"')
+  })
+})
+
+describe('renderFieldInput — range', () => {
+  it('renders two number inputs', () => {
+    const html = renderFieldInput(field({ field_type: 'range' }), null)
+    const count = (html.match(/<input type="number"/g) ?? []).length
+    expect(count).toBe(2)
+  })
+
+  it('uses .min data-key for first input', () => {
+    const html = renderFieldInput(field({ field_type: 'range' }), null)
+    expect(html).toContain('data-key="test_key.min"')
+  })
+
+  it('uses .max data-key for second input', () => {
+    const html = renderFieldInput(field({ field_type: 'range' }), null)
+    expect(html).toContain('data-key="test_key.max"')
+  })
+
+  it('populates min/max from rawValue object', () => {
+    const html = renderFieldInput(field({ field_type: 'range' }), { min: 100, max: 250 })
+    expect(html).toContain('value="100"')
+    expect(html).toContain('value="250"')
+  })
+
+  it('populates min/max from flat fallback', () => {
+    const html = renderFieldInput(field({ field_type: 'range' }), null, {
+      'test_key.min': 5,
+      'test_key.max': 15,
+    })
+    expect(html).toContain('value="5"')
+    expect(html).toContain('value="15"')
+  })
+
+  it('shows unit for range with unit config', () => {
+    const html = renderFieldInput(field({ field_type: 'range', config: { unit: '°C' } }), null)
+    expect(html).toContain('°C')
+  })
+})
+
+describe('collectSystemFieldValues', () => {
+  function rootWith(scalars: any[], multiselect: any[] = []): ParentNode {
+    return {
+      querySelectorAll: (selector: string) => selector === '.system-field-input' ? scalars : multiselect,
+    } as unknown as ParentNode
+  }
+
+  it('collects scalar, numeric, checkbox, and multiselect values centrally', () => {
+    const result = collectSystemFieldValues(rootWith([
+      { dataset: { key: 'name', type: 'text' }, value: 'PLA' },
+      { dataset: { key: 'temp', type: 'number' }, value: '215.5' },
+      { dataset: { key: 'enabled', type: 'checkbox' }, checked: true, value: '' },
+    ], [
+      { dataset: { key: 'tags' }, checked: true, value: 'Matte' },
+      { dataset: { key: 'tags' }, checked: false, value: 'Silk' },
+    ]))
+
+    expect(result).toEqual({
+      flat: { name: 'PLA', temp: 215.5, enabled: 'true' },
+      direct: { tags: ['Matte'] },
+    })
+  })
+
+  it('rejects a range whose minimum exceeds its maximum', () => {
+    let clearFromMin: (() => void) | undefined
+    const maxInput = {
+      dataset: { key: 'temps.max', type: 'number', rangeKey: 'temps', rangeEnd: 'max' },
+      value: '100',
+      setCustomValidity(message: string) { this.validationMessage = message },
+      addEventListener() {},
+      reportValidity() {},
+      validationMessage: '',
+    }
+    const result = collectSystemFieldValues(rootWith([
+      {
+        dataset: { key: 'temps.min', type: 'number', rangeKey: 'temps', rangeEnd: 'min' },
+        value: '200',
+        addEventListener(_event: string, listener: () => void) { clearFromMin = listener },
+      },
+      maxInput,
+    ]))
+
+    expect(result).toBeNull()
+    expect(maxInput.validationMessage).toContain('Maximum')
+    clearFromMin?.()
+    expect(maxInput.validationMessage).toBe('')
+  })
+})
+
+describe('unflattenFieldValues', () => {
+  it('builds range objects without coercing typed values', () => {
+    expect(unflattenFieldValues({
+      'temps.min': 190.5,
+      'temps.max': 220,
+      numeric_text: '00123',
+    })).toEqual({
+      temps: { min: 190.5, max: 220 },
+      numeric_text: '00123',
+    })
+  })
+})
+
+describe('renderFieldInput — date', () => {
+  it('renders date input', () => {
+    const html = renderFieldInput(field({ field_type: 'date' }), null)
+    expect(html).toContain('type="date"')
+    expect(html).toContain('data-type="date"')
+  })
+
+  it('prefills date value', () => {
+    const html = renderFieldInput(field({ field_type: 'date' }), '2024-06-15')
+    expect(html).toContain('value="2024-06-15"')
+  })
+})
+
+describe('renderFieldInput — url', () => {
+  it('renders url input', () => {
+    const html = renderFieldInput(field({ field_type: 'url' }), null)
+    expect(html).toContain('type="url"')
+    expect(html).toContain('placeholder="https://"')
+  })
+})
+
+describe('renderFieldInput — multiselect', () => {
+  const opts = ['Red', 'Green', 'Blue']
+
+  it('renders a checkbox per option', () => {
+    const html = renderFieldInput(field({ field_type: 'multiselect', options: opts }), [])
+    const count = (html.match(/type="checkbox"/g) ?? []).length
+    expect(count).toBe(3)
+  })
+
+  it('uses system-field-input-multi class', () => {
+    const html = renderFieldInput(field({ field_type: 'multiselect', options: opts }), [])
+    expect(html).toContain('system-field-input-multi')
+  })
+
+  it('marks selected options as checked', () => {
+    const html = renderFieldInput(field({ field_type: 'multiselect', options: opts }), ['Green'])
+    // Green should be checked, Red should not
+    expect(html).toContain('" checked')
+    const greenChecked = html.match(/value="Green"([^>]*)/)?.[0] ?? ''
+    expect(greenChecked).toContain('checked')
+  })
+
+  it('handles empty rawValue array', () => {
+    const html = renderFieldInput(field({ field_type: 'multiselect', options: opts }), [])
+    expect(html).not.toContain(' checked')
+  })
+
+  it('handles null options gracefully', () => {
+    const html = renderFieldInput(field({ field_type: 'multiselect', options: null }), [])
+    expect(html).toContain('flex-direction:column')
+  })
+})
+
+describe('renderFieldInput — textarea', () => {
+  it('renders textarea element', () => {
+    const html = renderFieldInput(field({ field_type: 'textarea' }), null)
+    expect(html).toContain('<textarea')
+    expect(html).toContain('data-type="textarea"')
+  })
+
+  it('uses max_length from config', () => {
+    const html = renderFieldInput(field({ field_type: 'textarea', config: { max_length: 200 } }), null)
+    expect(html).toContain('maxlength="200"')
+  })
+
+  it('defaults maxlength to 2000', () => {
+    const html = renderFieldInput(field({ field_type: 'textarea' }), null)
+    expect(html).toContain('maxlength="2000"')
+  })
+
+  it('includes prefilled value', () => {
+    const html = renderFieldInput(field({ field_type: 'textarea' }), 'some notes')
+    expect(html).toContain('some notes')
+  })
+})
+
+describe('renderFieldInput — checkbox', () => {
+  it('renders checkbox input', () => {
+    const html = renderFieldInput(field({ field_type: 'checkbox', label: 'Enabled' }), null)
+    expect(html).toContain('type="checkbox"')
+  })
+
+  it('includes field label', () => {
+    const html = renderFieldInput(field({ field_type: 'checkbox', label: 'Enabled' }), null)
+    expect(html).toContain('Enabled')
+  })
+
+  it('sets checked for true string', () => {
+    const html = renderFieldInput(field({ field_type: 'checkbox', label: 'L' }), 'true')
+    expect(html).toContain(' checked')
+  })
+
+  it('sets checked for boolean true', () => {
+    const html = renderFieldInput(field({ field_type: 'checkbox', label: 'L' }), true)
+    expect(html).toContain(' checked')
+  })
+
+  it('does not set checked for false', () => {
+    const html = renderFieldInput(field({ field_type: 'checkbox', label: 'L' }), false)
+    expect(html).not.toContain(' checked')
+  })
+})
+
+describe('renderFieldInput — dropdown', () => {
+  it('renders select element', () => {
+    const html = renderFieldInput(field({ field_type: 'dropdown', options: ['A', 'B'] }), null)
+    expect(html).toContain('<select')
+    expect(html).toContain('data-type="dropdown"')
+  })
+
+  it('renders one option per value plus empty default', () => {
+    const html = renderFieldInput(field({ field_type: 'dropdown', options: ['X', 'Y'] }), null)
+    const count = (html.match(/<option/g) ?? []).length
+    expect(count).toBe(3) // empty + X + Y
+  })
+
+  it('marks matching option as selected', () => {
+    const html = renderFieldInput(field({ field_type: 'dropdown', options: ['A', 'B', 'C'] }), 'B')
+    expect(html).toContain('value="B" selected')
+  })
+})
+
+describe('renderFieldInput — formula', () => {
+  it('renders computed span', () => {
+    const html = renderFieldInput(field({ field_type: 'formula' }), null)
+    expect(html).toContain('(computed)')
+  })
+})
+
+describe('renderFieldInput — text (default)', () => {
+  it('renders text input for type "text"', () => {
+    const html = renderFieldInput(field({ field_type: 'text' }), null)
+    expect(html).toContain('type="text"')
+    expect(html).toContain('data-type="text"')
+  })
+
+  it('renders text input for unknown type', () => {
+    const html = renderFieldInput(field({ field_type: 'unknown_future_type' }), null)
+    expect(html).toContain('type="text"')
+  })
+})
+
+describe('renderFieldInput — XSS safety', () => {
+  it('escapes key in data-key attribute', () => {
+    const html = renderFieldInput(field({ field_type: 'text', key: '"><script>' }), null)
+    expect(html).not.toContain('<script>')
+  })
+
+  it('escapes value to prevent XSS', () => {
+    const html = renderFieldInput(field({ field_type: 'text' }), '<img onerror=alert(1)>')
+    expect(html).not.toContain('<img')
+  })
+})
+
+// ── renderFieldDisplay ───────────────────────────────────────────────────────
+
+describe('renderFieldDisplay — null / undefined', () => {
+  it('returns em-dash for null', () => {
+    expect(renderFieldDisplay(field({ field_type: 'text' }), null)).toBe('—')
+  })
+
+  it('returns em-dash for undefined', () => {
+    expect(renderFieldDisplay(field({ field_type: 'text' }), undefined)).toBe('—')
+  })
+})
+
+describe('renderFieldDisplay — number', () => {
+  it('formats number with decimal places', () => {
+    const html = renderFieldDisplay(field({ field_type: 'number', config: { decimal_places: 2 } }), 3.14159)
+    expect(html).toContain('3.14')
+  })
+
+  it('shows number without unit when config absent', () => {
+    const html = renderFieldDisplay(field({ field_type: 'number' }), 42)
+    expect(html).toContain('42')
+    expect(html).not.toContain('<span style')
+  })
+
+  it('appends unit span when unit configured', () => {
+    const html = renderFieldDisplay(field({ field_type: 'number', config: { unit: 'kg' } }), 1.5)
+    expect(html).toContain('kg')
+  })
+
+  it('returns string for non-numeric value', () => {
+    const html = renderFieldDisplay(field({ field_type: 'number' }), 'not-a-number')
+    expect(html).toContain('not-a-number')
+  })
+
+  it('does not partially parse malformed numeric strings', () => {
+    expect(renderFieldDisplay(field({ field_type: 'number' }), '12abc')).toBe('12abc')
+  })
+})
+
+describe('renderFieldDisplay — range', () => {
+  it('renders min–max with en dash', () => {
+    const html = renderFieldDisplay(field({ field_type: 'range' }), { min: 100, max: 250 })
+    expect(html).toContain('100')
+    expect(html).toContain('250')
+    expect(html).toContain('–')
+  })
+
+  it('applies decimal places to both bounds', () => {
+    const html = renderFieldDisplay(
+      field({ field_type: 'range', config: { decimal_places: 1 } }),
+      { min: 100, max: 250 }
+    )
+    expect(html).toContain('100.0')
+    expect(html).toContain('250.0')
+  })
+
+  it('returns string for non-object value', () => {
+    const result = renderFieldDisplay(field({ field_type: 'range' }), 'not-an-object')
+    expect(result).toContain('not-an-object')
+  })
+})
+
+describe('renderFieldDisplay — date', () => {
+  it('wraps date string in span', () => {
+    const html = renderFieldDisplay(field({ field_type: 'date' }), '2024-06-15')
+    expect(html).toContain('2024-06-15')
+    expect(html).toContain('<span>')
+  })
+})
+
+describe('renderFieldDisplay — url', () => {
+  it('renders anchor tag', () => {
+    const html = renderFieldDisplay(field({ field_type: 'url' }), 'https://example.com')
+    expect(html).toContain('<a href="https://example.com"')
+    expect(html).toContain('target="_blank"')
+    expect(html).toContain('rel="noopener noreferrer"')
+  })
+
+  it('renders unsafe URL schemes as plain text', () => {
+    const html = renderFieldDisplay(field({ field_type: 'url' }), 'javascript:alert(1)')
+    expect(html).not.toContain('href="javascript:')
+    expect(html).not.toContain('<a ')
+    expect(html).toContain('javascript:alert(1)')
+  })
+
+  it('renders malformed HTTP URLs as plain text', () => {
+    const html = renderFieldDisplay(field({ field_type: 'url' }), 'https://')
+    expect(html).toBe('https://')
+  })
+})
+
+describe('renderFieldDisplay — multiselect', () => {
+  it('wraps each value in fm-pill span', () => {
+    const html = renderFieldDisplay(field({ field_type: 'multiselect' }), ['PLA', 'PETG'])
+    expect(html).toContain('class="fm-pill"')
+    expect(html).toContain('>PLA<')
+    expect(html).toContain('>PETG<')
+  })
+
+  it('returns string for non-array value', () => {
+    const result = renderFieldDisplay(field({ field_type: 'multiselect' }), 'not-array')
+    expect(result).toContain('not-array')
+  })
+})
+
+describe('renderFieldDisplay — textarea', () => {
+  it('wraps in pre-wrap div', () => {
+    const html = renderFieldDisplay(field({ field_type: 'textarea' }), 'line1\nline2')
+    expect(html).toContain('white-space:pre-wrap')
+    expect(html).toContain('line1\nline2')
+  })
+})
+
+describe('renderFieldDisplay — checkbox', () => {
+  it('returns checkmark for true', () => {
+    expect(renderFieldDisplay(field({ field_type: 'checkbox' }), true)).toBe('✓')
+  })
+
+  it('returns checkmark for string "true"', () => {
+    expect(renderFieldDisplay(field({ field_type: 'checkbox' }), 'true')).toBe('✓')
+  })
+
+  it('returns cross for false', () => {
+    expect(renderFieldDisplay(field({ field_type: 'checkbox' }), false)).toBe('✗')
+  })
+
+  it('returns cross for string "false"', () => {
+    expect(renderFieldDisplay(field({ field_type: 'checkbox' }), 'false')).toBe('✗')
+  })
+})
+
+describe('renderFieldDisplay — text (default)', () => {
+  it('returns escaped value', () => {
+    const result = renderFieldDisplay(field({ field_type: 'text' }), 'Hello <World>')
+    expect(result).toContain('&lt;World&gt;')
+    expect(result).not.toContain('<World>')
+  })
+})
+
+describe('renderFieldPlainText', () => {
+  it('formats numbers with configured decimals and unit for labels', () => {
+    const result = renderFieldPlainText(
+      field({ field_type: 'number', config: { decimal_places: 1, unit: 'g' } }),
+      215.55,
+    )
+    expect(result).toBe('215.6 g')
+  })
+
+  it('formats ranges without object stringification', () => {
+    const result = renderFieldPlainText(
+      field({ field_type: 'range', config: { decimal_places: 1, unit: '°C' } }),
+      { min: 190, max: 215 },
+    )
+    expect(result).toBe('190.0–215.0 °C')
+  })
+
+  it('formats multiselect values with readable separators', () => {
+    expect(renderFieldPlainText(field({ field_type: 'multiselect' }), ['Matte', 'Silk']))
+      .toBe('Matte, Silk')
+  })
+})
+
+describe('renderUnknownFieldPlainText', () => {
+  it('keeps unknown arrays at one readable top-level value', () => {
+    expect(renderUnknownFieldPlainText(['One', 'Two'])).toBe('One, Two')
+  })
+
+  it('keeps unknown range-like objects readable for labels', () => {
+    expect(renderUnknownFieldPlainText({ min: 12.5, max: 88.5 })).toBe('12.5–88.5')
+  })
+
+  it('serializes unknown objects without object stringification', () => {
+    expect(renderUnknownFieldPlainText({ alpha: 'A', beta: 'B' })).toBe('{"alpha":"A","beta":"B"}')
+  })
+})

--- a/frontend/src/lib/extra-fields.ts
+++ b/frontend/src/lib/extra-fields.ts
@@ -1,0 +1,365 @@
+/**
+ * Shared helpers for rendering system extra field inputs and display values.
+ * Used by filament/spool create, edit, and detail pages.
+ */
+
+export interface SystemExtraFieldDef {
+  id?: number
+  key: string
+  label: string
+  field_type?: string
+  options?: string[] | null
+  default_value?: string | null
+  config?: {
+    unit?: string
+    decimal_places?: number | null
+    min_bound?: number | null
+    max_bound?: number | null
+    max_length?: number | null
+  } | null
+}
+
+export function escapeHtml(s: string | null | undefined): string {
+  if (s == null) return ''
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+}
+
+/**
+ * Convert decimal_places config value to an HTML <input step> attribute value.
+ *   null/undefined → "any"
+ *   0             → "1"   (whole numbers)
+ *   n             → "0.0…01" with n decimal places
+ */
+export function dpToStep(dp: number | null | undefined): string {
+  if (dp == null) return 'any'
+  if (dp === 0) return '1'
+  return (1 / Math.pow(10, dp)).toFixed(dp)
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string' || value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function safeHttpUrl(value: unknown): string | null {
+  const candidate = String(value).trim()
+  try {
+    const protocol = new URL(candidate).protocol.toLowerCase()
+    return protocol === 'http:' || protocol === 'https:' ? candidate : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Estimate a good pixel width for a number <input> from its field config.
+ * Counts the expected digit count from min/max bounds and decimal places so
+ * the input is compact but wide enough for realistic values.
+ */
+function numberInputWidth(cfg: SystemExtraFieldDef['config']): number {
+  const c = cfg ?? {}
+  const absMax = Math.max(
+    c.max_bound != null ? Math.abs(c.max_bound) : 0,
+    c.min_bound != null ? Math.abs(c.min_bound) : 0,
+    99,
+  )
+  const intDigits = Math.floor(absMax).toString().length
+  const fracDigits = c.decimal_places ?? 0
+  // chars: sign + integer digits + optional '.' + fractional digits
+  const chars = 1 + intDigits + (fracDigits > 0 ? 1 + fracDigits : 0)
+  // 10px/char + 24px input padding + 20px for browser spin buttons; min 80px
+  return Math.max(80, chars * 10 + 44)
+}
+
+export interface CollectedSystemFieldValues {
+  flat: Record<string, unknown>
+  direct: Record<string, string[]>
+}
+
+/** Collect rendered controls once for all create/edit forms. */
+export function collectSystemFieldValues(root: ParentNode = document): CollectedSystemFieldValues | null {
+  const flat: Record<string, unknown> = {}
+  const direct: Record<string, string[]> = {}
+  const ranges = new Map<string, Partial<Record<'min' | 'max', HTMLInputElement>>>()
+
+  root.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('.system-field-input').forEach(input => {
+    const key = input.dataset.key
+    if (!key) return
+    if (input.dataset.type === 'checkbox') {
+      flat[key] = (input as HTMLInputElement).checked ? 'true' : 'false'
+    } else if (input.dataset.type === 'number') {
+      const value = input.value.trim()
+      if (value) flat[key] = Number(value)
+    } else {
+      const value = input.value.trim()
+      if (value) flat[key] = value
+    }
+
+    const rangeKey = input.dataset.rangeKey
+    const rangeEnd = input.dataset.rangeEnd as 'min' | 'max' | undefined
+    if (rangeKey && rangeEnd) {
+      const entries = ranges.get(rangeKey) ?? {}
+      entries[rangeEnd] = input as HTMLInputElement
+      ranges.set(rangeKey, entries)
+    }
+  })
+
+  for (const entries of ranges.values()) {
+    const min = entries.min
+    const max = entries.max
+    max?.setCustomValidity('')
+    if (min?.value && max?.value && Number(min.value) > Number(max.value)) {
+      max.setCustomValidity('Maximum must be greater than or equal to minimum.')
+      const clearRangeError = () => max.setCustomValidity('')
+      min.addEventListener('input', clearRangeError, { once: true })
+      max.addEventListener('input', clearRangeError, { once: true })
+      max.reportValidity()
+      return null
+    }
+  }
+
+  root.querySelectorAll<HTMLInputElement>('.system-field-input-multi').forEach(input => {
+    const key = input.dataset.key
+    if (!key) return
+    direct[key] ??= []
+    if (input.checked) direct[key].push(input.value)
+  })
+
+  return { flat, direct }
+}
+
+/** Expand dot-separated field paths while preserving already parsed value types. */
+export function unflattenFieldValues(flat: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [path, value] of Object.entries(flat)) {
+    const keys = path.split('.')
+    let current = result
+    keys.forEach((key, index) => {
+      if (index === keys.length - 1) {
+        current[key] = value
+      } else {
+        const child = current[key]
+        if (!child || typeof child !== 'object' || Array.isArray(child)) current[key] = {}
+        current = current[key] as Record<string, unknown>
+      }
+    })
+  }
+  return result
+}
+
+/**
+ * Render the appropriate <input> / <select> / <textarea> for a system extra field.
+ *
+ * @param field      Field definition from the API
+ * @param rawValue   Raw value from custom_fields[key] (object for range, array
+ *                   for multiselect, scalar otherwise). Pass null/undefined when
+ *                   creating a new record.
+ * @param flat       Flattened custom_fields (dot-notation). Used as fallback for
+ *                   scalar types and for range .min/.max when rawValue is absent.
+ */
+export function renderFieldInput(
+  field: SystemExtraFieldDef,
+  rawValue: unknown,
+  flat: Record<string, any> = {}
+): string {
+  const key = escapeHtml(field.key)
+  const cfg = field.config ?? {}
+  const dp = cfg.decimal_places ?? null
+  const step = dpToStep(dp)
+  const unit = cfg.unit ?? ''
+  const minAttr = cfg.min_bound != null ? ` min="${cfg.min_bound}"` : ''
+  const maxAttr = cfg.max_bound != null ? ` max="${cfg.max_bound}"` : ''
+  const unitHtml = unit
+    ? `<span style="color:var(--text-muted);font-size:0.85rem;flex-shrink:0">${escapeHtml(unit)}</span>`
+    : ''
+
+  const scalarVal =
+    rawValue != null
+      ? escapeHtml(String(rawValue))
+      : flat[field.key] != null
+        ? escapeHtml(String(flat[field.key]))
+        : ''
+  const displayVal = scalarVal || (field.default_value ? escapeHtml(field.default_value) : '')
+
+  switch (field.field_type) {
+    case 'float': // legacy alias — falls through
+    case 'number': {
+      const numW = numberInputWidth(cfg)
+      const numInput = `<input type="number" class="fm-input system-field-input" data-key="${key}" data-type="${escapeHtml(field.field_type)}" value="${displayVal}" step="${step}"${minAttr}${maxAttr} style="width:${numW}px" />`
+      if (unit) return `<div style="display:flex;align-items:center;gap:6px">${numInput}${unitHtml}</div>`
+      return numInput
+    }
+    case 'range': {
+      const rangeObj =
+        typeof rawValue === 'object' && rawValue !== null && !Array.isArray(rawValue)
+          ? (rawValue as Record<string, any>)
+          : {}
+      const minVal =
+        rangeObj.min != null
+          ? escapeHtml(String(rangeObj.min))
+          : flat[field.key + '.min'] != null
+            ? escapeHtml(String(flat[field.key + '.min']))
+            : ''
+      const maxVal =
+        rangeObj.max != null
+          ? escapeHtml(String(rangeObj.max))
+          : flat[field.key + '.max'] != null
+            ? escapeHtml(String(flat[field.key + '.max']))
+            : ''
+      const numW = numberInputWidth(cfg)
+      return (
+        `<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">` +
+        `<input type="number" class="fm-input system-field-input" data-key="${key}.min" data-type="number" data-range-key="${key}" data-range-end="min" placeholder="Min" value="${minVal}" step="${step}"${minAttr}${maxAttr} style="width:${numW}px;flex-shrink:0" />` +
+        `<span style="color:var(--text-muted)">–</span>` +
+        `<input type="number" class="fm-input system-field-input" data-key="${key}.max" data-type="number" data-range-key="${key}" data-range-end="max" placeholder="Max" value="${maxVal}" step="${step}"${minAttr}${maxAttr} style="width:${numW}px;flex-shrink:0" />` +
+        `${unitHtml}</div>`
+      )
+    }
+    case 'date':
+      return `<input type="date" class="fm-input system-field-input" data-key="${key}" data-type="date" value="${displayVal}" style="max-width:160px" />`
+    case 'url':
+      return `<input type="url" class="fm-input system-field-input" data-key="${key}" data-type="url" value="${displayVal}" placeholder="https://" />`
+    case 'multiselect': {
+      const selected: string[] = Array.isArray(rawValue) ? rawValue.map(String) : []
+      const opts = (field.options ?? [])
+        .map(opt => {
+          const esc = escapeHtml(opt)
+          const chk = selected.includes(opt) ? ' checked' : ''
+          return `<label style="display:flex;align-items:center;gap:6px;cursor:pointer"><input type="checkbox" class="system-field-input-multi" data-key="${key}" data-type="multiselect" value="${esc}"${chk} />${esc}</label>`
+        })
+        .join('')
+      return `<div style="display:flex;flex-direction:column;gap:4px">${opts}</div>`
+    }
+    case 'textarea': {
+      const maxLen = cfg.max_length ?? 2000
+      return `<textarea class="fm-input system-field-input" data-key="${key}" data-type="textarea" rows="3" maxlength="${maxLen}" style="resize:vertical">${displayVal}</textarea>`
+    }
+    case 'checkbox': {
+      const chk = displayVal === 'true' || rawValue === true ? ' checked' : ''
+      return `<label style="display:flex;align-items:center;gap:8px;cursor:pointer"><input type="checkbox" class="system-field-input" data-key="${key}" data-type="checkbox"${chk} /> ${escapeHtml(field.label)}</label>`
+    }
+    case 'dropdown': {
+      const optsHtml = (field.options ?? [])
+        .map(opt => {
+          const esc = escapeHtml(opt)
+          const sel = displayVal === esc ? ' selected' : ''
+          return `<option value="${esc}"${sel}>${esc}</option>`
+        })
+        .join('')
+      return `<select class="fm-select system-field-input" data-key="${key}" data-type="dropdown"><option value=""></option>${optsHtml}</select>`
+    }
+    case 'formula':
+      return `<span style="color:var(--text-muted);font-style:italic;font-size:0.9rem">(computed)</span>`
+    default: // text and unknown
+      return `<input type="text" class="fm-input system-field-input" data-key="${key}" data-type="text" value="${displayVal}" />`
+  }
+}
+
+/**
+ * Render a read-only display value for a system extra field.
+ * Returns an HTML string (safe for innerHTML).
+ */
+export function renderFieldDisplay(field: SystemExtraFieldDef, value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  const cfg = field.config ?? {}
+  const unit = cfg.unit ?? ''
+  const dp = cfg.decimal_places ?? null
+  const unitSpan = unit
+    ? ` <span style="color:var(--text-muted);font-size:0.85rem">${escapeHtml(unit)}</span>`
+    : ''
+
+  switch (field.field_type) {
+    case 'float': // legacy alias — falls through
+    case 'number': {
+      const num = finiteNumber(value)
+      if (num == null) return escapeHtml(String(value))
+      const formatted = dp != null ? num.toFixed(dp) : String(num)
+      return `<span>${escapeHtml(formatted)}${unitSpan}</span>`
+    }
+    case 'range': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value))
+        return escapeHtml(String(value))
+      const rv = value as Record<string, any>
+      const minNum = finiteNumber(rv.min)
+      const maxNum = finiteNumber(rv.max)
+      const minStr = minNum != null && dp != null ? minNum.toFixed(dp) : String(rv.min ?? '?')
+      const maxStr = maxNum != null && dp != null ? maxNum.toFixed(dp) : String(rv.max ?? '?')
+      return `<span>${escapeHtml(minStr)}–${escapeHtml(maxStr)}${unitSpan}</span>`
+    }
+    case 'date':
+      return `<span>${escapeHtml(String(value))}</span>`
+    case 'url': {
+      const url = String(value)
+      const safeSrc = safeHttpUrl(url)
+      if (!safeSrc) return escapeHtml(url)
+      return `<a href="${escapeHtml(safeSrc)}" target="_blank" rel="noopener noreferrer" style="color:var(--accent)">${escapeHtml(url)}</a>`
+    }
+    case 'multiselect':
+      if (!Array.isArray(value)) return escapeHtml(String(value))
+      return (value as any[]).map(v => `<span class="fm-pill">${escapeHtml(String(v))}</span>`).join(' ')
+    case 'textarea':
+      return `<div style="white-space:pre-wrap;font-size:0.9em">${escapeHtml(String(value))}</div>`
+    case 'checkbox':
+      return value === true || value === 'true' ? '✓' : '✗'
+    default:
+      return escapeHtml(String(value))
+  }
+}
+
+/**
+ * Render a system extra field for plain-text surfaces such as printed labels.
+ * This keeps label tokens from falling back to raw object/array stringification
+ * for rich field types like range and multiselect.
+ */
+export function renderFieldPlainText(field: SystemExtraFieldDef, value: unknown): string {
+  if (value === null || value === undefined) return ''
+  const cfg = field.config ?? {}
+  const unit = cfg.unit ? ` ${cfg.unit}` : ''
+  const dp = cfg.decimal_places ?? null
+
+  switch (field.field_type) {
+    case 'float': // legacy alias — falls through
+    case 'number': {
+      const num = finiteNumber(value)
+      if (num == null) return String(value)
+      return `${dp != null ? num.toFixed(dp) : String(num)}${unit}`
+    }
+    case 'range': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return renderUnknownFieldPlainText(value)
+      }
+      const rv = value as Record<string, unknown>
+      const minNum = finiteNumber(rv.min)
+      const maxNum = finiteNumber(rv.max)
+      const minStr = minNum != null && dp != null ? minNum.toFixed(dp) : String(rv.min ?? '')
+      const maxStr = maxNum != null && dp != null ? maxNum.toFixed(dp) : String(rv.max ?? '')
+      return `${minStr}–${maxStr}${unit}`.trim()
+    }
+    case 'multiselect':
+      return Array.isArray(value) ? value.map(String).join(', ') : String(value)
+    case 'checkbox':
+      return value === true || value === 'true' ? '✓' : '✗'
+    default:
+      return renderUnknownFieldPlainText(value)
+  }
+}
+
+export function renderUnknownFieldPlainText(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (Array.isArray(value)) return value.map(String).join(', ')
+  if (typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>
+    if ('min' in objectValue || 'max' in objectValue) {
+      return `${objectValue.min ?? ''}–${objectValue.max ?? ''}`.trim()
+    }
+    return JSON.stringify(value)
+  }
+  return String(value)
+}

--- a/frontend/src/lib/filament-label-data.ts
+++ b/frontend/src/lib/filament-label-data.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isBuiltInLabelField } from './label-extra-fields'
+import { renderFieldPlainText, renderUnknownFieldPlainText, type SystemExtraFieldDef } from './extra-fields'
 
 export interface FilamentLabelData {
   id: string
@@ -221,17 +222,18 @@ export function buildReducedStandardFilamentExtraFieldsFromLabelData(data: Filam
 
 export function buildFilamentExtraFieldsForPrint(
   filament: any,
-  systemFieldMap: Record<string, { label?: string }>,
+  systemFieldMap: Record<string, Partial<SystemExtraFieldDef> & { label?: string }>,
 ): FilamentExtraField[] {
   const fields = buildReducedStandardFilamentExtraFieldsFromLabelData(buildFilamentLabelDataFromApi(filament))
   const customFlat: Record<string, unknown> = filament?.custom_fields ?? {}
   for (const [key, def] of Object.entries(systemFieldMap)) {
     if (isBuiltInLabelField('filament', key, def.label)) continue
     const raw = customFlat[key]
+    const fieldDef = { ...def, key, label: def.label ?? key, field_type: def.field_type ?? 'text' } as SystemExtraFieldDef
     fields.push({
       key: `filament.${key}`,
       label: def.label ?? key,
-      value: toLabelString(raw),
+      value: renderFieldPlainText(fieldDef, raw),
       source: 'filament',
     })
   }
@@ -240,7 +242,7 @@ export function buildFilamentExtraFieldsForPrint(
       fields.push({
         key: `filament.${key}`,
         label: key,
-        value: toLabelString(value),
+        value: renderUnknownFieldPlainText(value),
         source: 'filament',
       })
     }
@@ -248,14 +250,21 @@ export function buildFilamentExtraFieldsForPrint(
   return fields
 }
 
-export function buildDesignerExtraFieldsFromFilament(filament: any): FilamentExtraField[] {
+export function buildDesignerExtraFieldsFromFilament(
+  filament: any,
+  systemFieldMap: Record<string, Partial<SystemExtraFieldDef> & { label?: string }> = {},
+): FilamentExtraField[] {
   const customFields = filament?.custom_fields ?? {}
   return Object.entries(customFields as Record<string, unknown>)
     .filter(([key]) => !isBuiltInLabelField('filament', key))
-    .map(([key, value]) => ({
-      key: `filament.${key}`,
-      label: key,
-      value: toLabelString(value),
-      source: 'filament',
-    }))
+    .map(([key, value]) => {
+      const def = systemFieldMap[key]
+      const fieldDef = def ? { ...def, key, label: def.label ?? key, field_type: def.field_type ?? 'text' } as SystemExtraFieldDef : null
+      return {
+        key: `filament.${key}`,
+        label: def?.label ?? key,
+        value: fieldDef ? renderFieldPlainText(fieldDef, value) : renderUnknownFieldPlainText(value),
+        source: 'filament',
+      }
+    })
 }

--- a/frontend/src/lib/label-designer.ts
+++ b/frontend/src/lib/label-designer.ts
@@ -6,6 +6,7 @@ import {
   type SpoolData,
 } from './label-template'
 import { isBuiltInLabelField, type LabelExtraFieldSource } from './label-extra-fields'
+import { renderFieldPlainText, renderUnknownFieldPlainText, type SystemExtraFieldDef } from './extra-fields'
 import { updateLabelPrintPageStyle } from './label-print-style'
 import { canvasToQrImage, ensureQrCodeLoaded, getQrCodeConstructor } from './qr-code'
 
@@ -346,6 +347,8 @@ export interface DesignerFlatLabelData {
   extraFields?: DesignerExtraField[]
 }
 
+type ExtraFieldDefinitionMap = Partial<Record<LabelExtraFieldSource, Record<string, SystemExtraFieldDef>>>
+
 function getApiFilamentColors(filament: any): any[] {
   const list = Array.isArray(filament?.filament_colors)
     ? filament.filament_colors
@@ -426,7 +429,7 @@ export function buildSpoolDataFromFlatLabel(data: DesignerFlatLabelData): SpoolD
   }
 }
 
-export function buildSpoolDataFromApiSpool(spool: any): SpoolData {
+export function buildSpoolDataFromApiSpool(spool: any, fieldDefs?: ExtraFieldDefinitionMap): SpoolData {
   const fil = spool?.filament ?? {}
   const firstColor = getFirstFilamentColor(fil)
   const color = firstColor?.display_name_override
@@ -478,14 +481,14 @@ export function buildSpoolDataFromApiSpool(spool: any): SpoolData {
     low_weight_threshold_g: spool?.low_weight_threshold_g,
     stocked_in_at: formatDate(spool?.stocked_in_at),
     last_used_at: formatDate(spool?.last_used_at),
-    extraFields: buildDesignerExtraFieldsFromApiSpool(spool),
+    extraFields: buildDesignerExtraFieldsFromApiSpool(spool, fieldDefs),
   })
 }
 
-export function buildDesignerExtraFieldsFromApiSpool(spool: any): DesignerExtraField[] {
+export function buildDesignerExtraFieldsFromApiSpool(spool: any, fieldDefs?: ExtraFieldDefinitionMap): DesignerExtraField[] {
   return [
-    ...flattenExtraFields(spool?.custom_fields, 'spool'),
-    ...flattenExtraFields(spool?.filament?.custom_fields, 'filament'),
+    ...flattenExtraFields(spool?.custom_fields, 'spool', '', fieldDefs?.spool),
+    ...flattenExtraFields(spool?.filament?.custom_fields, 'filament', '', fieldDefs?.filament),
   ]
 }
 
@@ -503,19 +506,25 @@ export function getFirstFilamentColor(filament: any): any {
   return {}
 }
 
-function flattenExtraFields(value: any, source: LabelExtraFieldSource, prefix = ''): DesignerExtraField[] {
+function flattenExtraFields(
+  value: any,
+  source: LabelExtraFieldSource,
+  prefix = '',
+  fieldDefs: Record<string, SystemExtraFieldDef> = {},
+): DesignerExtraField[] {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return []
   const fields: DesignerExtraField[] = []
   for (const [key, raw] of Object.entries(value)) {
     const path = prefix ? `${prefix}.${key}` : key
-    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-      fields.push(...flattenExtraFields(raw, source, path))
+    const fieldDef = fieldDefs[path]
+    if (raw && typeof raw === 'object' && !Array.isArray(raw) && fieldDef?.field_type !== 'range') {
+      fields.push(...flattenExtraFields(raw, source, path, fieldDefs))
     } else {
       if (isBuiltInLabelField(source, path)) continue
       fields.push({
         key: `${source}.${path}`,
         label: path,
-        value: raw,
+        value: fieldDef ? renderFieldPlainText(fieldDef, raw) : renderUnknownFieldPlainText(raw),
         source,
       })
     }

--- a/frontend/src/pages/admin/extra-fields.astro
+++ b/frontend/src/pages/admin/extra-fields.astro
@@ -73,18 +73,52 @@ import Layout from '../../layouts/Layout.astro'
           <select id="field-type" required class="fm-select">
             <option value="text">Text</option>
             <option value="number">Number</option>
+            <option value="range">Range (min–max)</option>
             <option value="dropdown">Dropdown</option>
+            <option value="multiselect">Multi-select</option>
             <option value="checkbox">Checkbox</option>
+            <option value="date">Date</option>
+            <option value="url">URL</option>
+            <option value="textarea">Text Area</option>
           </select>
         </div>
 
         <div id="options-container" style="display: none;">
-          <label for="field-options" class="fm-label"><span data-i18n="admin.dropdownOptions">Dropdown Options</span> *</label>
+          <label for="field-options" class="fm-label"><span id="options-label">Options</span> *</label>
           <textarea id="field-options" class="fm-input" rows="5" placeholder="One option per line&#10;e.g.&#10;Option A&#10;Option B&#10;Option C" style="resize: vertical;"></textarea>
           <small style="color: var(--text-muted); font-size: 0.75rem;" data-i18n="admin.dropdownOptionsHint">Enter one option per line.</small>
         </div>
+
+        <div id="numeric-config-container" style="display: none; flex-direction: column; gap: 10px; border: 1px solid var(--border); border-radius: 6px; padding: 12px; background: var(--bg-soft);">
+          <div style="font-size: 0.8rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Field Config</div>
+          <div style="display: flex; gap: 12px; align-items: flex-end;">
+            <div style="flex: 1;">
+              <label for="config-unit" class="fm-label" style="font-size: 0.8rem;">Unit <small style="color: var(--text-muted); font-weight: 400;">(optional)</small></label>
+              <input type="text" id="config-unit" class="fm-input" placeholder="e.g. °C, mm, %" style="height: 32px; font-size: 0.85rem;" />
+            </div>
+            <div style="flex: 1;">
+              <label for="config-decimal-places" class="fm-label" style="font-size: 0.8rem;">Decimal places <small style="color: var(--text-muted); font-weight: 400;">(optional)</small></label>
+              <input type="number" id="config-decimal-places" class="fm-input" min="0" max="10" placeholder="0=int, blank=any" style="height: 32px; font-size: 0.85rem;" />
+            </div>
+          </div>
+          <div style="display: flex; gap: 12px; align-items: flex-end;">
+            <div style="flex: 1;">
+              <label for="config-min-bound" class="fm-label" style="font-size: 0.8rem;">Min bound <small style="color: var(--text-muted); font-weight: 400;">(optional)</small></label>
+              <input type="number" id="config-min-bound" class="fm-input" placeholder="e.g. 0" step="any" style="height: 32px; font-size: 0.85rem;" />
+            </div>
+            <div style="flex: 1;">
+              <label for="config-max-bound" class="fm-label" style="font-size: 0.8rem;">Max bound <small style="color: var(--text-muted); font-weight: 400;">(optional)</small></label>
+              <input type="number" id="config-max-bound" class="fm-input" placeholder="e.g. 500" step="any" style="height: 32px; font-size: 0.85rem;" />
+            </div>
+          </div>
+        </div>
+
+        <div id="textarea-config-container" style="display: none;">
+          <label for="config-max-length" class="fm-label" style="font-size: 0.8rem;">Max length <small style="color: var(--text-muted); font-weight: 400;">(optional, default 2000)</small></label>
+          <input type="number" id="config-max-length" class="fm-input" min="1" max="100000" placeholder="2000" style="height: 32px; font-size: 0.85rem;" />
+        </div>
         
-        <div>
+        <div id="default-value-wrapper">
           <label for="field-default" class="fm-label" data-i18n="admin.defaultValue">Default Value (Optional)</label>
           <input type="text" id="field-default" class="fm-input" placeholder="e.g. PLA" />
           <small style="color: var(--text-muted); font-size: 0.75rem;" data-i18n="admin.defaultValueHint">This value will be pre-filled when creating new items.</small>
@@ -134,8 +168,15 @@ import Layout from '../../layouts/Layout.astro'
       switch (ft) {
         case 'text': return 'Text'
         case 'number': return 'Number'
+        case 'float': return 'Number'  // legacy alias
+        case 'range': return 'Range'
         case 'dropdown': return 'Dropdown'
+        case 'multiselect': return 'Multi-select'
         case 'checkbox': return 'Checkbox'
+        case 'formula': return 'Formula'
+        case 'date': return 'Date'
+        case 'url': return 'URL'
+        case 'textarea': return 'Text Area'
         default: return ft || 'Text'
       }
     }
@@ -154,7 +195,7 @@ import Layout from '../../layouts/Layout.astro'
           ? `<span title="${t('admin.pluginManagedField') || 'Managed by plugin'}: ${escapeHtml(f.source)}" style="color: var(--text-muted); cursor: help;">🔒</span>`
           : `<button data-id="${f.id}" class="btn-edit" style="color: var(--accent); background: none; border: none; cursor: pointer; margin-right: 8px;">${t('common.edit')}</button><button data-id="${f.id}" class="btn-delete" style="color: var(--error-text); background: none; border: none; cursor: pointer;">${t('common.delete')}</button>`
         
-        const optionsInfo = f.field_type === 'dropdown' && f.options
+        const optionsInfo = (f.field_type === 'dropdown' || f.field_type === 'multiselect') && f.options
           ? ` <span title="${f.options.join('\n')}" style="color: var(--text-muted); cursor: help; font-size: 0.8rem;">(${f.options.length})</span>`
           : ''
 
@@ -210,13 +251,52 @@ import Layout from '../../layouts/Layout.astro'
 
     const fieldTypeSelect = document.getElementById('field-type') as HTMLSelectElement
     const optionsContainer = document.getElementById('options-container') as HTMLDivElement
+    const optionsLabel = document.getElementById('options-label') as HTMLElement
     const fieldOptionsTextarea = document.getElementById('field-options') as HTMLTextAreaElement
+    const numericConfigContainer = document.getElementById('numeric-config-container') as HTMLDivElement
+    const textareaConfigContainer = document.getElementById('textarea-config-container') as HTMLDivElement
+    const configUnit = document.getElementById('config-unit') as HTMLInputElement
+    const configDecimalPlaces = document.getElementById('config-decimal-places') as HTMLInputElement
+    const configMinBound = document.getElementById('config-min-bound') as HTMLInputElement
+    const configMaxBound = document.getElementById('config-max-bound') as HTMLInputElement
+    const configMaxLength = document.getElementById('config-max-length') as HTMLInputElement
 
-    fieldTypeSelect.addEventListener('change', () => {
-      const isDropdown = fieldTypeSelect.value === 'dropdown'
-      optionsContainer.style.display = isDropdown ? 'block' : 'none'
-      fieldOptionsTextarea.required = isDropdown
-    })
+    function updateTypeUi(type: string) {
+      const showOptions = type === 'dropdown' || type === 'multiselect'
+      const showNumeric = type === 'number' || type === 'range'
+      const showTextareaConfig = type === 'textarea'
+      optionsContainer.style.display = showOptions ? 'block' : 'none'
+      fieldOptionsTextarea.required = showOptions
+      optionsLabel.textContent = type === 'multiselect' ? 'Multi-select Options' : 'Dropdown Options'
+      numericConfigContainer.style.display = showNumeric ? 'flex' : 'none'
+      textareaConfigContainer.style.display = showTextareaConfig ? 'block' : 'none'
+      updateDefaultUi(type)
+    }
+
+    function updateDefaultUi(type: string) {
+      const wrapper = document.getElementById('default-value-wrapper') as HTMLDivElement
+      if (type === 'range' || type === 'multiselect') {
+        wrapper.style.display = 'none'
+        fieldDefaultInput.value = ''
+        return
+      }
+      wrapper.style.display = 'block'
+      if (type === 'number') {
+        fieldDefaultInput.type = 'number'
+        fieldDefaultInput.setAttribute('step', 'any')
+        fieldDefaultInput.placeholder = 'e.g. 0'
+      } else if (type === 'date') {
+        fieldDefaultInput.type = 'text'
+        fieldDefaultInput.removeAttribute('step')
+        fieldDefaultInput.placeholder = 'YYYY-MM-DD'
+      } else {
+        fieldDefaultInput.type = 'text'
+        fieldDefaultInput.removeAttribute('step')
+        fieldDefaultInput.placeholder = type === 'url' ? 'https://...' : 'e.g. PLA'
+      }
+    }
+
+    fieldTypeSelect.addEventListener('change', () => updateTypeUi(fieldTypeSelect.value))
     
     const fieldIdInput = document.getElementById('field-id') as HTMLInputElement
     const fieldTargetSelect = document.getElementById('field-target') as HTMLSelectElement
@@ -231,14 +311,20 @@ import Layout from '../../layouts/Layout.astro'
       
       error.classList.add('hidden')
       ;(document.getElementById('modal-form') as HTMLFormElement).reset()
-      optionsContainer.style.display = 'none'
-      fieldOptionsTextarea.required = false
+      updateTypeUi('text')
+      configUnit.value = ''
+      configDecimalPlaces.value = ''
+      configMinBound.value = ''
+      configMaxBound.value = ''
+      configMaxLength.value = ''
+      fieldDefaultInput.value = ''
       
       // Reset for "Add" mode
       fieldIdInput.value = ''
       modalTitle.textContent = t('admin.addField')
       fieldTargetSelect.disabled = false
       fieldKeyInput.disabled = false
+      fieldTypeSelect.disabled = false
       
       container.classList.add('open')
     }
@@ -257,16 +343,23 @@ import Layout from '../../layouts/Layout.astro'
       fieldDefaultInput.value = field.default_value || ''
       fieldTypeSelect.value = field.field_type || 'text'
       
-      // Handle dropdown options
-      const isDropdown = field.field_type === 'dropdown'
-      optionsContainer.style.display = isDropdown ? 'block' : 'none'
-      fieldOptionsTextarea.required = isDropdown
+      // Show/hide panels
+      updateTypeUi(field.field_type || 'text')
       fieldOptionsTextarea.value = field.options ? field.options.join('\n') : ''
+
+      // Populate config
+      const cfg = field.config || {}
+      configUnit.value = cfg.unit ?? ''
+      configDecimalPlaces.value = cfg.decimal_places != null ? String(cfg.decimal_places) : ''
+      configMinBound.value = cfg.min_bound != null ? String(cfg.min_bound) : ''
+      configMaxBound.value = cfg.max_bound != null ? String(cfg.max_bound) : ''
+      configMaxLength.value = cfg.max_length != null ? String(cfg.max_length) : ''
       
-      // Set Edit mode: target_type and key are read-only
+      // Set Edit mode: target_type and key are read-only; field_type is immutable
       modalTitle.textContent = t('admin.editField')
       fieldTargetSelect.disabled = true
       fieldKeyInput.disabled = true
+      fieldTypeSelect.disabled = true
       
       container.classList.add('open')
     }
@@ -294,17 +387,32 @@ import Layout from '../../layouts/Layout.astro'
       const fieldType = fieldTypeSelect.value
       
       let options: string[] | null = null
-      if (fieldType === 'dropdown') {
+      if (fieldType === 'dropdown' || fieldType === 'multiselect') {
         options = fieldOptionsTextarea.value
           .split('\n')
           .map(line => line.trim())
           .filter(line => line.length > 0)
         if (options.length === 0) {
           const error = document.getElementById('modal-error') as HTMLDivElement
-          error.textContent = t('admin.dropdownOptionsRequired') || 'At least one dropdown option is required'
+          error.textContent = t('admin.dropdownOptionsRequired') || 'At least one option is required'
           error.classList.remove('hidden')
           return
         }
+      }
+
+      // Build config object for numeric/textarea types
+      let config: Record<string, any> | null = null
+      if (fieldType === 'number' || fieldType === 'range') {
+        config = {}
+        if (configUnit.value.trim()) config.unit = configUnit.value.trim()
+        if (configDecimalPlaces.value !== '') config.decimal_places = parseInt(configDecimalPlaces.value, 10)
+        if (configMinBound.value !== '') config.min_bound = parseFloat(configMinBound.value)
+        if (configMaxBound.value !== '') config.max_bound = parseFloat(configMaxBound.value)
+        if (Object.keys(config).length === 0) config = null
+      } else if (fieldType === 'textarea') {
+        config = {}
+        if (configMaxLength.value !== '') config.max_length = parseInt(configMaxLength.value, 10)
+        if (Object.keys(config).length === 0) config = null
       }
       
       const error = document.getElementById('modal-error') as HTMLDivElement
@@ -320,8 +428,8 @@ import Layout from '../../layouts/Layout.astro'
           : '/api/v1/system-extra-fields'
         
         const body = isEdit
-          ? { label, default_value: defaultValue, field_type: fieldType, options }
-          : { target_type: targetType, key, label, default_value: defaultValue, field_type: fieldType, options }
+          ? { label, default_value: defaultValue, field_type: fieldType, options, config }
+          : { target_type: targetType, key, label, default_value: defaultValue, field_type: fieldType, options, config }
         
         const response = await fetch(url, {
           method: isEdit ? 'PUT' : 'POST',

--- a/frontend/src/pages/filaments/[id]/edit.astro
+++ b/frontend/src/pages/filaments/[id]/edit.astro
@@ -364,6 +364,7 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
   
   <script>
     import { t, initI18n } from '../../../lib/i18n'
+    import { collectSystemFieldValues, escapeHtml, renderFieldInput, unflattenFieldValues } from '../../../lib/extra-fields'
     import { cachedFetchAllPages, cachedFetch, fetchSequential, invalidateCachePrefix, CACHE_KEYS } from '../../../lib/cache'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
     import { createFilamentDbLookup, type LookupInstance, checkFilamentDbActive, fuzzyTokenScore } from '../../../lib/filamentdb-lookup'
@@ -463,29 +464,6 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
         }
       }
       return res
-    }
-
-    function unflattenObject(data: Record<string, any>) {
-      const result: any = {}
-      for (const key in data) {
-        if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const keys = key.split('.')
-          let current = result
-          for (let i = 0; i < keys.length; i++) {
-            const k = keys[i]
-            if (i === keys.length - 1) {
-              // Try to parse number if possible, else string
-              const val = data[key]
-              const num = Number(val)
-              current[k] = !isNaN(num) && val.trim() !== '' ? num : val
-            } else {
-              current[k] = current[k] || {}
-              current = current[k]
-            }
-          }
-        }
-      }
-      return result
     }
 
     function renderCustomFields() {
@@ -1024,7 +1002,9 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
         btnAddNewColor.parentElement!.classList.remove('hidden')
       } catch (error: any) {
         if (isAbortError(error)) return
-        await (window as any).__fmAlert?.(error.message) || alert(error.message)
+        const dialog = (window as any).__fmAlert
+        if (dialog) await dialog(error.message)
+        else alert(error.message)
       } finally {
         btnSaveNewColor.disabled = false
       }
@@ -1047,7 +1027,7 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
       }
     }
 
-    function renderSystemFields(filamentCustomFieldsFlat: Record<string, any> = {}) {
+    function renderSystemFields(filamentCustomFieldsFlat: Record<string, any> = {}, rawFields?: Record<string, any>) {
       const container = document.getElementById('system-fields-container') as HTMLDivElement
       const grid = document.getElementById('system-fields-grid') as HTMLDivElement
       if (!systemFields || systemFields.length === 0) {
@@ -1058,31 +1038,9 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
       grid.innerHTML = ''
       
       systemFields.forEach(field => {
-        const currentValue = filamentCustomFieldsFlat[field.key] !== undefined ? String(filamentCustomFieldsFlat[field.key]) : (field.default_value || '')
+        const rawValue = rawFields?.[field.key] ?? null
         const div = document.createElement('div')
-        let inputHtml = ''
-
-        switch (field.field_type) {
-          case 'number':
-            inputHtml = `<input type="number" class="fm-input system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}" value="${escapeHtml(currentValue)}" step="any" />`
-            break
-          case 'dropdown': {
-            const opts = (field.options || []).map((opt: string) => {
-              const selected = opt === currentValue ? ' selected' : ''
-              return `<option value="${escapeHtml(opt)}"${selected}>${escapeHtml(opt)}</option>`
-            }).join('')
-            inputHtml = `<select class="fm-select system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}"><option value="">\u2014</option>${opts}</select>`
-            break
-          }
-          case 'checkbox': {
-            const checked = currentValue === 'true' ? ' checked' : ''
-            inputHtml = `<label style="display: flex; align-items: center; gap: 8px; cursor: pointer;"><input type="checkbox" class="system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}"${checked} /> ${escapeHtml(field.label)}</label>`
-            break
-          }
-          default:
-            inputHtml = `<input type="text" class="fm-input system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}" value="${escapeHtml(currentValue)}" />`
-        }
-
+        const inputHtml = renderFieldInput(field, rawValue, filamentCustomFieldsFlat)
         if (field.field_type === 'checkbox') {
           div.innerHTML = inputHtml
         } else {
@@ -1090,13 +1048,6 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
         }
         grid.appendChild(div)
       })
-    }
-
-    function escapeHtml(str: string) {
-      if (!str) return ''
-      const div = document.createElement('div')
-      div.textContent = str
-      return div.innerHTML
     }
 
     // ── Pre-fill form with existing filament data ──
@@ -1179,10 +1130,10 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
         const systemKeys = systemFields.map(field => field.key)
 
         customFields = Object.entries(flat)
-          .filter(([key]) => !systemKeys.includes(key))
+          .filter(([key]) => !systemKeys.some(sk => key === sk || key.startsWith(sk + '.')))
           .map(([key, value]) => ({ key, value: String(value) }))
           
-        renderSystemFields(flat)
+        renderSystemFields(flat, f.custom_fields)
       } else {
         customFields = []
         renderSystemFields({})
@@ -1262,19 +1213,9 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
       patchData.shop_url = shopUrl || null
 
       // System Fields + Custom Fields
-      const fieldsObj: Record<string, any> = {}
-
-      document.querySelectorAll('.system-field-input').forEach((input: any) => {
-        const key = input.dataset.key
-        const type = input.dataset.type
-        if (!key) return
-        if (type === 'checkbox') {
-          fieldsObj[key] = input.checked ? 'true' : 'false'
-        } else {
-          const value = input.value.trim()
-          if (value) fieldsObj[key] = value
-        }
-      })
+      const systemValues = collectSystemFieldValues()
+      if (!systemValues) return
+      const fieldsObj = systemValues.flat
 
       if (customFields.length > 0) {
         customFields.forEach(f => {
@@ -1284,7 +1225,11 @@ const backHref = id === 'detail' ? '/filaments' : `/filaments/${id}`
         })
       }
       
-      patchData.custom_fields = Object.keys(fieldsObj).length > 0 ? unflattenObject(fieldsObj) : null
+      const cfUnflat = Object.keys(fieldsObj).length > 0 ? unflattenFieldValues(fieldsObj) : {}
+      for (const [k, v] of Object.entries(systemValues.direct)) {
+        cfUnflat[k] = v
+      }
+      patchData.custom_fields = Object.keys(cfUnflat).length > 0 ? cfUnflat : null
 
       // Build PUT /colors payload
       const colorsData = {

--- a/frontend/src/pages/filaments/[id]/index.astro
+++ b/frontend/src/pages/filaments/[id]/index.astro
@@ -93,6 +93,7 @@ const { id } = Astro.params
   <script is:inline src="/vendor/chart.min.js"></script>
   <script>
     import { t, initI18n } from '../../../lib/i18n'
+    import { escapeHtml as escapeExtraFieldHtml, renderFieldDisplay, renderUnknownFieldPlainText } from '../../../lib/extra-fields'
     import { cachedFetchAllPages, fetchSequential, CACHE_KEYS } from '../../../lib/cache'
     import { formatPrice, getCurrency, initCurrency } from '../../../lib/format'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
@@ -271,43 +272,33 @@ const { id } = Astro.params
       // Custom Fields
       let customFieldsHtml = ''
       if (f.custom_fields && Object.keys(f.custom_fields).length > 0) {
-        // Simple flatten for display
-        const flatten = (obj: any, prefix = '', res: Record<string, any> = {}): Record<string, any> => {
-          for (const key in obj) {
-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
-              const val = obj[key];
-              const newKey = prefix ? `${prefix}.${key}` : key;
-              if (typeof val === 'object' && val !== null) {
-                flatten(val, newKey, res);
-              } else {
-                res[newKey] = val;
-              }
-            }
-          }
-          return res;
-        }
-
-        const flatFields = flatten(f.custom_fields)
-        const rows = Object.entries(flatFields).map(([key, value]) => {
-          const sysDef = systemFieldMap[key]
-          if (sysDef) {
+        const sysKeys = new Set(Object.keys(systemFieldMap))
+        // System fields: render from raw values (handles range/multiselect correctly)
+        const sysRows = Object.values(systemFieldMap)
+          .filter((sysDef: any) => f.custom_fields[sysDef.key] !== undefined)
+          .map((sysDef: any) => {
+            const displayHtml = renderFieldDisplay(sysDef, f.custom_fields[sysDef.key])
             return `
             <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--accent-2) 5%, transparent); margin: 0 -8px; padding-left: 8px; padding-right: 8px;">
               <span style="display: flex; align-items: center; gap: 6px;">
-                <span style="color: var(--text-muted); font-weight: 500;">${sysDef.label}</span>
+                <span style="color: var(--text-muted); font-weight: 500;">${escapeExtraFieldHtml(sysDef.label)}</span>
                 <span style="background: color-mix(in srgb, var(--accent-2) 20%, transparent); color: var(--accent-2); padding: 1px 6px; border-radius: 3px; font-size: 0.7rem; font-weight: 600; white-space: nowrap;">${t('common.systemField')}</span>
               </span>
-              <span style="font-family: monospace; word-break: break-all;">${value}</span>
+              <span style="word-break: break-all;">${displayHtml}</span>
             </div>
             `
-          }
-          return `
+          }).join('')
+        // Keep unknown direct-API values at their top-level key so arrays and
+        // objects do not leak implementation paths such as field.0.
+        const customRows = Object.entries(f.custom_fields)
+          .filter(([key]) => !sysKeys.has(key))
+          .map(([key, value]) => `
           <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--border);">
-            <span style="color: var(--text-muted); font-weight: 500;">${key}</span>
-            <span style="font-family: monospace; word-break: break-all;">${value}</span>
+            <span style="color: var(--text-muted); font-weight: 500;">${escapeExtraFieldHtml(key)}</span>
+            <span style="font-family: monospace; word-break: break-all;">${escapeExtraFieldHtml(renderUnknownFieldPlainText(value))}</span>
           </div>
-          `
-        }).join('')
+          `).join('')
+        const rows = sysRows + customRows
 
         customFieldsHtml = `
           <div class="fm-card" style="margin-top: 16px;">

--- a/frontend/src/pages/filaments/[id]/print.astro
+++ b/frontend/src/pages/filaments/[id]/print.astro
@@ -77,6 +77,7 @@ export function getStaticPaths() {
     writeStorageValue,
   } from '../../../lib/label-print-page'
   import { isBuiltInLabelField, normalizeLabelFieldName } from '../../../lib/label-extra-fields'
+  import { renderFieldPlainText, type SystemExtraFieldDef } from '../../../lib/extra-fields'
 
   function applyPrintSidebarCollapse() {
     const page = document.getElementById('fm-page')
@@ -636,17 +637,14 @@ export function getStaticPaths() {
           fetch('/api/v1/system-extra-fields?target_type=filament', { credentials: 'include' }).then(r => r.ok ? r.json() : []),
           fetch(`/api/v1/filaments/${id}`, { credentials: 'include' }),
         ])
-        const allDefs: {key: string, label: string}[] = (Array.isArray(defs) ? defs : (defs.items || []))
-          .filter((def: {key: string, label: string}) => !isBuiltInLabelField('filament', def.key, def.label))
+        const allDefs: SystemExtraFieldDef[] = (Array.isArray(defs) ? defs : (defs.items || []))
+          .map((def: SystemExtraFieldDef) => ({ ...def, field_type: def.field_type || 'text' }))
+          .filter((def: SystemExtraFieldDef) => !isBuiltInLabelField('filament', def.key, def.label))
 
-        const filamentCustom: Record<string, string> = {}
+        let filamentCustom: Record<string, unknown> = {}
         if (filRes.ok) {
           const fd = await filRes.json()
-          if (fd.custom_fields) {
-            for (const [k, v] of Object.entries(fd.custom_fields as Record<string, unknown>)) {
-              if (v !== null && v !== undefined) filamentCustom[k] = String(v)
-            }
-          }
+          filamentCustom = (fd.custom_fields ?? {}) as Record<string, unknown>
           mergeMissingFilamentLabelData(labelData, buildFilamentLabelDataFromApi(fd, id))
         }
 
@@ -690,7 +688,7 @@ export function getStaticPaths() {
           makeEfCheckbox({
             key: `filament.${def.key}`,
             label: def.label,
-            value: filamentCustom[def.key] ?? '',
+            value: renderFieldPlainText(def, filamentCustom[def.key]),
             source: 'filament',
           })
         }

--- a/frontend/src/pages/filaments/new.astro
+++ b/frontend/src/pages/filaments/new.astro
@@ -344,6 +344,7 @@ import Layout from '../../layouts/Layout.astro'
   
   <script>
     import { t, initI18n } from '../../lib/i18n'
+    import { collectSystemFieldValues, escapeHtml, renderFieldInput, unflattenFieldValues } from '../../lib/extra-fields'
     import { getAbortSignal, isAbortError } from '../../lib/abort'
     import { cachedFetchAllPages, invalidateCachePrefix, CACHE_KEYS } from '../../lib/cache'
     import { createFilamentDbLookup, type LookupInstance, checkFilamentDbActive } from '../../lib/filamentdb-lookup'
@@ -398,28 +399,6 @@ import Layout from '../../layouts/Layout.astro'
 
     // ── Custom Fields Logic ──
     let customFields: Array<{ key: string, value: string }> = []
-
-    function unflattenObject(data: Record<string, any>) {
-      const result: any = {}
-      for (const key in data) {
-        if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const keys = key.split('.')
-          let current = result
-          for (let i = 0; i < keys.length; i++) {
-            const k = keys[i]
-            if (i === keys.length - 1) {
-              const val = data[key]
-              const num = Number(val)
-              current[k] = !isNaN(num) && val.trim() !== '' ? num : val
-            } else {
-              current[k] = current[k] || {}
-              current = current[k]
-            }
-          }
-        }
-      }
-      return result
-    }
 
     function renderCustomFields() {
       customFieldsContainer.innerHTML = ''
@@ -851,7 +830,22 @@ import Layout from '../../layouts/Layout.astro'
       }
     }
 
-    function renderSystemFields() {
+    function flattenObject(obj: any, prefix = '', res: any = {}) {
+      for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          const val = obj[key]
+          const newKey = prefix ? `${prefix}.${key}` : key
+          if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+            flattenObject(val, newKey, res)
+          } else {
+            res[newKey] = val
+          }
+        }
+      }
+      return res
+    }
+
+    function renderSystemFields(flat: Record<string, any> = {}, raw?: Record<string, any>) {
       const container = document.getElementById('system-fields-container') as HTMLDivElement
       const grid = document.getElementById('system-fields-grid') as HTMLDivElement
       if (!systemFields || systemFields.length === 0) {
@@ -861,36 +855,14 @@ import Layout from '../../layouts/Layout.astro'
       container.style.display = 'block'
       grid.innerHTML = ''
       
-      systemFields.forEach(field => {
-        const defaultVal = field.default_value || ''
+      systemFields.forEach((field: any) => {
         const div = document.createElement('div')
-        let inputHtml = ''
-
-        switch (field.field_type) {
-          case 'number':
-            inputHtml = `<input type="number" class="fm-input system-field-input" data-key="${field.key}" data-type="${field.field_type}" value="${defaultVal}" step="any" />`
-            break
-          case 'dropdown': {
-            const opts = (field.options || []).map((opt: string) => {
-              const selected = opt === defaultVal ? ' selected' : ''
-              return `<option value="${opt}"${selected}>${opt}</option>`
-            }).join('')
-            inputHtml = `<select class="fm-select system-field-input" data-key="${field.key}" data-type="${field.field_type}"><option value="">\u2014</option>${opts}</select>`
-            break
-          }
-          case 'checkbox': {
-            const checked = defaultVal === 'true' ? ' checked' : ''
-            inputHtml = `<label style="display: flex; align-items: center; gap: 8px; cursor: pointer;"><input type="checkbox" class="system-field-input" data-key="${field.key}" data-type="${field.field_type}"${checked} /> ${field.label}</label>`
-            break
-          }
-          default:
-            inputHtml = `<input type="text" class="fm-input system-field-input" data-key="${field.key}" data-type="${field.field_type}" value="${defaultVal}" />`
-        }
-
+        const rawValue = raw ? (raw[field.key] ?? null) : null
+        const inputHtml = renderFieldInput(field, rawValue, flat)
         if (field.field_type === 'checkbox') {
           div.innerHTML = inputHtml
         } else {
-          div.innerHTML = `<label class="fm-label">${field.label}</label>${inputHtml}`
+          div.innerHTML = `<label class="fm-label">${escapeHtml(field.label)}</label>${inputHtml}`
         }
         grid.appendChild(div)
       })
@@ -1009,7 +981,9 @@ import Layout from '../../layouts/Layout.astro'
         btnAddNewColor.parentElement!.classList.remove('hidden')
       } catch (error: any) {
         if (isAbortError(error)) return
-        await (window as any).__fmAlert?.(error.message) || alert(error.message)
+        const dialog = (window as any).__fmAlert
+        if (dialog) await dialog(error.message)
+        else alert(error.message)
       } finally {
         btnSaveNewColor.disabled = false
       }
@@ -1099,20 +1073,9 @@ import Layout from '../../layouts/Layout.astro'
       if (shopUrl) data.shop_url = shopUrl
 
       // System Fields + Custom Fields
-      const fieldsObj: Record<string, any> = {}
-
-      // Collect System Fields
-      document.querySelectorAll('.system-field-input').forEach((el: any) => {
-        const key = el.dataset.key
-        const type = el.dataset.type
-        if (!key) return
-        if (type === 'checkbox') {
-          fieldsObj[key] = el.checked ? 'true' : 'false'
-        } else {
-          const value = el.value.trim()
-          if (value) fieldsObj[key] = value
-        }
-      })
+      const systemValues = collectSystemFieldValues()
+      if (!systemValues) return
+      const fieldsObj = systemValues.flat
 
       // Collect Custom Fields
       if (customFields.length > 0) {
@@ -1123,8 +1086,11 @@ import Layout from '../../layouts/Layout.astro'
         })
       }
 
-      if (Object.keys(fieldsObj).length > 0) {
-        data.custom_fields = unflattenObject(fieldsObj)
+      if (Object.keys(fieldsObj).length > 0 || Object.keys(systemValues.direct).length > 0) {
+        data.custom_fields = unflattenFieldValues(fieldsObj)
+        for (const [k, v] of Object.entries(systemValues.direct)) {
+          data.custom_fields[k] = v
+        }
       }
 
       errorMessage.classList.add('hidden')
@@ -1260,13 +1226,20 @@ import Layout from '../../layouts/Layout.astro'
           const shopInput = document.getElementById('shop_url') as HTMLInputElement
           if (dup.shop_url) shopInput.value = dup.shop_url
 
-          // Custom Fields
+          // Custom Fields (non-system) + System Fields
           if (dup.custom_fields && typeof dup.custom_fields === 'object') {
-            const entries = Object.entries(dup.custom_fields)
-            if (entries.length > 0) {
-              customFields = entries.map(([key, value]) => ({ key, value: String(value) }))
+            const systemKeySet = new Set((systemFields ?? []).map((f: any) => f.key))
+            const allEntries = Object.entries(dup.custom_fields as Record<string, any>)
+            const customEntries = allEntries.filter(
+              ([k]) => !systemKeySet.has(k) && ![...systemKeySet].some(sk => k.startsWith(sk + '.'))
+            )
+            if (customEntries.length > 0) {
+              customFields = customEntries.map(([key, value]) => ({ key, value: String(value) }))
               renderCustomFields()
             }
+            // Prefill system fields from duplicate
+            const dupFlat = flattenObject(dup.custom_fields)
+            renderSystemFields(dupFlat, dup.custom_fields)
           }
         } catch (e) {
           console.error('Failed to apply duplicate filament data:', e)

--- a/frontend/src/pages/filaments/print.astro
+++ b/frontend/src/pages/filaments/print.astro
@@ -82,6 +82,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     writeStorageValue,
   } from '../../lib/label-print-page'
   import { isBuiltInLabelField } from '../../lib/label-extra-fields'
+  import { renderFieldPlainText, type SystemExtraFieldDef } from '../../lib/extra-fields'
   import { t, initI18n } from '../../lib/i18n'
 
   installPrintFunction()
@@ -117,7 +118,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
   const previewContainer = document.getElementById('preview-container') as HTMLElement
   const sheetControls = bindLabelSheetControls(queueRenderAll, (key, fallback) => t(key) || fallback)
 
-  type ExtraFieldDef = { key: string; label: string }
+  type ExtraFieldDef = SystemExtraFieldDef
   type ApiObject = Record<string, unknown>
   type ApiFilament = ApiObject & {
     id?: string | number
@@ -146,7 +147,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     return typeof value === 'object' && value !== null
   }
 
-  function isExtraFieldDef(value: unknown): value is ExtraFieldDef {
+  function isExtraFieldDef(value: unknown): value is SystemExtraFieldDef {
     return isApiObject(value) && typeof value.key === 'string' && typeof value.label === 'string'
   }
 
@@ -156,7 +157,17 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       : isApiObject(value) && Array.isArray(value.items)
         ? value.items
         : []
-    return items.filter(isExtraFieldDef)
+    return items.filter(isExtraFieldDef).map(def => ({
+      ...def,
+      id: typeof def.id === 'number' ? def.id : 0,
+      key: def.key,
+      label: def.label,
+      field_type: typeof def.field_type === 'string' ? def.field_type : 'text',
+    }))
+  }
+
+  function getExtraFieldDefinitionMap(): Record<string, SystemExtraFieldDef> {
+    return Object.fromEntries(efDefs.map(def => [def.key, def]))
   }
 
   function saveSettings() {
@@ -230,7 +241,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       fields.set(key, { key, label: def.label, value: '', source: 'filament' })
     }
     for (const filament of filaments) {
-      for (const field of buildDesignerExtraFieldsFromFilament(filament)) {
+      for (const field of buildDesignerExtraFieldsFromFilament(filament, getExtraFieldDefinitionMap())) {
         if (!field?.key || fields.has(field.key)) continue
         fields.set(field.key, field)
       }
@@ -249,7 +260,9 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       if (!efCheckMap[efMapKey(def.key)]?.checked) continue
       // Standard fields use shared reduced definitions; system custom fields use custom_fields[key].
       const stdDef = STANDARD_FILAMENT_EF.find(s => s.key === def.key)
-      const rawValue = stdDef ? stdDef.valueFromApi(filament) : (custom[def.key] !== null && custom[def.key] !== undefined ? String(custom[def.key]) : '')
+      const rawValue = stdDef
+        ? stdDef.valueFromApi(filament)
+        : (custom[def.key] !== null && custom[def.key] !== undefined ? renderFieldPlainText(def, custom[def.key]) : '')
       if (rawValue !== '') {
         result.push({ label: def.label, value: rawValue })
       }
@@ -320,7 +333,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       spool_width_mm: data.spool_width_mm,
       spool_material: data.spool_material,
       shop_url: data.shop_url,
-      extraFields: buildDesignerExtraFieldsFromFilament(filament),
+      extraFields: buildDesignerExtraFieldsFromFilament(filament, getExtraFieldDefinitionMap()),
     })
   }
 

--- a/frontend/src/pages/spools/[id]/edit.astro
+++ b/frontend/src/pages/spools/[id]/edit.astro
@@ -287,6 +287,7 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
   
   <script>
     import { t, initI18n } from '../../../lib/i18n'
+    import { collectSystemFieldValues, escapeHtml, renderFieldInput, unflattenFieldValues } from '../../../lib/extra-fields'
     import { cachedFetchAllPages, cachedFetch, fetchSequential, invalidateCachePrefix, CACHE_KEYS } from '../../../lib/cache'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
     import { createFilamentDbLookup, type LookupInstance, checkFilamentDbActive } from '../../../lib/filamentdb-lookup'
@@ -335,28 +336,6 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
         }
       }
       return res
-    }
-
-    function unflattenObject(data: any) {
-      const result: Record<string, any> = {}
-      for (const key in data) {
-        if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const keys = key.split('.')
-          let current: any = result
-          for (let i = 0; i < keys.length; i++) {
-            const k = keys[i]
-            if (i === keys.length - 1) {
-              const val = data[key]
-              const num = Number(val)
-              current[k] = !isNaN(num) && val.trim() !== '' ? num : val
-            } else {
-              current[k] = current[k] || {}
-              current = current[k]
-            }
-          }
-        }
-      }
-      return result
     }
 
     function renderCustomFields() {
@@ -587,7 +566,7 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
       }
     }
 
-    function renderSystemFields(spoolCustomFieldsFlat: Record<string, any> = {}) {
+    function renderSystemFields(spoolCustomFieldsFlat: Record<string, any> = {}, rawFields?: Record<string, any>) {
       const container = document.getElementById('system-fields-container') as HTMLElement
       const grid = document.getElementById('system-fields-grid') as HTMLElement
       if (!systemFields || systemFields.length === 0) {
@@ -598,31 +577,9 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
       grid.innerHTML = ''
       
       systemFields.forEach(field => {
-        const currentValue = spoolCustomFieldsFlat[field.key] !== undefined ? String(spoolCustomFieldsFlat[field.key]) : (field.default_value || '')
+        const rawValue = rawFields?.[field.key] ?? null
         const div = document.createElement('div')
-        let inputHtml = ''
-
-        switch (field.field_type) {
-          case 'number':
-            inputHtml = `<input type="number" class="fm-input system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}" value="${escapeHtml(currentValue)}" step="any" />`
-            break
-          case 'dropdown': {
-            const opts = (field.options || []).map((opt: any) => {
-              const selected = opt === currentValue ? ' selected' : ''
-              return `<option value="${escapeHtml(opt)}"${selected}>${escapeHtml(opt)}</option>`
-            }).join('')
-            inputHtml = `<select class="fm-select system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}"><option value="">\u2014</option>${opts}</select>`
-            break
-          }
-          case 'checkbox': {
-            const checked = currentValue === 'true' ? ' checked' : ''
-            inputHtml = `<label style="display: flex; align-items: center; gap: 8px; cursor: pointer;"><input type="checkbox" class="system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}"${checked} /> ${escapeHtml(field.label)}</label>`
-            break
-          }
-          default:
-            inputHtml = `<input type="text" class="fm-input system-field-input" data-key="${escapeHtml(field.key)}" data-type="${field.field_type}" value="${escapeHtml(currentValue)}" />`
-        }
-
+        const inputHtml = renderFieldInput(field, rawValue, spoolCustomFieldsFlat)
         if (field.field_type === 'checkbox') {
           div.innerHTML = inputHtml
         } else {
@@ -630,13 +587,6 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
         }
         grid.appendChild(div)
       })
-    }
-
-    function escapeHtml(str: any) {
-      if (!str) return ''
-      const div = document.createElement('div')
-      div.textContent = str
-      return div.innerHTML
     }
 
     function prefillForm(s: any) {
@@ -689,10 +639,10 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
         const systemKeys = systemFields.map(f => f.key)
         
         customFields = Object.entries(flat)
-          .filter(([key]) => !systemKeys.includes(key))
+          .filter(([key]) => !systemKeys.some(sk => key === sk || key.startsWith(sk + '.')))
           .map(([key, value]) => ({ key, value: String(value) }))
           
-        renderSystemFields(flat)
+        renderSystemFields(flat, s.custom_fields)
       } else {
         customFields = []
         renderSystemFields({})
@@ -770,19 +720,9 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
       const purchaseDate = formData.get('purchase_date')
       patchData.purchase_date = purchaseDate || null
 
-      const fieldsObj: Record<string, string> = {}
-
-      document.querySelectorAll<HTMLInputElement>('.system-field-input').forEach(input => {
-        const key = input.dataset.key
-        const type = input.dataset.type
-        if (!key) return
-        if (type === 'checkbox') {
-          fieldsObj[key] = input.checked ? 'true' : 'false'
-        } else {
-          const value = input.value.trim()
-          if (value) fieldsObj[key] = value
-        }
-      })
+      const systemValues = collectSystemFieldValues()
+      if (!systemValues) return
+      const fieldsObj = systemValues.flat
 
       if (customFields.length > 0) {
         customFields.forEach(f => {
@@ -792,7 +732,11 @@ const backHref = id === 'detail' ? '/spools' : `/spools/${id}`
         })
       }
       
-      patchData.custom_fields = Object.keys(fieldsObj).length > 0 ? unflattenObject(fieldsObj) : null
+      const cfUnflat = Object.keys(fieldsObj).length > 0 ? unflattenFieldValues(fieldsObj) : {}
+      for (const [k, v] of Object.entries(systemValues.direct)) {
+        cfUnflat[k] = v
+      }
+      patchData.custom_fields = Object.keys(cfUnflat).length > 0 ? cfUnflat : null
 
       errorMessage.classList.add('hidden')
       submitBtn.disabled = true

--- a/frontend/src/pages/spools/[id]/index.astro
+++ b/frontend/src/pages/spools/[id]/index.astro
@@ -176,6 +176,7 @@ const { id } = Astro.params
 
   <script>
     import { t, initI18n } from '../../../lib/i18n'
+    import { escapeHtml as escapeExtraFieldHtml, renderFieldDisplay, renderFieldPlainText, renderUnknownFieldPlainText } from '../../../lib/extra-fields'
     import { cachedFetchAllPages, fetchSequential, CACHE_KEYS } from '../../../lib/cache'
     import { getAbortSignal, isAbortError } from '../../../lib/abort'
     import { initPerModelProfilePicker } from '../../../lib/cloud-profile-picker'
@@ -210,43 +211,6 @@ const { id } = Astro.params
     let pendingSlotTimeout: ReturnType<typeof setTimeout> | null = null
     let pendingSlotPollTimer: ReturnType<typeof setTimeout> | null = null
     
-    function flattenObject(obj: any, prefix = '', res: Record<string, string> = {}) {
-      for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-          const val = obj[key]
-          const newKey = prefix ? `${prefix}.${key}` : key
-          if (typeof val === 'object' && val !== null) {
-            flattenObject(val, newKey, res)
-          } else {
-            res[newKey] = String(val)
-          }
-        }
-      }
-      return res
-    }
-
-    function unflattenObject(data: any) {
-      const result: Record<string, any> = {}
-      for (const key in data) {
-        if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const keys = key.split('.')
-          let current: any = result
-          for (let i = 0; i < keys.length; i++) {
-            const k = keys[i]
-            if (i === keys.length - 1) {
-              const val = data[key]
-              const num = Number(val)
-              current[k] = !isNaN(num) && val.trim() !== '' ? num : val
-            } else {
-              current[k] = current[k] || {}
-              current = current[k]
-            }
-          }
-        }
-      }
-      return result
-    }
-
     function getCsrfToken() {
       const match = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/)
       return match ? decodeURIComponent(match[1]) : ''
@@ -423,26 +387,32 @@ const { id } = Astro.params
           <div class="fm-card" style="margin-top: 16px;">
             <div style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 8px;">${t('common.extraFields')}</div>
             <div>
-              ${Object.entries(flattenObject(spool.custom_fields)).map(([key, value]) => {
-                const sysDef = spoolSystemFieldMap[key]
-                if (sysDef) {
-                  return `
+              ${(() => {
+                const sysKeys = new Set(Object.keys(spoolSystemFieldMap))
+                const sysRows = Object.values(spoolSystemFieldMap)
+                  .filter(sysDef => spool.custom_fields[sysDef.key] !== undefined)
+                  .map(sysDef => {
+                    const displayHtml = renderFieldDisplay(sysDef, spool.custom_fields[sysDef.key])
+                    return `
                     <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--accent-2) 5%, transparent); margin: 0 -8px; padding-left: 8px; padding-right: 8px;">
                       <span style="display: flex; align-items: center; gap: 6px;">
-                        <span style="color: var(--text-muted); font-weight: 500;">${sysDef.label}</span>
+                        <span style="color: var(--text-muted); font-weight: 500;">${escapeExtraFieldHtml(sysDef.label)}</span>
                         <span style="background: color-mix(in srgb, var(--accent-2) 20%, transparent); color: var(--accent-2); padding: 1px 6px; border-radius: 3px; font-size: 0.7rem; font-weight: 600; white-space: nowrap;">${t('common.systemField')}</span>
                       </span>
-                      <span style="font-family: monospace; word-break: break-all;">${value}</span>
+                      <span style="word-break: break-all;">${displayHtml}</span>
                     </div>
                   `
-                }
-                return `
+                  }).join('')
+                const customRows = Object.entries(spool.custom_fields)
+                  .filter(([key]) => !sysKeys.has(key))
+                  .map(([key, value]) => `
                   <div style="display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--border);">
-                    <span style="color: var(--text-muted); font-weight: 500;">${key}</span>
-                    <span style="font-family: monospace; word-break: break-all;">${value}</span>
+                    <span style="color: var(--text-muted); font-weight: 500;">${escapeExtraFieldHtml(key)}</span>
+                    <span style="font-family: monospace; word-break: break-all;">${escapeExtraFieldHtml(renderUnknownFieldPlainText(value))}</span>
                   </div>
-                `
-              }).join('')}
+                  `).join('')
+                return sysRows + customRows
+              })()}
             </div>
           </div>
         ` : ''}
@@ -528,28 +498,26 @@ const { id } = Astro.params
         efForPrint.push({ key, label, value: value !== undefined && value !== null ? String(value) : '', source: 'spool' })
       }
 
-      const spoolFlat = spool.custom_fields ? flattenObject(spool.custom_fields) : {}
+      const spoolCustom = spool.custom_fields ?? {}
       for (const [key, def] of Object.entries(spoolSystemFieldMap)) {
         if (isBuiltInLabelField('spool', key, def.label)) continue
-        const raw = spoolFlat[key]
-        efForPrint.push({ key: `spool.${key}`, label: def.label, value: raw !== undefined && raw !== null ? String(raw) : '', source: 'spool' })
+        efForPrint.push({ key: `spool.${key}`, label: def.label, value: renderFieldPlainText(def, spoolCustom[key]), source: 'spool' })
       }
       // Also include any spool custom fields not covered by system definitions
-      for (const [key, value] of Object.entries(spoolFlat)) {
+      for (const [key, value] of Object.entries(spoolCustom)) {
         if (!spoolSystemFieldMap[key] && !isBuiltInLabelField('spool', key)) {
-          efForPrint.push({ key: `spool.${key}`, label: key, value: value !== undefined && value !== null ? String(value) : '', source: 'spool' })
+          efForPrint.push({ key: `spool.${key}`, label: key, value: renderUnknownFieldPlainText(value), source: 'spool' })
         }
       }
-      const filamentFlat = spool.filament?.custom_fields ? flattenObject(spool.filament.custom_fields) : {}
+      const filamentCustom = spool.filament?.custom_fields ?? {}
       for (const [key, def] of Object.entries(filamentSystemFieldMap)) {
         if (isBuiltInLabelField('filament', key, def.label)) continue
-        const raw = filamentFlat[key]
-        efForPrint.push({ key: `filament.${key}`, label: def.label, value: raw !== undefined && raw !== null ? String(raw) : '', source: 'filament' })
+        efForPrint.push({ key: `filament.${key}`, label: def.label, value: renderFieldPlainText(def, filamentCustom[key]), source: 'filament' })
       }
       // Also include any filament custom fields not covered by system definitions
-      for (const [key, value] of Object.entries(filamentFlat)) {
+      for (const [key, value] of Object.entries(filamentCustom)) {
         if (!filamentSystemFieldMap[key] && !isBuiltInLabelField('filament', key)) {
-          efForPrint.push({ key: `filament.${key}`, label: key, value: value !== undefined && value !== null ? String(value) : '', source: 'filament' })
+          efForPrint.push({ key: `filament.${key}`, label: key, value: renderUnknownFieldPlainText(value), source: 'filament' })
         }
       }
       sessionStorage.setItem('filaman-label-extra-fields', JSON.stringify(efForPrint))

--- a/frontend/src/pages/spools/[id]/print.astro
+++ b/frontend/src/pages/spools/[id]/print.astro
@@ -98,6 +98,7 @@ export function getStaticPaths() {
     writeStorageValue,
   } from '../../../lib/label-print-page'
   import { isBuiltInLabelField, normalizeLabelFieldName } from '../../../lib/label-extra-fields'
+  import { renderFieldPlainText, type SystemExtraFieldDef } from '../../../lib/extra-fields'
 
   // Auto-collapse nav sidebar on the print page when the viewport is narrow —
   // the print page needs maximum horizontal space and the overlay would cover the controls.
@@ -906,27 +907,19 @@ export function getStaticPaths() {
           fetch('/api/v1/system-extra-fields?target_type=spool', { credentials: 'include' }).then(r => r.ok ? r.json() : []),
           fetch('/api/v1/system-extra-fields?target_type=filament', { credentials: 'include' }).then(r => r.ok ? r.json() : []),
         ])
-        const allDefs: {key: string, label: string, target_type: string}[] = [
-          ...(Array.isArray(spoolDefs) ? spoolDefs : []).map((d: {key: string, label: string}) => ({...d, target_type: 'spool'})),
-          ...(Array.isArray(filamentDefs) ? filamentDefs : []).map((d: {key: string, label: string}) => ({...d, target_type: 'filament'})),
+        const allDefs: (SystemExtraFieldDef & {target_type: string})[] = [
+          ...(Array.isArray(spoolDefs) ? spoolDefs : []).map((d: SystemExtraFieldDef) => ({...d, field_type: d.field_type || 'text', target_type: 'spool'})),
+          ...(Array.isArray(filamentDefs) ? filamentDefs : []).map((d: SystemExtraFieldDef) => ({...d, field_type: d.field_type || 'text', target_type: 'filament'})),
         ].filter(def => !isBuiltInLabelField(def.target_type, def.key, def.label))
         if (allDefs.length === 0) return
 
         // Attempt to get actual spool values
-        const spoolCustom: Record<string, string> = {}
-        const filamentCustom: Record<string, string> = {}
+        let spoolCustom: Record<string, unknown> = {}
+        let filamentCustom: Record<string, unknown> = {}
         const sd = apiSpoolData ?? await fetchSpoolApiData()
         if (sd) {
-          if (sd.custom_fields) {
-            for (const [k, v] of Object.entries(sd.custom_fields as Record<string, unknown>)) {
-              if (v !== null && v !== undefined) spoolCustom[k] = String(v)
-            }
-          }
-          if (sd.filament?.custom_fields) {
-            for (const [k, v] of Object.entries(sd.filament.custom_fields as Record<string, unknown>)) {
-              if (v !== null && v !== undefined) filamentCustom[k] = String(v)
-            }
-          }
+          spoolCustom = (sd.custom_fields ?? {}) as Record<string, unknown>
+          filamentCustom = (sd.filament?.custom_fields ?? {}) as Record<string, unknown>
         }
 
         // Populate extraFields and rebuild UI.
@@ -936,10 +929,11 @@ export function getStaticPaths() {
 
         for (const def of sortedDefs) {
           const valueMap = def.target_type === 'spool' ? spoolCustom : filamentCustom
+          const rawValue = valueMap[def.key]
           const ef = {
             key: `${def.target_type}.${def.key}`,
             label: def.label,
-            value: valueMap[def.key] ?? '',
+            value: renderFieldPlainText(def, rawValue),
             source: def.target_type,
           }
           extraFields.push(ef)

--- a/frontend/src/pages/spools/new.astro
+++ b/frontend/src/pages/spools/new.astro
@@ -290,6 +290,7 @@ const filamentId = Astro.url.searchParams.get('filament_id')
 
   <script>
     import { t, initI18n } from '../../lib/i18n'
+    import { collectSystemFieldValues, escapeHtml, renderFieldInput, unflattenFieldValues } from '../../lib/extra-fields'
     import { cachedFetchAllPages, fetchSequential, CACHE_KEYS, invalidateCachePrefix } from '../../lib/cache'
     import { getAbortSignal, isAbortError } from '../../lib/abort'
     import { createFilamentDbLookup, type LookupInstance, checkFilamentDbActive } from '../../lib/filamentdb-lookup'
@@ -311,28 +312,6 @@ const filamentId = Astro.url.searchParams.get('filament_id')
 
     // ── Custom Fields Logic ──
     let customFields: Array<{ key: string, value: string }> = []
-
-    function unflattenObject(data: Record<string, any>) {
-      const result: any = {}
-      for (const key in data) {
-        if (Object.prototype.hasOwnProperty.call(data, key)) {
-          const keys = key.split('.')
-          let current = result
-          for (let i = 0; i < keys.length; i++) {
-            const k = keys[i]
-            if (i === keys.length - 1) {
-              const val = data[key]
-              const num = Number(val)
-              current[k] = !isNaN(num) && val.trim() !== '' ? num : val
-            } else {
-              current[k] = current[k] || {}
-              current = current[k]
-            }
-          }
-        }
-      }
-      return result
-    }
 
     function renderCustomFields() {
       customFieldsContainer.innerHTML = ''
@@ -580,9 +559,25 @@ const filamentId = Astro.url.searchParams.get('filament_id')
       }
     })
 
-    function renderSystemFields() {
-      const container = document.getElementById('system-fields-container') as HTMLElement
-      const grid = document.getElementById('system-fields-grid') as HTMLElement
+    function flattenObject(obj: any, prefix = '', res: any = {}) {
+      for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          const val = obj[key]
+          const newKey = prefix ? `${prefix}.${key}` : key
+          if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+            flattenObject(val, newKey, res)
+          } else {
+            res[newKey] = val
+          }
+        }
+      }
+      return res
+    }
+
+    function renderSystemFields(flat: Record<string, any> = {}, raw?: Record<string, any>) {
+      const container = document.getElementById('system-fields-container') as HTMLDivElement | null
+      const grid = document.getElementById('system-fields-grid') as HTMLDivElement | null
+      if (!container || !grid) return
       if (!systemFields || systemFields.length === 0) {
         container.style.display = 'none'
         return
@@ -591,35 +586,13 @@ const filamentId = Astro.url.searchParams.get('filament_id')
       grid.innerHTML = ''
       
       systemFields.forEach((field: any) => {
-        const defaultVal = field.default_value || ''
         const div = document.createElement('div')
-        let inputHtml = ''
-
-        switch (field.field_type) {
-          case 'number':
-            inputHtml = `<input type="number" class="fm-input system-field-input" data-key="${field.key}" data-type="${field.field_type}" value="${defaultVal}" step="any" />`
-            break
-          case 'dropdown': {
-            const opts = (field.options || []).map((opt: string) => {
-              const selected = opt === defaultVal ? ' selected' : ''
-              return `<option value="${opt}"${selected}>${opt}</option>`
-            }).join('')
-            inputHtml = `<select class="fm-select system-field-input" data-key="${field.key}" data-type="${field.field_type}"><option value="">\u2014</option>${opts}</select>`
-            break
-          }
-          case 'checkbox': {
-            const checked = defaultVal === 'true' ? ' checked' : ''
-            inputHtml = `<label style="display: flex; align-items: center; gap: 8px; cursor: pointer;"><input type="checkbox" class="system-field-input" data-key="${field.key}" data-type="${field.field_type}"${checked} /> ${field.label}</label>`
-            break
-          }
-          default:
-            inputHtml = `<input type="text" class="fm-input system-field-input" data-key="${field.key}" data-type="${field.field_type}" value="${defaultVal}" />`
-        }
-
+        const rawValue = raw ? (raw[field.key] ?? null) : null
+        const inputHtml = renderFieldInput(field, rawValue, flat)
         if (field.field_type === 'checkbox') {
           div.innerHTML = inputHtml
         } else {
-          div.innerHTML = `<label class="fm-label">${field.label}</label>${inputHtml}`
+          div.innerHTML = `<label class="fm-label">${escapeHtml(field.label)}</label>${inputHtml}`
         }
         grid.appendChild(div)
       })
@@ -745,13 +718,20 @@ const filamentId = Astro.url.searchParams.get('filament_id')
               (document.getElementById('rfid_uid') as HTMLInputElement).value = dup.rfid_uid
             }
 
-            // Custom Fields
+            // Custom Fields (non-system) + System Fields
             if (dup.custom_fields && typeof dup.custom_fields === 'object') {
-              const entries = Object.entries(dup.custom_fields)
-              if (entries.length > 0) {
-                customFields = entries.map(([key, value]) => ({ key, value: String(value) }))
+              const systemKeySet = new Set((systemFields ?? []).map((f: any) => f.key))
+              const allEntries = Object.entries(dup.custom_fields as Record<string, any>)
+              const customEntries = allEntries.filter(
+                ([k]) => !systemKeySet.has(k) && ![...systemKeySet].some(sk => k.startsWith(sk + '.'))
+              )
+              if (customEntries.length > 0) {
+                customFields = customEntries.map(([key, value]) => ({ key, value: String(value) }))
                 renderCustomFields()
               }
+              // Prefill system fields from duplicate
+              const dupFlat = flattenObject(dup.custom_fields)
+              renderSystemFields(dupFlat, dup.custom_fields)
             }
           } catch (e) {
             console.error('Failed to apply duplicate spool data:', e)
@@ -891,21 +871,10 @@ const filamentId = Astro.url.searchParams.get('filament_id')
       if (externalId) data.external_id = externalId
 
       // System Fields + Custom Fields
-      const fieldsObj: Record<string, string> = {}
-      
-      // Collect System Fields
-      document.querySelectorAll<HTMLInputElement>('.system-field-input').forEach(input => {
-        const key = input.dataset.key
-        const type = input.dataset.type
-        if (!key) return
-        if (type === 'checkbox') {
-          fieldsObj[key] = input.checked ? 'true' : 'false'
-        } else {
-          const value = input.value.trim()
-          if (value) fieldsObj[key] = value
-        }
-      })
-      
+      const systemValues = collectSystemFieldValues()
+      if (!systemValues) return
+      const fieldsObj = systemValues.flat
+
       // Collect Custom Fields
       if (customFields.length > 0) {
         customFields.forEach(f => {
@@ -914,9 +883,13 @@ const filamentId = Astro.url.searchParams.get('filament_id')
           }
         })
       }
-      
-      if (Object.keys(fieldsObj).length > 0) {
-        data.custom_fields = unflattenObject(fieldsObj)
+
+      if (Object.keys(fieldsObj).length > 0 || Object.keys(systemValues.direct).length > 0) {
+        const customFieldsData = unflattenFieldValues(fieldsObj) as Record<string, any>
+        for (const [k, v] of Object.entries(systemValues.direct)) {
+          customFieldsData[k] = v
+        }
+        data.custom_fields = customFieldsData
       }
       
       const quantity = Math.max(1, parseInt((document.getElementById('spool_quantity') as HTMLInputElement).value) || 1)

--- a/frontend/src/pages/spools/print.astro
+++ b/frontend/src/pages/spools/print.astro
@@ -82,6 +82,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     writeStorageValue,
   } from '../../lib/label-print-page'
   import { isBuiltInLabelField } from '../../lib/label-extra-fields'
+  import { renderFieldPlainText, type SystemExtraFieldDef } from '../../lib/extra-fields'
   import { t, initI18n } from '../../lib/i18n'
 
   installPrintFunction()
@@ -116,7 +117,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
   const previewContainer = document.getElementById('preview-container') as HTMLElement
   const sheetControls = bindLabelSheetControls(queueRenderAll, (key, fallback) => t(key) || fallback)
 
-  type ExtraFieldDef = { key: string; label: string; target_type: 'spool' | 'filament' }
+  type ExtraFieldDef = SystemExtraFieldDef & { target_type: 'spool' | 'filament' }
   type ApiObject = Record<string, unknown>
   type ApiFilament = ApiObject & { custom_fields?: Record<string, unknown> }
   type ApiSpool = ApiObject & {
@@ -147,7 +148,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     return typeof value === 'object' && value !== null
   }
 
-  function isExtraFieldDef(value: unknown): value is { key: string; label: string } {
+  function isExtraFieldDef(value: unknown): value is SystemExtraFieldDef {
     return isApiObject(value) && typeof value.key === 'string' && typeof value.label === 'string'
   }
 
@@ -159,7 +160,25 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
         : []
     return items
       .filter(isExtraFieldDef)
-      .map(def => ({ key: def.key, label: def.label, target_type: targetType }))
+      .map(def => ({
+        ...def,
+        id: typeof def.id === 'number' ? def.id : 0,
+        key: def.key,
+        label: def.label,
+        field_type: typeof def.field_type === 'string' ? def.field_type : 'text',
+        target_type: targetType,
+      }))
+  }
+
+  function getExtraFieldDefinitionMaps() {
+    const maps: { spool: Record<string, SystemExtraFieldDef>; filament: Record<string, SystemExtraFieldDef> } = {
+      spool: {},
+      filament: {},
+    }
+    for (const def of efDefs) {
+      maps[def.target_type][def.key] = def
+    }
+    return maps
   }
 
   function saveSettings() {
@@ -225,7 +244,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       fields.set(key, { key, label: def.label, value: '', source: def.target_type })
     }
     for (const spool of spools) {
-      for (const field of buildDesignerExtraFieldsFromApiSpool(spool)) {
+      for (const field of buildDesignerExtraFieldsFromApiSpool(spool, getExtraFieldDefinitionMaps())) {
         if (!field?.key || fields.has(field.key)) continue
         fields.set(field.key, field)
       }
@@ -293,10 +312,10 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       let val: string | null = null
       if (def.target_type === 'spool' && spool.custom_fields) {
         const raw = spool.custom_fields[def.key]
-        if (raw !== undefined && raw !== null) val = String(raw)
+        if (raw !== undefined && raw !== null) val = renderFieldPlainText(def, raw)
       } else if (def.target_type === 'filament' && spool.filament?.custom_fields) {
         const raw = spool.filament.custom_fields[def.key]
-        if (raw !== undefined && raw !== null) val = String(raw)
+        if (raw !== undefined && raw !== null) val = renderFieldPlainText(def, raw)
       }
       if (val !== null) result.push({ key: def.key, label: def.label, value: val })
     }
@@ -330,7 +349,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     getId: spool => spool?.id,
     getLogoManufacturerId: getManufacturerIdFromApiSpool,
     buildStandardData: spool => buildStandardLabelDataFromApiSpool(spool, getExtraFieldsForSpool(spool)),
-    buildDesignerData: buildSpoolDataFromApiSpool,
+    buildDesignerData: spool => buildSpoolDataFromApiSpool(spool, getExtraFieldDefinitionMaps()),
     singlePngName: spool => `label-${spool.id}.png`,
     zipName: () => datedExportName('labels', 'zip'),
     zipEntryName: spool => `label-${spool.id}.png`,


### PR DESCRIPTION
## Summary

Adds richer system extra-field definitions for filament and spool custom data:

- Number
- Numeric range
- Date
- URL
- Multi-select
- Textarea

The feature extends the existing extra-field system across definition management, entity forms, persisted `custom_fields`, detail display, plugin registration, and label printing.

## Data model and migration

Adds a nullable JSON `config` column to `system_extra_fields`.

Existing entity `custom_fields` data does not require a migration. Rich values use these shapes:

| Field type | `custom_fields` value |
|---|---|
| `text`, `dropdown`, `textarea`, `date`, `url` | JSON string |
| `number` | JSON number |
| `range` | `{ "min": number, "max": number }` |
| `multiselect` | JSON string array |
| `checkbox` | Existing checkbox representation |

Native filament and spool columns—including names, weights, prices, dates, and identifiers—retain their existing database and API types. The `system_extra_fields.field_type` column also remains a string; this migration does not retype existing field definitions or rewrite stored `custom_fields` values.

One normalization can occur through the UI: when an existing system or plugin extra field is already declared as `number`, its next form save stores the value as a JSON number (`215.5`) rather than the legacy JSON string (`"215.5"`). Existing numeric strings remain readable and are not converted automatically. Consumers that inspect `custom_fields` directly should accept both representations during the transition.

Type-specific definition configuration includes:

- `number` and `range`: `unit`, `decimal_places`, `min_bound`, `max_bound`
- `textarea`: `max_length`
- `dropdown` and `multiselect`: `options`

## API compatibility

### Existing Spoolman-compatible integrations

This PR does not change the separately mounted SpoolmanAPI plugin, its routes, authentication/access configuration, or its vendor, filament, spool, and usage payloads. Existing clients such as Moonraker and OctoPrint can continue using their current FilaMan-as-Spoolman configuration.

This PR does not add or modify Spoolman's `/api/v1/field/{entity_type}` or `/api/v1/field/{entity_type}/{key}` contract. It extends FilaMan's native extra-field system and UI.

### Existing FilaMan definition API

`/api/v1/system-extra-fields` remains FilaMan's definition endpoint.

- Existing create responses remain `200 OK`.
- Existing field types, including legacy or plugin-defined strings, remain accepted.
- Existing option combinations remain accepted.
- Existing user-created fields can still change `field_type` through `PUT`.
- Existing definitions without rich configuration retain their previous response shape; `config` is omitted when unset.
- Rich definitions can include the optional `config` object. Validation is limited to newly supplied rich configuration and the new `multiselect` type.

Filament and spool create/update schemas continue to accept arbitrary JSON objects for `custom_fields`. Direct API clients can continue sending their existing payloads. Clients that use the new rich types should preserve the typed value shapes documented above.

## Relationship to Spoolman extra fields

The feature is informed by Spoolman's typed extra fields, but the native FilaMan types are not a wire-level copy:

| FilaMan | Closest Spoolman concept |
|---|---|
| `number` | `integer` / `float` |
| `range` | `integer_range` / `float_range` |
| `date` | `datetime` |
| `multiselect` | `choice` with `multi_choice` |
| `url`, `textarea` | FilaMan-specific presentation types |

This adds comparable user-facing capabilities without claiming that FilaMan's native `system-extra-fields` endpoint implements Spoolman's field-definition API.

## Frontend behavior

Shared extra-field helpers provide type-specific controls and display formatting for filament and spool create, edit, duplicate, and detail flows.

The admin UI exposes rich field types and their applicable configuration. Number and range controls support bounds, precision, and units; multi-select uses configured options; textarea supports a configured length; date and URL use dedicated controls.

Range and multi-select defaults are not represented as typed values because the existing `default_value` column remains string-based.

## Printing

Rich values are available to filament and spool label flows, including single and batch pages, Standard Label output, and Label Designer tokens.

Formatting presents range, multi-select, date, URL, textarea, and configured number values as label text rather than raw JSON.

## Compatibility considerations

- The schema addition is nullable and does not require rewriting entity JSON.
- Existing definitions and payloads remain valid.
- Native built-in filament and spool fields retain their existing database and API types.
- Existing numeric strings in `custom_fields` are not migrated. Saving an existing `number` extra field through the UI normalizes that value from a JSON string to a JSON number; readers of raw `custom_fields` should accept both representations.
- Rich number, range, and multi-select values introduce optional typed JSON conventions for clients that use the new field types.
- Value constraints are primarily enforced by the UI because entity `custom_fields` remains an open JSON object.
- `float` remains accepted for legacy/API compatibility and is rendered as a frontend alias; new FilaMan definitions use `number`.

## Validation

- Replayed cleanly onto current upstream `main` (`1.2.29`).
- Backend: 384 tests passed.
- Frontend: 85 tests passed.
- Changed backend files: Ruff passed.
- Astro check: 0 errors.
- ESLint: 0 errors (existing warnings only).
- Production frontend build passed without changing version files.
- `git diff --check` passed.
- Alembic reports one head; SQLite upgrade, downgrade, and re-upgrade passed.

## Screenshots

### Configure a rich range field

<img width="1440" height="1000" alt="Range field configuration with unit, precision, minimum, and maximum bounds" src="https://github.com/user-attachments/assets/a8249749-a6bf-4748-9168-fa6cc82733b8" />

### Filament details — formatted rich field values

<img width="1440" height="1000" alt="Filament detail page showing formatted URL, date, textarea, multi-select, range, and number values" src="https://github.com/user-attachments/assets/ff38b723-c0c2-4e48-a90c-20d02ac9c0bb" />

### Standard label — readable rich field output

<img width="2400" height="1854" alt="Wide standard label with date, multi-select, range, and number fields separated cleanly from the QR code" src="https://github.com/user-attachments/assets/04dd8d13-a127-4159-a4a8-4b33380e0420" />
