### PR TITLE
Fix spool label location rendering

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "eslint": "^9.26.0",
         "eslint-plugin-astro": "^1.3.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.32.0"
+        "typescript-eslint": "^8.32.0",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2292,6 +2293,17 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2300,6 +2312,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2661,6 +2680,121 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
       "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
@@ -2922,6 +3056,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astro": {
       "version": "5.17.2",
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
@@ -3161,6 +3305,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3213,6 +3367,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3253,6 +3424,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3637,6 +3818,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4233,6 +4424,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4993,6 +5194,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -5391,6 +5599,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.2.6",
@@ -6636,6 +6851,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -7372,6 +7604,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7409,6 +7648,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -7427,6 +7673,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -7494,6 +7747,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/supports-color": {
@@ -7604,6 +7870,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -7627,6 +7900,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8199,6 +8502,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -8675,6 +9001,86 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/volar-service-css": {
       "version": "0.0.70",
       "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
@@ -8963,6 +9369,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,14 +8,16 @@
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
-    "lint": "eslint 'src/pages/spools/[id]/index.astro' 'src/pages/spools/[id]/print.astro' 'src/pages/spools/print.astro' 'src/pages/filaments/[id]/index.astro' 'src/pages/filaments/[id]/print.astro' 'src/pages/filaments/print.astro' 'src/components/LabelDesignerEditor.astro' 'src/components/LabelSheetOutputSettings.astro' 'src/components/SingleLabelPrintStyles.astro' 'src/components/StandardLabelSettingsPanel.astro' 'src/components/BatchLabelPrintStyles.astro' 'src/lib/label-template.ts' 'src/lib/label-export.ts' 'src/lib/label-designer.ts' 'src/lib/label-designer-editor.ts' 'src/lib/label-standard.ts' 'src/lib/filament-label-data.ts' 'src/lib/label-extra-fields.ts' 'src/lib/label-print-page.ts' 'src/lib/label-print-style.ts' 'src/lib/label-sheet.ts' 'src/lib/qr-code.ts' --no-error-on-unmatched-pattern"
+    "lint": "eslint 'src/pages/spools/[id]/index.astro' 'src/pages/spools/[id]/print.astro' 'src/pages/spools/print.astro' 'src/pages/filaments/[id]/index.astro' 'src/pages/filaments/[id]/print.astro' 'src/pages/filaments/print.astro' 'src/components/LabelDesignerEditor.astro' 'src/components/LabelSheetOutputSettings.astro' 'src/components/SingleLabelPrintStyles.astro' 'src/components/StandardLabelSettingsPanel.astro' 'src/components/BatchLabelPrintStyles.astro' 'src/lib/label-template.ts' 'src/lib/label-export.ts' 'src/lib/label-designer.ts' 'src/lib/label-designer-editor.ts' 'src/lib/label-standard.ts' 'src/lib/filament-label-data.ts' 'src/lib/label-extra-fields.ts' 'src/lib/label-print-page.ts' 'src/lib/label-print-style.ts' 'src/lib/label-sheet.ts' 'src/lib/spool-label-lookups.ts' 'src/lib/label-token-contract.test.ts' 'src/lib/qr-code.ts' --no-error-on-unmatched-pattern",
+    "test:labels": "vitest run src/lib/label-token-contract.test.ts"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "eslint": "^9.26.0",
     "eslint-plugin-astro": "^1.3.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.32.0"
+    "typescript-eslint": "^8.32.0",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.3",

--- a/frontend/src/lib/label-designer.ts
+++ b/frontend/src/lib/label-designer.ts
@@ -8,6 +8,11 @@ import {
 import { isBuiltInLabelField, type LabelExtraFieldSource } from './label-extra-fields'
 import { updateLabelPrintPageStyle } from './label-print-style'
 import { canvasToQrImage, ensureQrCodeLoaded, getQrCodeConstructor } from './qr-code'
+import {
+  EMPTY_SPOOL_LABEL_LOOKUPS,
+  resolveSpoolLabelRelations,
+  type SpoolLabelLookups,
+} from './spool-label-lookups'
 
 export const DESIGNER_KEY = 'filaman-label-designer-v1'
 export const DESIGNER_SCHEMA_VERSION = 1
@@ -426,8 +431,12 @@ export function buildSpoolDataFromFlatLabel(data: DesignerFlatLabelData): SpoolD
   }
 }
 
-export function buildSpoolDataFromApiSpool(spool: any): SpoolData {
+export function buildSpoolDataFromApiSpool(
+  spool: any,
+  lookups: SpoolLabelLookups = EMPTY_SPOOL_LABEL_LOOKUPS,
+): SpoolData {
   const fil = spool?.filament ?? {}
+  const relations = resolveSpoolLabelRelations(spool, lookups)
   const firstColor = getFirstFilamentColor(fil)
   const color = firstColor?.display_name_override
     || fil.manufacturer_color_name
@@ -450,8 +459,8 @@ export function buildSpoolDataFromApiSpool(spool: any): SpoolData {
     color_hexes: getFilamentColorHexes(fil),
     color_mode: fil.color_mode,
     multi_color_style: fil.multi_color_style,
-    extruder_temp: fil.settings_extruder_temp,
-    bed_temp: fil.settings_bed_temp,
+    extruder_temp: fil.settings_extruder_temp ?? fil.custom_fields?.extruder_temp,
+    bed_temp: fil.settings_bed_temp ?? fil.custom_fields?.bed_temp,
     raw_material_weight_g: fil.raw_material_weight_g ?? fil.weight,
     weight: fil.raw_material_weight_g ?? fil.weight,
     diameter: fil.diameter_mm,
@@ -468,8 +477,8 @@ export function buildSpoolDataFromApiSpool(spool: any): SpoolData {
     lot_number: spool?.lot_number,
     external_id: spool?.external_id,
     rfid_uid: spool?.rfid_uid,
-    location: spool?.location?.label ?? spool?.location?.name,
-    status: spool?.status?.label,
+    location: relations.location,
+    status: relations.status,
     purchase_date: formatDate(spool?.purchase_date),
     purchase_price: spool?.purchase_price,
     remaining_weight_g: spool?.remaining_weight_g,

--- a/frontend/src/lib/label-token-contract.test.ts
+++ b/frontend/src/lib/label-token-contract.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FILAMENT_TOKENS,
+  SPOOL_TOKENS,
+  buildSpoolDataFromApiSpool,
+} from './label-designer'
+import { renderTemplateText } from './label-template'
+import {
+  createSpoolLabelLookups,
+  resolveSpoolLabelRelations,
+} from './spool-label-lookups'
+
+const apiSpool = {
+  id: 42,
+  filament_id: 8,
+  status_id: 3,
+  location_id: 7,
+  lot_number: 'LOT-42',
+  external_id: 'spoolman:42',
+  rfid_uid: 'AA:BB:CC:DD',
+  purchase_date: '2026-01-02T00:00:00Z',
+  purchase_price: 24.95,
+  stocked_in_at: '2026-01-03T00:00:00Z',
+  last_used_at: '2026-01-04T00:00:00Z',
+  remaining_weight_g: 712,
+  initial_total_weight_g: 1250,
+  empty_spool_weight_g: 250,
+  low_weight_threshold_g: 100,
+  custom_fields: { storage_note: 'Keep dry' },
+  filament: {
+    id: 8,
+    manufacturer_id: 5,
+    designation: 'Galaxy PLA',
+    material_type: 'PLA',
+    material_subgroup: 'Silk',
+    manufacturer_color_name: 'Nebula',
+    color_mode: 'multi',
+    multi_color_style: 'gradient',
+    raw_material_weight_g: 1000,
+    diameter_mm: 1.75,
+    finish_type: 'Glossy',
+    density_g_cm3: 1.24,
+    price: 22.5,
+    default_spool_weight_g: 250,
+    spool_outer_diameter_mm: 200,
+    spool_width_mm: 65,
+    spool_material: 'Cardboard',
+    shop_url: 'https://example.test/galaxy-pla',
+    custom_fields: {
+      extruder_temp: 215,
+      bed_temp: 60,
+    },
+    manufacturer: {
+      id: 5,
+      name: 'Example Filaments',
+    },
+    colors: [
+      {
+        display_name_override: 'Galaxy Blue',
+        color: { name: 'Blue', hex_code: '#123456' },
+      },
+      {
+        color: { name: 'Purple', hex_code: '#654321' },
+      },
+    ],
+  },
+}
+
+const lookups = createSpoolLabelLookups(
+  [{ id: 7, name: 'Rack A' }],
+  [{ id: 3, label: 'Opened' }],
+)
+
+describe('spool label token contract', () => {
+  it('renders every advertised filament and spool token from the API wire shape', () => {
+    const data = buildSpoolDataFromApiSpool(apiSpool, lookups)
+
+    expect(data.location).toBe('Rack A')
+    expect(data.status).toBe('Opened')
+
+    for (const { token } of [...FILAMENT_TOKENS, ...SPOOL_TOKENS]) {
+      const rendered = renderTemplateText(token, data)
+      expect(rendered, `${token} should render a value`).not.toBe('')
+      expect(rendered, `${token} should not remain unresolved`).not.toContain('{')
+    }
+  })
+
+  it('prefers resolved relationship objects while retaining ID lookup fallback', () => {
+    expect(resolveSpoolLabelRelations(apiSpool, lookups)).toEqual({
+      location: 'Rack A',
+      status: 'Opened',
+    })
+
+    expect(resolveSpoolLabelRelations({
+      ...apiSpool,
+      location: { id: 7, name: 'Resolved Rack' },
+      status: { id: 3, label: 'Resolved Status' },
+    }, lookups)).toEqual({
+      location: 'Resolved Rack',
+      status: 'Resolved Status',
+    })
+  })
+
+  it('omits optional wrappers cleanly when a relationship is unset', () => {
+    const data = buildSpoolDataFromApiSpool({
+      ...apiSpool,
+      location_id: null,
+      status_id: null,
+    })
+
+    expect(renderTemplateText('{Location: {location}}', data)).toBe('')
+    expect(renderTemplateText('{Status: {status}}', data)).toBe('')
+  })
+})

--- a/frontend/src/lib/spool-label-lookups.ts
+++ b/frontend/src/lib/spool-label-lookups.ts
@@ -1,0 +1,83 @@
+import { fetchAllPages } from './api'
+
+type NamedLookupItem = {
+  id?: unknown
+  label?: unknown
+  name?: unknown
+}
+
+type SpoolWithRelations = {
+  location_id?: unknown
+  status_id?: unknown
+  location?: NamedLookupItem | null
+  status?: NamedLookupItem | null
+}
+
+export interface SpoolLabelLookups {
+  locationsById: ReadonlyMap<string, string>
+  statusesById: ReadonlyMap<string, string>
+}
+
+export const EMPTY_SPOOL_LABEL_LOOKUPS: SpoolLabelLookups = {
+  locationsById: new Map(),
+  statusesById: new Map(),
+}
+
+function toLookupKey(value: unknown): string {
+  return value === undefined || value === null ? '' : String(value)
+}
+
+function toLabelValue(value: unknown): string {
+  return value === undefined || value === null ? '' : String(value).trim()
+}
+
+function buildNameMap(items: NamedLookupItem[], field: 'label' | 'name'): ReadonlyMap<string, string> {
+  const result = new Map<string, string>()
+  for (const item of items) {
+    const key = toLookupKey(item?.id)
+    const value = toLabelValue(item?.[field])
+    if (key && value) result.set(key, value)
+  }
+  return result
+}
+
+export function createSpoolLabelLookups(
+  locations: NamedLookupItem[] = [],
+  statuses: NamedLookupItem[] = [],
+): SpoolLabelLookups {
+  return {
+    locationsById: buildNameMap(locations, 'name'),
+    statusesById: buildNameMap(statuses, 'label'),
+  }
+}
+
+export function resolveSpoolLabelRelations(
+  spool: SpoolWithRelations,
+  lookups: SpoolLabelLookups = EMPTY_SPOOL_LABEL_LOOKUPS,
+): { location: string; status: string } {
+  const location = toLabelValue(spool?.location?.label)
+    || toLabelValue(spool?.location?.name)
+    || lookups.locationsById.get(toLookupKey(spool?.location_id))
+    || ''
+  const status = toLabelValue(spool?.status?.label)
+    || toLabelValue(spool?.status?.name)
+    || lookups.statusesById.get(toLookupKey(spool?.status_id))
+    || ''
+  return { location, status }
+}
+
+export async function loadSpoolLabelLookups(): Promise<SpoolLabelLookups> {
+  const [locationsResult, statusesResult] = await Promise.allSettled([
+    fetchAllPages<NamedLookupItem>('/api/v1/locations'),
+    fetch('/api/v1/spools/statuses', { credentials: 'include' }).then(async response => {
+      if (!response.ok) throw new Error(`Failed to load spool statuses: ${response.status}`)
+      const data = await response.json()
+      return Array.isArray(data) ? data as NamedLookupItem[] : []
+    }),
+  ])
+
+  return createSpoolLabelLookups(
+    locationsResult.status === 'fulfilled' ? locationsResult.value.items : [],
+    statusesResult.status === 'fulfilled' ? statusesResult.value : [],
+  )
+}

--- a/frontend/src/pages/spools/[id]/print.astro
+++ b/frontend/src/pages/spools/[id]/print.astro
@@ -103,6 +103,12 @@ export function getStaticPaths() {
     hydrateLabelPresetStorage,
     SPOOL_LABEL_PRESETS_KEY,
   } from '../../../lib/label-preset-storage'
+  import {
+    EMPTY_SPOOL_LABEL_LOOKUPS,
+    loadSpoolLabelLookups,
+    resolveSpoolLabelRelations,
+    type SpoolLabelLookups,
+  } from '../../../lib/spool-label-lookups'
 
   // Auto-collapse nav sidebar on the print page when the viewport is narrow —
   // the print page needs maximum horizontal space and the overlay would cover the controls.
@@ -142,6 +148,7 @@ export function getStaticPaths() {
   const translate = (key: string, fallback = '') => (window as TranslationWindow).__t?.(key) || fallback
 
   const id = window.location.pathname.split('/').filter(Boolean).slice(-2, -1)[0]
+  let labelLookups: SpoolLabelLookups = EMPTY_SPOOL_LABEL_LOOKUPS
 
   const params = new URLSearchParams(window.location.search)
   const labelData = {
@@ -236,6 +243,8 @@ export function getStaticPaths() {
     }
   }
   type ApiSpoolForPrint = {
+    status_id?: unknown
+    location_id?: unknown
     filament_id?: unknown
     lot_number?: unknown
     rfid_uid?: unknown
@@ -277,6 +286,7 @@ export function getStaticPaths() {
       .map(color => color?.color?.hex_code)
       .filter(Boolean)
       .join(', ')
+    const relations = resolveSpoolLabelRelations(spool, labelLookups)
 
     Object.assign(labelData, {
       filament_id: firstValue(spool?.filament_id, labelData.filament_id),
@@ -309,8 +319,8 @@ export function getStaticPaths() {
       lot_number: firstValue(spool?.lot_number, labelData.lot_number),
       external_id: firstValue(spool?.external_id, labelData.external_id),
       rfid_uid: firstValue(spool?.rfid_uid, labelData.rfid_uid),
-      location: firstValue(spool?.location?.label, spool?.location?.name, labelData.location),
-      status: firstValue(spool?.status?.label, labelData.status),
+      location: firstValue(relations.location, labelData.location),
+      status: firstValue(relations.status, labelData.status),
       purchase_date: firstValue(spool?.purchase_date, labelData.purchase_date),
       purchase_price: firstValue(spool?.purchase_price, labelData.purchase_price),
       remaining_weight_g: firstValue(spool?.remaining_weight_g, labelData.remaining_weight_g),
@@ -327,7 +337,6 @@ export function getStaticPaths() {
       const response = await fetch(`/api/v1/spools/${id}`, { credentials: 'include' })
       if (!response.ok) return null
       const spool = await response.json()
-      applySpoolApiData(spool)
       return spool
     } catch {
       return null
@@ -743,7 +752,14 @@ export function getStaticPaths() {
   function getSelectedStandardExtraFields(): StandardExtraField[] {
     return extraFieldChecks
       .filter(ef => ef.checkbox.checked)
-      .map(ef => ({ label: ef.label, value: ef.value }))
+      .map(ef => ({
+        label: ef.label,
+        value: ef.key === 'location'
+          ? labelData.location
+          : ef.key === 'status'
+            ? labelData.status
+            : ef.value,
+      }))
   }
 
   function getStandardSettings(): StandardLabelSettings {
@@ -893,7 +909,12 @@ export function getStaticPaths() {
     updatePreview()
   })
 
-  const apiSpoolData = await fetchSpoolApiData()
+  const [apiSpoolData, loadedLookups] = await Promise.all([
+    fetchSpoolApiData(),
+    loadSpoolLabelLookups(),
+  ])
+  labelLookups = loadedLookups
+  if (apiSpoolData) applySpoolApiData(apiSpoolData)
 
   // Restore active tab now that all designer state is fully initialized
   if (savedTab === 'designer') tabControls.activate('designer')

--- a/frontend/src/pages/spools/print.astro
+++ b/frontend/src/pages/spools/print.astro
@@ -87,6 +87,12 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     hydrateLabelPresetStorage,
     SPOOL_LABEL_PRESETS_KEY,
   } from '../../lib/label-preset-storage'
+  import {
+    EMPTY_SPOOL_LABEL_LOOKUPS,
+    loadSpoolLabelLookups,
+    resolveSpoolLabelRelations,
+    type SpoolLabelLookups,
+  } from '../../lib/spool-label-lookups'
   import { t, initI18n } from '../../lib/i18n'
 
   installPrintFunction()
@@ -129,11 +135,14 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     id?: string | number
     custom_fields?: Record<string, unknown>
     filament?: ApiFilament
+    location_id?: unknown
+    status_id?: unknown
     location?: { label?: unknown; name?: unknown }
     status?: { label?: unknown }
   }
 
   let spools: ApiSpool[] = []
+  let labelLookups: SpoolLabelLookups = EMPTY_SPOOL_LABEL_LOOKUPS
   type SpoolLabelEntity = ApiSpool
   const logoCache: Record<number, string | null> = {}
   let activePreviewTab: PrintDesignerTab = readPrintDesignerTab('filaman-label-active-tab')
@@ -267,6 +276,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
 
   function getExtraFieldsForSpool(spool: ApiSpool): {key: string, label: string, value: string}[] {
     const result: {key: string, label: string, value: string}[] = []
+    const relations = resolveSpoolLabelRelations(spool, labelLookups)
 
     // ── Spool model field checkboxes (shown when checked in sidebar) ──────
     const fmtDate = (raw: unknown) => raw ? new Date(String(raw)).toLocaleDateString() : ''
@@ -274,8 +284,8 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
       ['lot_number',             'Lot Number',              spool.lot_number],
       ['external_id',            'External ID',             spool.external_id],
       ['rfid_uid',               'RFID UID',                spool.rfid_uid],
-      ['location',               'Location',                spool.location?.label ?? spool.location?.name],
-      ['status',                 'Status',                  spool.status?.label],
+      ['location',               'Location',                relations.location],
+      ['status',                 'Status',                  relations.status],
       ['purchase_date',          'Purchase Date',           fmtDate(spool.purchase_date)],
       ['purchase_price',         'Purchase Price',          spool.purchase_price],
       ['remaining_weight_g',     'Remaining Weight (g)',    spool.remaining_weight_g],
@@ -336,7 +346,7 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     getId: spool => spool?.id,
     getLogoManufacturerId: getManufacturerIdFromApiSpool,
     buildStandardData: spool => buildStandardLabelDataFromApiSpool(spool, getExtraFieldsForSpool(spool)),
-    buildDesignerData: buildSpoolDataFromApiSpool,
+    buildDesignerData: spool => buildSpoolDataFromApiSpool(spool, labelLookups),
     singlePngName: spool => `label-${spool.id}.png`,
     zipName: () => datedExportName('labels', 'zip'),
     zipEntryName: spool => `label-${spool.id}.png`,
@@ -695,14 +705,16 @@ import BatchLabelPrintStyles from '../../components/BatchLabelPrintStyles.astro'
     countEl.textContent = t('labelPrint.labelsLoading', { count: String(ids.length) })
     ids.forEach(id => previewContainer.insertAdjacentHTML('beforeend', makeLabelHtml(id)))
 
-    const [spoolResults] = await Promise.all([
+    const [spoolResults, , loadedLookups] = await Promise.all([
       Promise.allSettled(ids.map(async id => {
         const r = await fetch(`/api/v1/spools/${id}`, { credentials: 'include' })
         if (!r.ok) throw new Error(`Failed to load spool ${id}: ${r.status}`)
         return await r.json()
       })),
       loadExtraFieldDefs(),
+      loadSpoolLabelLookups(),
     ])
+    labelLookups = loadedLookups
     spools = spoolResults.filter(r => r.status === 'fulfilled').map(r => (r as PromiseFulfilledResult<ApiSpool>).value)
     designerEditor.refreshExtraFields(getBatchDesignerExtraFields())
     updateLabelCount()


### PR DESCRIPTION
## Summary

- resolve spool location and status labels from their existing `location_id` and `status_id` API fields before printing
- share the lookup behavior across single, batch, standard, and designer label paths without changing the public spool API response
- add an automated contract test that renders every advertised filament and spool label token from a representative API payload
- restore custom-field temperature fallbacks uncovered by the token contract test

## Root cause

The spool API intentionally returns `location_id` and `status_id`, while the print frontend attempted to read `spool.location.name` and `spool.status.label`. Those nested objects were not part of `SpoolResponse`, so Location and Status rendered as empty values even when the spool had valid relationships.

## Impact

Standard and designer labels now resolve Location and Status consistently for imported and newly created spools. Existing nested relationship objects remain supported as a compatibility fallback.

## Validation

- `npm run test:labels`
- `npm run lint` (passes with pre-existing warnings)
- `npm run check`
- `frontend/node_modules/.bin/astro build`
- `git diff --check`
- browser smoke test with an ID-only spool response:
  - standard label rendered `Location: Rack A` and `Status: Opened`
  - designer template `{location} / {status}` rendered `Rack A / Opened`

## Screenshots

### Standard label — resolved Location and Status

<img width="1280" height="720" alt="Standard label showing Location Rack A and Status Opened" src="https://github.com/user-attachments/assets/5f7a0a86-2c66-48fb-af14-10726a5fd2d1" />

### Designer label — `{location} / {status}`

<img width="1280" height="720" alt="Designer label showing Rack A and Opened" src="https://github.com/user-attachments/assets/a840e886-c8ee-4c00-83c0-349cd46eb541" />