### PR TITLE
fix: run printer driver lifecycle on the primary worker

### DIFF
--- a/backend/app/api/v1/printers.py
+++ b/backend/app/api/v1/printers.py
@@ -31,6 +31,10 @@ _PRIMARY_PROXY_HEADER = "x-filaman-primary-hop"
 _PRIMARY_PROXY_MAX_HOPS = 12
 _PRIMARY_PROXY_RETRIES = 8
 
+# Changing one of these restarts the printer's driver, and drivers live on the
+# primary worker only.  A request touching them has to be handled there.
+_DRIVER_LIFECYCLE_FIELDS = frozenset({"driver_key", "driver_config", "is_active"})
+
 
 def _is_primary_worker() -> bool:
     """Resolve primary worker state lazily to avoid import cycles."""
@@ -236,6 +240,7 @@ async def list_printers(
 @router.post("", response_model=PrinterResponse, status_code=status.HTTP_201_CREATED)
 async def create_printer(
     data: PrinterCreate,
+    request: Request,
     db: DBSession,
     principal=RequirePermission("printers:create"),
 ):
@@ -254,13 +259,17 @@ async def create_printer(
     await db.commit()
     await db.refresh(printer)
 
-    # Auto-start driver if printer is active (default)
+    # Auto-start driver if printer is active (default).  Only the primary worker
+    # holds drivers, so anywhere else the start has to be handed over.
     if printer.is_active and printer.driver_key:
-        started = await plugin_manager.start_printer(printer)
-        if not started:
-            logger.warning(
-                f"Driver {printer.driver_key} could not be started for new printer {printer.id}"
-            )
+        if not _is_primary_worker():
+            await _driver_lifecycle_via_primary(request, printer.id, "start")
+        else:
+            started = await plugin_manager.start_printer(printer)
+            if not started:
+                logger.warning(
+                    f"Driver {printer.driver_key} could not be started for new printer {printer.id}"
+                )
 
     return printer
 
@@ -379,9 +388,24 @@ async def get_printer(
 async def update_printer(
     printer_id: int,
     data: PrinterUpdate,
+    request: Request,
     db: DBSession,
     principal=RequirePermission("printers:update"),
 ):
+    updates = data.model_dump(exclude_unset=True)
+
+    # The driver restart below is the point of such a change, so the whole
+    # request goes to the worker that can actually perform it, before anything
+    # is written.  That keeps exactly one worker applying the update.
+    if (_DRIVER_LIFECYCLE_FIELDS & updates.keys()) and not _is_primary_worker():
+        payload = await _proxy_to_primary(
+            request,
+            method="PATCH",
+            path=f"/api/v1/printers/{printer_id}",
+            json_body=data.model_dump(exclude_unset=True, mode="json"),
+        )
+        return PrinterResponse.model_validate(payload)
+
     result = await db.execute(
         select(Printer).where(Printer.id == printer_id, Printer.deleted_at.is_(None))
     )
@@ -393,7 +417,6 @@ async def update_printer(
             detail={"code": "not_found", "message": "Printer not found"},
         )
 
-    updates = data.model_dump(exclude_unset=True)
     driver_changed = "driver_key" in updates or "driver_config" in updates
     active_changed = (
         "is_active" in updates and updates["is_active"] != printer.is_active
@@ -423,6 +446,7 @@ async def update_printer(
 @router.delete("/{printer_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_printer(
     printer_id: int,
+    request: Request,
     db: DBSession,
     principal=RequirePermission("printers:delete"),
     delete_params: bool = Query(
@@ -444,8 +468,12 @@ async def delete_printer(
             detail={"code": "not_found", "message": "Printer not found"},
         )
 
-    # Stop driver before soft-delete
-    await plugin_manager.stop_printer(printer_id)
+    # Stop driver before soft-delete.  Only the primary worker holds drivers, so
+    # anywhere else the stop has to be handed over.
+    if not _is_primary_worker():
+        await _driver_lifecycle_via_primary(request, printer_id, "stop")
+    else:
+        await plugin_manager.stop_printer(printer_id)
 
     # Optionally hard-delete calibration data
     if delete_params:
@@ -634,6 +662,28 @@ async def pick_bambuddy_driver(db: DBSession) -> tuple[int, Any]:
             "message": "No Bambuddy driver is running",
         },
     )
+
+
+async def _driver_lifecycle_via_primary(
+    request: Request, printer_id: int, action: str
+) -> None:
+    """Ask the primary worker to start or stop a driver, best effort.
+
+    Drivers live on the primary worker, so a request served anywhere else cannot
+    reach them.  The caller has already committed its own database work, and
+    failing to reach the primary must not undo that, so this only logs.
+    """
+    try:
+        await _proxy_to_primary(
+            request,
+            method="POST",
+            path=f"/api/v1/printers/{printer_id}/driver/{action}",
+        )
+    except Exception as exc:
+        logger.warning(
+            f"Could not {action} the driver for printer {printer_id} on the "
+            f"primary worker: {exc}"
+        )
 
 
 async def _invoke_driver_method(driver: Any, method_name: str, **kwargs: Any) -> Any:
@@ -985,10 +1035,20 @@ async def reconnect_all_printers(
 @router.get("/{printer_id}/driver/debug")
 async def driver_debug_log(
     printer_id: int,
+    request: Request,
     since: str | None = Query(None),
     db: DBSession = None,
     principal: PrincipalDep = None,
 ):
+    # The debug log lives inside the driver instance, so only the primary worker
+    # can answer.  Query parameters travel with the forwarded request.
+    if not _is_primary_worker():
+        return await _proxy_to_primary(
+            request,
+            method="GET",
+            path=f"/api/v1/printers/{printer_id}/driver/debug",
+        )
+
     driver = plugin_manager.drivers.get(printer_id)
     if not driver:
         raise HTTPException(

--- a/backend/tests/test_printers.py
+++ b/backend/tests/test_printers.py
@@ -297,3 +297,138 @@ class TestDriverActionProxy:
 
         assert response.status_code == 502
         assert response.json()["detail"]["code"] == "primary_proxy_invalid_response"
+
+
+class TestDriverLifecycleWorkerRouting:
+    """Drivers live on the primary worker, so routes touching them must hand over.
+
+    Every test here runs with _is_primary_worker() returning False, which is the
+    state of three out of four gunicorn workers and the reason the driver work
+    used to be dropped silently.
+    """
+
+    @pytest.mark.asyncio
+    async def test_driver_config_change_is_handed_to_the_primary_worker(
+        self, auth_client, db_session, mock_plugin_manager
+    ):
+        client, csrf_token = auth_client
+        printer = await _create_printer(db_session, name="Bambu")
+
+        forwarded = {
+            "id": printer.id,
+            "name": "Bambu",
+            "location_id": None,
+            "is_active": True,
+            "driver_key": printer.driver_key,
+            "custom_fields": None,
+        }
+
+        with patch("app.api.v1.printers._is_primary_worker", return_value=False), patch(
+            "app.api.v1.printers._proxy_to_primary",
+            new=AsyncMock(return_value=forwarded),
+        ) as proxy:
+            response = await client.patch(
+                f"/api/v1/printers/{printer.id}",
+                json={"driver_config": {"host": "192.168.0.9"}},
+                headers={"X-CSRF-Token": csrf_token},
+            )
+
+        assert response.status_code == 200
+        proxy.assert_awaited_once()
+        assert proxy.await_args.kwargs["method"] == "PATCH"
+        assert proxy.await_args.kwargs["path"] == f"/api/v1/printers/{printer.id}"
+
+        # The handover happens before the commit, so this worker wrote nothing
+        # and never pretended to restart a driver it does not hold.
+        await db_session.refresh(printer)
+        assert printer.driver_config is None
+        mock_plugin_manager.start_printer.assert_not_awaited()
+        mock_plugin_manager.stop_printer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rename_is_handled_locally(self, auth_client, db_session):
+        client, csrf_token = auth_client
+        printer = await _create_printer(db_session, name="Old Name")
+
+        with patch("app.api.v1.printers._is_primary_worker", return_value=False), patch(
+            "app.api.v1.printers._proxy_to_primary", new=AsyncMock()
+        ) as proxy:
+            response = await client.patch(
+                f"/api/v1/printers/{printer.id}",
+                json={"name": "New Name"},
+                headers={"X-CSRF-Token": csrf_token},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "New Name"
+        # A field that cannot affect the driver must not cost an extra hop.
+        proxy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_primary_worker_restarts_the_driver_itself(
+        self, auth_client, db_session, mock_plugin_manager
+    ):
+        client, csrf_token = auth_client
+        printer = await _create_printer(db_session, name="Bambu")
+
+        with patch("app.api.v1.printers._is_primary_worker", return_value=True), patch(
+            "app.api.v1.printers._proxy_to_primary", new=AsyncMock()
+        ) as proxy:
+            response = await client.patch(
+                f"/api/v1/printers/{printer.id}",
+                json={"driver_config": {"host": "192.168.0.9"}},
+                headers={"X-CSRF-Token": csrf_token},
+            )
+
+        assert response.status_code == 200
+        proxy.assert_not_awaited()
+        mock_plugin_manager.stop_printer.assert_awaited_once()
+        mock_plugin_manager.start_printer.assert_awaited_once()
+        await db_session.refresh(printer)
+        assert printer.driver_config == {"host": "192.168.0.9"}
+
+    @pytest.mark.asyncio
+    async def test_delete_hands_the_stop_over_but_still_soft_deletes(
+        self, auth_client, db_session, mock_plugin_manager
+    ):
+        client, csrf_token = auth_client
+        printer = await _create_printer(db_session, name="Delete Me")
+
+        with patch("app.api.v1.printers._is_primary_worker", return_value=False), patch(
+            "app.api.v1.printers._proxy_to_primary", new=AsyncMock(return_value=None)
+        ) as proxy:
+            response = await client.delete(
+                f"/api/v1/printers/{printer.id}",
+                headers={"X-CSRF-Token": csrf_token},
+            )
+
+        assert response.status_code == 204
+        proxy.assert_awaited_once()
+        assert proxy.await_args.kwargs["path"] == (
+            f"/api/v1/printers/{printer.id}/driver/stop"
+        )
+        # The soft-delete is this worker's own job and stays local.
+        await db_session.refresh(printer)
+        assert printer.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_survives_an_unreachable_primary_worker(
+        self, auth_client, db_session
+    ):
+        client, csrf_token = auth_client
+        printer = await _create_printer(db_session, name="Delete Me Too")
+
+        with patch("app.api.v1.printers._is_primary_worker", return_value=False), patch(
+            "app.api.v1.printers._proxy_to_primary",
+            new=AsyncMock(side_effect=RuntimeError("primary unreachable")),
+        ):
+            response = await client.delete(
+                f"/api/v1/printers/{printer.id}",
+                headers={"X-CSRF-Token": csrf_token},
+            )
+
+        # Stopping the driver is best effort; losing the primary must not keep
+        # the user from deleting a printer.
+        assert response.status_code == 204
+        await db_session.refresh(printer)
+        assert printer.deleted_at is not None


### PR DESCRIPTION
Follow-up to the primary-worker forwarding you hardened in 1.2.44 (6705f9d). The forwarding itself works; four routes just never used it.

## The problem

Drivers live in the primary gunicorn worker only, so `plugin_manager.drivers` is empty in every other worker. All routes under `/driver/...` account for that and hand the request over with `_proxy_to_primary()`. Four routes that also touch `plugin_manager` do not:

| Route | Driver call | Effect on a non-primary worker |
|---|---|---|
| `POST /printers` | `start_printer` | a new printer does not start its driver |
| `PATCH /printers/{id}` | `stop_printer` + `start_printer` | **config change never reaches the running driver** |
| `DELETE /printers/{id}` | `stop_printer` | a deleted printer leaves its driver running |
| `GET /printers/{id}/driver/debug` | `drivers.get()` | answers `driver_not_running` for a driver that is running |

`update_printer` is the one that hurts. It commits the new `driver_config` and then calls `stop_printer` / `start_printer` against an empty registry. The response is a clean 200 and the row is correct, so nothing anywhere reports a problem.

## Reproduction

On my four-worker instance, enabling a driver option through the printer form:

```
GET /api/v1/printers/1               -> driver_config.resolve_shop_images: true
GET /api/v1/printers/1/driver/health -> resolve_shop_images: false
```

Saving again eventually works, because with four workers the request lands on the primary roughly one time in four. An explicit `POST /driver/stop` + `POST /driver/start` always works, since those forward correctly. That intermittency is what makes it hard to pin down from the outside; it reads like "the setting sometimes doesn't apply".

## The change

Where the database write is the point of the request, it stays local and only the driver side effect is handed over, best effort, so a create or delete never fails because the primary is briefly unreachable.

`update_printer` is the exception: the restart is the whole purpose of such a change, so the request itself goes to the primary before anything is written, and only for the three fields that can affect the driver (`driver_key`, `driver_config`, `is_active`). Renaming a printer or moving it to another location costs no extra hop.

`_proxy_to_primary()` is unchanged. Its retries only happen on the 503 raised before any work is done, so forwarding a write cannot apply it twice.

## Tests

Five tests in `TestDriverLifecycleWorkerRouting`, all running with `_is_primary_worker()` returning False, which is the state that used to drop the work. Two of them fail against the current code with `Expected mock to have been awaited once. Awaited 0 times.` - the bug stated as an assertion. The other three pin down what must not change: a rename costs no hop, the primary still restarts the driver itself, and a delete succeeds even when the primary cannot be reached.

Full suite: 725 passed. Two pre-existing failures in `test_color_alpha_migration` and `test_spoolman_import_service` also occur on an unmodified checkout in my environment and are unrelated.

Happy to add a changelog entry if you would rather have it in the PR.
