### PR TITLE
fix(devices): route auto-assign weighs to primary over loopback

### DIFF
--- a/backend/app/api/v1/devices.py
+++ b/backend/app/api/v1/devices.py
@@ -493,17 +493,33 @@ async def weigh_spool(
     # Drivers only live on the primary Gunicorn worker. Proxy the whole request
     # there so auto-assign can reach them; the primary handles measurement too.
     if device.auto_assign_enabled and not _is_primary_worker():
-        try:
-            from app.api.v1.printers import _proxy_to_primary
-            payload = await _proxy_to_primary(
-                request,
-                method="POST",
-                path="/api/v1/devices/scale/weight",
-                json_body=data.model_dump(),
+        from app.api.v1.printers import _PRIMARY_PROXY_HEADER, _proxy_to_primary
+
+        hop = int(request.headers.get(_PRIMARY_PROXY_HEADER, "0") or "0")
+        if hop > 0:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "primary_worker_required",
+                    "message": "Auto-assign requires the primary worker; retrying.",
+                },
             )
-            return WeighResponse.model_validate(payload)
-        except Exception as e:
-            logger.warning(f"Auto-assign primary-proxy failed, running locally: {e}")
+
+        payload = await _proxy_to_primary(
+            request,
+            method="POST",
+            path="/api/v1/devices/scale/weight",
+            json_body=data.model_dump(),
+        )
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={
+                    "code": "primary_proxy_failed",
+                    "message": "Primary worker did not return a valid weigh response.",
+                },
+            )
+        return WeighResponse.model_validate(payload)
 
     service = SpoolService(db)
 

--- a/backend/app/api/v1/printers.py
+++ b/backend/app/api/v1/printers.py
@@ -1,6 +1,7 @@
 import logging
 import inspect
 import contextlib
+import os
 from typing import Any
 
 import httpx
@@ -30,6 +31,14 @@ router = APIRouter(prefix="/printers", tags=["printers"])
 _PRIMARY_PROXY_HEADER = "x-filaman-primary-hop"
 _PRIMARY_PROXY_MAX_HOPS = 12
 _PRIMARY_PROXY_RETRIES = 8
+_DEFAULT_GUNICORN_URL = os.environ.get("FILAMAN_GUNICORN_URL", "http://127.0.0.1:8001")
+
+
+def _primary_proxy_url(path: str) -> str:
+    base = _DEFAULT_GUNICORN_URL.rstrip("/")
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return f"{base}{path}"
 
 # Changing one of these restarts the printer's driver, and drivers live on the
 # primary worker only.  A request touching them has to be handled there.
@@ -88,14 +97,14 @@ async def _proxy_to_primary(
             },
         )
 
-    target = request.url.replace(path=path, query="")
-    # Route through same service endpoint and rely on retry loop to
-    # eventually hit the primary worker.
-    url = str(target)
+    target = _primary_proxy_url(path)
+    # Hit Gunicorn on loopback (not request.url / public Host) and rely on the
+    # retry loop to eventually reach the primary worker.
+    url = target
     headers = _forward_headers(request, hop)
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        for _ in range(_PRIMARY_PROXY_RETRIES):
+    for _ in range(_PRIMARY_PROXY_RETRIES):
+        async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.request(
                 method,
                 url,

--- a/backend/tests/test_devices.py
+++ b/backend/tests/test_devices.py
@@ -391,8 +391,67 @@ class TestWeighSpool:
         await db_session.refresh(spool)
         assert spool.remaining_weight_g == 250.0
 
+    @pytest.mark.asyncio
+    async def test_weigh_spool_auto_assign_proxies_to_primary(self, auth_client, db_session):
+        client, csrf_token = auth_client
+        await _create_device(db_session, device_code="ABC123", auto_assign_enabled=True)
+        token, _ = await _register_device(client, "ABC123", csrf_token)
 
-class TestLocateSpool:
+        manufacturer = await _create_manufacturer(db_session)
+        filament = await _create_filament(db_session, manufacturer.id, default_spool_weight_g=250.0)
+        status = await _get_status(db_session, "new")
+        spool = await _create_spool(db_session, filament.id, status.id, empty_spool_weight_g=None)
+
+        proxied = {
+            "remaining_weight_g": 250.0,
+            "spool_id": spool.id,
+            "filament_name": "Test PLA",
+        }
+
+        with patch("app.api.v1.devices._is_primary_worker", return_value=False), patch(
+            "app.api.v1.printers._proxy_to_primary",
+            new=AsyncMock(return_value=proxied),
+        ) as mock_proxy:
+            response = await client.post(
+                "/api/v1/devices/scale/weight",
+                json={"spool_id": spool.id, "measured_weight_g": 500.0},
+                headers={
+                    **_device_headers(token),
+                    "X-CSRF-Token": csrf_token,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json() == proxied
+        mock_proxy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_weigh_spool_auto_assign_rejects_proxied_hop_on_secondary(
+        self, auth_client, db_session
+    ):
+        client, csrf_token = auth_client
+        await _create_device(db_session, device_code="ABC123", auto_assign_enabled=True)
+        token, _ = await _register_device(client, "ABC123", csrf_token)
+
+        manufacturer = await _create_manufacturer(db_session)
+        filament = await _create_filament(db_session, manufacturer.id)
+        status = await _get_status(db_session, "new")
+        spool = await _create_spool(db_session, filament.id, status.id)
+
+        with patch("app.api.v1.devices._is_primary_worker", return_value=False):
+            response = await client.post(
+                "/api/v1/devices/scale/weight",
+                json={"spool_id": spool.id, "measured_weight_g": 500.0},
+                headers={
+                    **_device_headers(token),
+                    "X-CSRF-Token": csrf_token,
+                    "x-filaman-primary-hop": "1",
+                },
+            )
+
+        assert response.status_code == 503
+        assert response.json()["detail"]["code"] == "primary_worker_required"
+
     @pytest.mark.asyncio
     async def test_locate_spool_success(self, auth_client, db_session):
         client, csrf_token = auth_client

--- a/backend/tests/test_printers.py
+++ b/backend/tests/test_printers.py
@@ -3,7 +3,15 @@ from sqlalchemy import event
 from sqlalchemy.orm.attributes import set_committed_value
 from unittest.mock import AsyncMock, patch
 
+from app.api.v1.printers import _primary_proxy_url
 from app.models import Location, Printer, PrinterSlot
+
+
+class TestPrimaryProxyUrl:
+    def test_primary_proxy_url_uses_loopback(self):
+        assert _primary_proxy_url("/api/v1/devices/scale/weight") == (
+            "http://127.0.0.1:8001/api/v1/devices/scale/weight"
+        )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- When auto-assign is enabled, secondary Gunicorn workers proxy `/devices/scale/weight` to the primary over loopback (`127.0.0.1:8001`) instead of the public Host URL.
- On proxy failure, return 503 with `primary_worker_required` / `primary_proxy_failed` instead of silently weighing locally without drivers (which left AMS pending unarmed).
- Also arms pending with the weigh request's RFID UID and avoids overwriting an existing remaining weight from older `/rfid-result` payloads.

## Test plan
- [ ] Multi-worker Gunicorn (`-w > 1`): weigh with auto-assign enabled; pending arms and AMS insert assigns
- [ ] Single-worker: weigh + auto-assign still works
- [ ] `pytest backend/tests/test_devices.py backend/tests/test_printers.py` for proxy/weigh cases