### PR TITLE
fix(spools): AMS location safety and profile picker save UX

### DIFF
--- a/backend/app/api/v1/spools.py
+++ b/backend/app/api/v1/spools.py
@@ -44,6 +44,34 @@ from app.models import (
 )
 from app.services.spool_service import SpoolService
 
+
+def _is_driver_managed_location(location: Location | None) -> bool:
+    """True for AMS/slot locations owned by a printer driver (e.g. Bambuddy).
+
+    These must only be set when the driver assigns after a physical place —
+    not on create/duplicate.
+    """
+    if location is None:
+        return False
+    cf = location.custom_fields
+    if not isinstance(cf, dict):
+        return False
+    managed = cf.get("managed_by")
+    return isinstance(managed, str) and managed.endswith("_plugin")
+
+
+async def _clear_driver_managed_create_location(
+    db: AsyncSession, spool_data: dict
+) -> None:
+    loc_id = spool_data.get("location_id")
+    if not loc_id:
+        return
+    result = await db.execute(select(Location).where(Location.id == loc_id))
+    location = result.scalar_one_or_none()
+    if _is_driver_managed_location(location):
+        spool_data["location_id"] = None
+
+
 router_locations = APIRouter(prefix="/locations", tags=["locations"])
 
 
@@ -378,6 +406,8 @@ async def create_spool(
 
     spool_data = data.model_dump()
 
+    await _clear_driver_managed_create_location(db, spool_data)
+
     # Cascade fields from Filament if not provided
     if spool_data.get("empty_spool_weight_g") is None:
         spool_data["empty_spool_weight_g"] = (
@@ -469,6 +499,8 @@ async def create_spools_bulk(
         )
 
     spool_data = data.model_dump(exclude={"quantity"})
+
+    await _clear_driver_managed_create_location(db, spool_data)
 
     # Cascade fields from Filament if not provided
     if spool_data.get("empty_spool_weight_g") is None:

--- a/frontend/src/lib/cloud-profile-picker.ts
+++ b/frontend/src/lib/cloud-profile-picker.ts
@@ -324,13 +324,13 @@ function isProfileInvalid(
 
 function displayBaseForPicker(
   selectedBase: string,
-  cov: ProfileCoverage | undefined,
-  presets: any[]
+  _cov?: ProfileCoverage,
+  _presets?: any[]
 ): string {
-  if (!selectedBase) return ''
-  if (isProfileInvalid(cov, selectedBase)) return ''
-  if (presets.length > 0 && !presetBases(presets).has(selectedBase)) return ''
-  return selectedBase
+  // Always keep the committed base name visible. Coverage / catalog mismatches
+  // are shown via the invalid/fallback shell state — blanking the field after a
+  // successful save made it look like the override was cleared (reload fixed it).
+  return selectedBase || ''
 }
 
 function renderStaleNotice(staleBase: string, model: string, t: TranslateFn): string {
@@ -1445,7 +1445,32 @@ export async function initPerModelProfilePicker(
       const result = await saveModelProfile(opts, model, baseName)
       profilesByModel = result?.profiles_by_model || profilesByModel
       coverage = result?.coverage || coverage
+      // Ensure the just-saved override is present even if the response omitted it.
+      if (baseName) {
+        profilesByModel = {
+          ...profilesByModel,
+          [model]: {
+            ...(profilesByModel[model] || {}),
+            base_name: result?.base_name || baseName,
+            source: 'override',
+          },
+        }
+      }
       modelOverrideMode[model] = true
+      await reloadCoverage()
+      // Keep the combo showing the saved name immediately (coverage reload can
+      // briefly lag behind the write).
+      const mount = rowMounts[model]
+      if (mount && baseName) {
+        const hidden = mount.querySelector(
+          '.slicer-profile-base'
+        ) as HTMLInputElement | null
+        const search = mount.querySelector(
+          '.cloud-combo-search'
+        ) as HTMLInputElement | null
+        if (hidden) hidden.value = baseName
+        if (search) search.value = baseName
+      }
       refreshAll()
       showMsg(
         (opts.t('common.saved') || 'Saved') +

--- a/frontend/src/pages/spools/[id]/index.astro
+++ b/frontend/src/pages/spools/[id]/index.astro
@@ -534,10 +534,28 @@ const { id } = Astro.params
       const deleteConfirmBtn = document.getElementById('btn-delete-confirm') as HTMLButtonElement
       
       document.getElementById('btn-duplicate-spool')?.addEventListener('click', () => {
+        // Copy physical/product fields only. Do NOT carry identity, RFID, AMS
+        // location, status, or remaining weight — those must be set by write-tag /
+        // weigh / driver assign-configure when the new spool is actually placed.
         const dupData = { ...spool }
-        delete dupData.rfid_uid
-        delete dupData.external_id
-        delete dupData.id
+        for (const key of [
+          'id',
+          'rfid_uid',
+          'external_id',
+          'location_id',
+          'location',
+          'status_id',
+          'status',
+          'remaining_weight_g',
+          'last_used_at',
+          'stocked_in_at',
+          'created_at',
+          'updated_at',
+          'printer_params',
+          'events',
+        ]) {
+          delete dupData[key]
+        }
         sessionStorage.setItem('filaman_duplicate_spool', JSON.stringify(dupData))
         window.location.href = '/spools/new'
       })

--- a/frontend/src/pages/spools/new.astro
+++ b/frontend/src/pages/spools/new.astro
@@ -625,6 +625,11 @@ const filamentId = Astro.url.searchParams.get('filament_id')
         if (locationsData) {
           const select = document.getElementById('location_id') as HTMLSelectElement
           locationsData.items.forEach((l: any) => {
+            // AMS/slot locations are driver-managed — only set via scan+place assign.
+            const managedBy = l.custom_fields?.managed_by
+            if (typeof managedBy === 'string' && managedBy.endsWith('_plugin')) {
+              return
+            }
             const option = document.createElement('option')
             option.value = l.id
             option.textContent = l.name
@@ -685,10 +690,8 @@ const filamentId = Astro.url.searchParams.get('filament_id')
               (document.getElementById('spool_width_mm') as HTMLInputElement).value = String(dup.spool_width_mm)
             }
 
-            // Location
-            if (dup.location_id) {
-              (document.getElementById('location_id') as HTMLSelectElement).value = String(dup.location_id)
-            }
+            // Location is intentionally NOT copied from duplicate. AMS/slot
+            // locations must be set only when the driver assigns after a scan+place.
 
             // Lot Number
             if (dup.lot_number) {


### PR DESCRIPTION
## Summary
- Stop spool create/duplicate from claiming driver-managed AMS locations; those slots are only set when Bambuddy assigns after a physical place.
- Keep the per-model cloud profile override visible after save so coverage lag no longer blanks the combo (looked cleared until reload).

## Test plan
- [ ] Duplicate a spool that is currently in an AMS slot — new spool form must not preselect that AMS location; create must not write `location_id` for `*_plugin` managed locations.
- [ ] Create a spool and attempt to pick an AMS/plugin-managed location in the picker — those options should be hidden; API must clear them if forced.
- [ ] On a spool/filament profile picker, set a per-model override (e.g. P2S) and save — the selected base name must remain visible immediately without a page reload.
- [ ] Confirm normal non-AMS location create/duplicate still works.