### PR TITLE
fix: stop importing a Spoolman article number as a shop URL

### DIFF
--- a/backend/app/services/spoolman_import_service.py
+++ b/backend/app/services/spoolman_import_service.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -1125,7 +1126,7 @@ class SpoolmanImportService:
                     default_spool_weight_g=spool_weight,
                     density_g_cm3=fil_data.get("density"),
                     price=fil_data.get("price"),
-                    shop_url=self._clean(fil_data.get("article_number")),
+                    shop_url=self._shop_url(fil_data.get("article_number")),
                     manufacturer_color_name=self._clean(fil_data.get("color_hex")),
                     color_mode=color_mode,
                     multi_color_style=multi_color_style,
@@ -1404,6 +1405,27 @@ class SpoolmanImportService:
         self.db.add(new_mfr)
         await self.db.flush()
         return new_mfr.id
+
+    @classmethod
+    def _shop_url(cls, value: Any) -> str | None:
+        """Keep a bare article number out of the shop URL column.
+
+        Spoolman has no URL field on a filament. Its `article_number` documents
+        itself as "Vendor article number, e.g. EAN, QR code", so importing that
+        value into `shop_url` stores something that is not a link: the filament
+        form renders the field as <input type="url"> and refuses to save such a
+        record, and any code that fills an empty shop_url later finds the field
+        occupied. Some users do keep a real link there, so a value that parses
+        as one is still imported; everything else stays where it belongs, in
+        custom_fields["article_number"].
+        """
+        cleaned = cls._clean(value)
+        if not cleaned:
+            return None
+        parsed = urlparse(cleaned)
+        if parsed.scheme in ("http", "https") and parsed.netloc:
+            return cleaned
+        return None
 
     @staticmethod
     def _clean(value: Any) -> str | None:

--- a/backend/tests/test_spoolman_import_service.py
+++ b/backend/tests/test_spoolman_import_service.py
@@ -1335,3 +1335,36 @@ async def test_import_entities_without_extra_objects(db_session):
     spool = await db_session.scalar(select(Spool))
     assert filament.custom_field_definitions is None
     assert spool.custom_field_definitions is None
+
+
+class TestSpoolmanImportShopUrl:
+    """Spoolman has no URL field, so article_number must not become one."""
+
+    @pytest.mark.parametrize(
+        "article_number",
+        ["33300", "PM70820", "EAN 4260469530012", "  12104  "],
+    )
+    def test_article_numbers_do_not_become_shop_urls(self, article_number):
+        service = SpoolmanImportService(None)
+        assert service._shop_url(article_number) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://eu.store.bambulab.com/de/products/petg-hf",
+            "http://shop.example.com/filament?id=7",
+        ],
+    )
+    def test_a_real_link_is_still_imported(self, value):
+        service = SpoolmanImportService(None)
+        assert service._shop_url(value) == value
+
+    @pytest.mark.parametrize("value", [None, "", "   ", 12104])
+    def test_empty_and_non_string_values_stay_empty(self, value):
+        service = SpoolmanImportService(None)
+        assert service._shop_url(value) is None
+
+    def test_a_scheme_we_cannot_link_to_is_rejected(self):
+        service = SpoolmanImportService(None)
+        assert service._shop_url("javascript:alert(1)") is None
+        assert service._shop_url("file:///etc/passwd") is None


### PR DESCRIPTION
## The problem

`spoolman_import_service.py` maps Spoolman's `article_number` into the filament's `shop_url` column:

```python
shop_url=self._clean(fil_data.get("article_number")),
```

Spoolman documents that field as *"Vendor article number, e.g. EAN, QR code"* (example value `PM70820`) and has no URL field on a filament at all, so for most sources the value landing in `shop_url` is not a link.

Three things follow:

1. The filament form renders `shop_url` as `<input type="url">`, so editing such a filament fails validation on a field the user never filled in.
2. The stored value is useless as a link.
3. Code that fills an empty `shop_url` later - for example a driver plugin resolving a product page - finds the field occupied and leaves it alone.

I hit all three on my own instance: 32 Bambu filaments imported from Spoolman carried a bare five-digit Bambu product code in `shop_url`, could not be saved from the filament form, and blocked the Bambu Lab plugin from writing the real store URL.

## The change

The value is still imported when it parses as an `http`/`https` URL with a host, since some people do keep a real link in `article_number`. Everything else stays where the importer already puts it anyway, in `custom_fields["article_number"]` - so no information is lost either way.

This only affects newly imported filaments. Records that already carry an article number in `shop_url` are untouched, because repairing them is a separate decision with its own migration; I cleaned up my own by hand. Glad to add a repair migration in a follow-up if you want one - I see there is precedent in `test_color_alpha_migration`.

If the current mapping was deliberate, because Spoolman users often do put a link there, then this change should still be safe: that case keeps working.

## Tests

11 parametrised cases covering article numbers, real links, empty and non-string values, and schemes that are not linkable (`javascript:`, `file:`).

Full suite: 731 passed. Two failures in `test_color_alpha_migration` and `test_spoolman_import_service` are pre-existing; they occur on an unmodified checkout in my environment too and are unrelated to this change.

Happy to add a changelog entry if you would rather have it in the PR.
