### PR TITLE
fix: keep the port in the Host header handed to the backend

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -106,7 +106,7 @@ http {
 
         location /api/ {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -117,7 +117,7 @@ http {
         # SSE endpoint — disable buffering for real-time events
         location = /api/v1/events/stream {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -134,7 +134,7 @@ http {
             limit_req zone=login_limit burst=5 nodelay;
 
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -144,7 +144,7 @@ http {
         # Other auth endpoints (no rate limit needed)
         location /auth/ {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -153,7 +153,7 @@ http {
 
         location /health {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -163,7 +163,7 @@ http {
         # Plugin pages — served by backend (dynamic)
         location /plugin-page/ {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -173,7 +173,7 @@ http {
         # SpoolmanAPI plugin mount prefix
         location /spoolman/ {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
@@ -198,7 +198,7 @@ http {
         # Named location — fallback for routes without a static file
         location @backend {
             proxy_pass http://backend;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;


### PR DESCRIPTION
## What happens

On any installation not served on port 80 or 443, the hand-over to the primary worker fails and takes the spool assignment with it. From a live instance running on `:8002`:

```
WARNING app.api.v1.devices Auto-assign primary-proxy failed, running locally: 403:
{'code': 'proxy_failed', 'message': '[{"error":{"address":"/devices/scale/weight",
"description":"unauthorized user","type":1}}]'}
```

That error text is not FilaMan's. It comes from an unrelated service on port 80 of the same machine.

## Why

`nginx.conf` passes `proxy_set_header Host $host`, and nginx' `$host` is the hostname **without** the port. A request arriving at `192.168.4.100:8002` therefore reaches the app announcing itself as `192.168.4.100`.

`_proxy_to_primary` builds its target from `request.url` (`printers.py:87`), so the call leaves for port 80. Reproduced from inside the container:

```
POST http://192.168.4.100:8002/api/v1/devices/scale/weight  -> 401 {"detail":{"code":"unauthenticated"...}}   FilaMan
POST http://192.168.4.100/api/v1/devices/scale/weight       -> 403 [{"error":{...,"description":"unauthorized user"}}]   somebody else
```

The second is exactly what the log recorded.

Drivers live on the primary worker, so with four workers three out of four scale reports need this hand-over. The same path sits behind `GET /printers/{id}/driver/health?refresh=1`, where it shows up as 403s in the access log while the page merely looks unresponsive.

## Why it matters beyond auto-assign

The driver lifecycle fix in v1.2.46 routes printer config changes to the primary worker through this same `_proxy_to_primary`. On an installation served on a non-standard port that hand-over is aimed at the wrong service: `update_printer` surfaces the failure to the user, while `_driver_lifecycle_via_primary` swallows it as a warning and the driver quietly keeps its old config until the next restart. Whether it bites depends on which of the four workers answers, so it looks intermittent.

## What this changes

`$http_host` instead of `$host` in the eight `proxy_pass` blocks: the Host header as the client sent it, port included. Installations on port 80 or 443 see no difference, which is why this went unnoticed.

## Testing

Config validated with `nginx -t` inside the running container. I did not reload nginx on that instance, so the end-to-end path is argued from the reproduction above rather than from a live run - happy to confirm it on the instance if you would like that before merging.