### PR TITLE
Add Display API: read-only feed for dashboards and swatch boards

### DIFF
--- a/backend/app/api/v1/display.py
+++ b/backend/app/api/v1/display.py
@@ -1,0 +1,89 @@
+"""GET /api/v1/display — read-only feed for dashboards and digital swatch boards.
+
+Auth: any principal with ``display:read`` — a logged-in user, an API key, or
+a registered device whose scopes include ``display:read`` (so a wall panel
+authenticates like a scale: ``Authorization: Device <token>``).
+
+Polling: send ``If-None-Match`` with the last ``ETag`` and an unchanged board
+answers ``304`` with no body.  ``?fields=slots`` trims the payload to what a
+swatch board needs.  See ``docs/display-api.md``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
+from sqlalchemy import select
+
+from app.api.deps import DBSession, RequirePermission
+from app.models import Printer
+from app.services.display_service import build_display, compute_etag
+
+router = APIRouter(prefix="/display", tags=["display"])
+
+
+async def _driver_state(printer: Printer) -> dict[str, Any] | None:
+    """Ask the printer's running driver for live state; None when unsupported."""
+    from app.plugins.manager import plugin_manager
+
+    driver = plugin_manager.drivers.get(printer.id)
+    getter = getattr(driver, "get_display_state", None)
+    if driver is None or getter is None:
+        return None
+    result = getter()
+    if inspect.isawaitable(result):
+        result = await result
+    return result if isinstance(result, dict) else None
+
+
+def _respond(request: Request, response: Response, payload: dict[str, Any]) -> Any:
+    etag = compute_etag(payload)
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = "no-cache"
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
+    return payload
+
+
+@router.get("")
+async def get_display(
+    request: Request,
+    response: Response,
+    db: DBSession,
+    fields: Literal["full", "slots"] = Query("full"),
+    principal=RequirePermission("display:read"),
+):
+    """All active printers with their AMS slots."""
+    result = await db.execute(
+        select(Printer)
+        .where(Printer.is_active.is_(True), Printer.deleted_at.is_(None))
+        .order_by(Printer.id)
+    )
+    printers = list(result.scalars().all())
+    payload = await build_display(db, printers, _driver_state, fields=fields)
+    return _respond(request, response, payload)
+
+
+@router.get("/printers/{printer_id}")
+async def get_printer_display(
+    printer_id: int,
+    request: Request,
+    response: Response,
+    db: DBSession,
+    fields: Literal["full", "slots"] = Query("full"),
+    principal=RequirePermission("display:read"),
+):
+    """One printer; same shape as the list entry, wrapped in the same envelope."""
+    result = await db.execute(
+        select(Printer).where(Printer.id == printer_id, Printer.deleted_at.is_(None))
+    )
+    printer = result.scalar_one_or_none()
+    if printer is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": "Printer not found"},
+        )
+    payload = await build_display(db, [printer], _driver_state, fields=fields)
+    return _respond(request, response, payload)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -5,6 +5,7 @@ from app.api.v1.app_settings_admin import public_router as app_settings_public_r
 from app.api.v1.app_settings_admin import router as app_settings_admin_router
 from app.api.v1.dashboard import router as dashboard_router
 from app.api.v1.devices import router as devices_router
+from app.api.v1.display import router as display_router
 from app.api.v1.events import router as events_router
 from app.api.v1.filamentdb_proxy import router as filamentdb_router
 from app.api.v1.filaments import router, router_colors, router_filaments
@@ -40,6 +41,7 @@ api_router.include_router(label_presets_router)
 api_router.include_router(printers_router)
 api_router.include_router(admin_router)
 api_router.include_router(devices_router)
+api_router.include_router(display_router)
 api_router.include_router(system_router)
 api_router.include_router(spoolman_router)
 api_router.include_router(plugin_public_router)

--- a/backend/app/core/seeds/__init__.py
+++ b/backend/app/core/seeds/__init__.py
@@ -162,6 +162,11 @@ PERMISSIONS = [
     },
     {"key": "printers:read", "description": "View printers", "category": "printers"},
     {
+        "key": "display:read",
+        "description": "Read the display feed (dashboards, swatch boards)",
+        "category": "display",
+    },
+    {
         "key": "printers:create",
         "description": "Create printers",
         "category": "printers",
@@ -252,6 +257,7 @@ VIEWER_PERMISSIONS = [
     "spools:read",
     "spool_events:read",
     "printers:read",
+    "display:read",
     "ratings:read",
     "colors:read",
 ]
@@ -261,6 +267,7 @@ USER_PERMISSIONS = [
     "manufacturers:read",
     "locations:read",
     "printers:read",
+    "display:read",
     "ratings:read",
     "spools:read",
     "spools:create",

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -43,6 +43,19 @@ class BaseDriver(ABC):
     def validate_config(self) -> None:
         pass
 
+    async def get_display_state(self) -> dict[str, Any] | None:
+        """Live printer/AMS state for the Display API (GET /api/v1/display).
+
+        Optional.  Return None (default) and the display still shows the
+        spools FilaMan has assigned to this printer's slots.  Return a dict to
+        add live tray contents, job progress, temperatures and the active
+        slot; see app.services.display_service.normalize_driver_state for
+        the accepted keys (Bambu/Bambuddy status dicts are accepted as-is).
+        Must be cheap: it is called on every poll of the display feed, so
+        return cached state rather than querying the printer.
+        """
+        return None
+
     def log_debug(self, direction: str, topic: str, payload: Any) -> None:
         """Add a message to the debug ring buffer (only when debug console is open)."""
         if not self._debug_enabled:

--- a/backend/app/services/display_service.py
+++ b/backend/app/services/display_service.py
@@ -37,6 +37,7 @@ from app.models import Filament, FilamentColor, Printer, PrinterSlot, PrinterSlo
 SCHEMA_VERSION = 3
 DEFAULT_EMPTY_COLOR = "#202020"
 AMS_HT_ID_BASE = 128  # Bambu numbers AMS-HT units from 128
+EXTERNAL_IDS = {254, 255}  # Bambu: external spool holder / virtual tray
 SLOTS_PER_AMS = 4
 
 
@@ -91,12 +92,17 @@ def ams_letter(ams_id: int) -> str:
 
 
 def ams_kind(ams_id: int, unit: dict[str, Any] | None = None) -> str:
+    """``ams`` (4 slots) | ``ams_ht`` (1 slot) | ``external`` (spool holder, 1 slot)."""
+    if ams_id in EXTERNAL_IDS or (unit and unit.get("is_external")):
+        return "external"
     if unit and unit.get("is_ams_ht"):
         return "ams_ht"
     return "ams_ht" if ams_id >= AMS_HT_ID_BASE else "ams"
 
 
 def ams_label(ams_id: int, kind: str) -> str:
+    if kind == "external":
+        return "External"
     if kind == "ams_ht":
         n = ams_id - AMS_HT_ID_BASE + 1 if ams_id >= AMS_HT_ID_BASE else ams_id + 1
         return f"HT{n}"
@@ -104,7 +110,7 @@ def ams_label(ams_id: int, kind: str) -> str:
 
 
 def slot_label(ams_id: int, slot: int, kind: str) -> str:
-    if kind == "ams_ht":
+    if kind in ("ams_ht", "external"):
         return ams_label(ams_id, kind)
     return f"{ams_letter(ams_id)}{slot + 1}"
 
@@ -509,7 +515,7 @@ def build_printer_display(
         unit = units_by_id[ams_id]
         kind = unit["kind"]
         slot_nos = unit.pop("_slot_nos")
-        if kind != "ams_ht":
+        if kind == "ams":
             slot_nos |= set(range(SLOTS_PER_AMS))
         elif not slot_nos:
             slot_nos = {0}

--- a/backend/app/services/display_service.py
+++ b/backend/app/services/display_service.py
@@ -1,0 +1,596 @@
+"""Display API: one read-only feed for dashboards and digital swatch boards.
+
+Anyone building a wall display, an e-paper swatch panel or a tablet kiosk
+polls ``GET /api/v1/display`` and gets, per printer, every AMS unit and slot
+with the loaded filament's colour, material, manufacturer and remaining
+amount, plus a small printer/job summary.  Nothing here knows about a
+particular piece of hardware; formatting (locale, clocks, thresholds) is the
+client's job, so the feed carries raw numbers only.
+
+Two data sources are merged:
+
+* **FilaMan itself** — ``printer_slots`` + ``printer_slot_assignments`` say
+  which spool sits in which slot.  This alone yields a swatch board, even for
+  a printer whose driver reports nothing live.
+* **The printer driver (optional)** — a driver may implement
+  ``get_display_state()`` returning live tray/job/temperature data (see
+  :func:`normalize_driver_state` for the accepted shape).  The Bambuddy
+  driver hands back the raw Bambuddy printer status; the extractor is
+  tolerant of that shape and of the documented normalised one.
+
+Schema version 3.  Bump when a field changes meaning; adding fields is free.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import Filament, FilamentColor, Printer, PrinterSlot, PrinterSlotAssignment, Spool
+
+SCHEMA_VERSION = 3
+DEFAULT_EMPTY_COLOR = "#202020"
+AMS_HT_ID_BASE = 128  # Bambu numbers AMS-HT units from 128
+SLOTS_PER_AMS = 4
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+
+def _first(payload: dict[str, Any], keys: tuple[str, ...], default: Any = None) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if value not in (None, ""):
+            return value
+    return default
+
+
+def _deep_get(payload: Any, path: tuple[str, ...]) -> Any:
+    current = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        if value in (None, ""):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Any) -> int | None:
+    f = _as_float(value)
+    return int(round(f)) if f is not None else None
+
+
+def normalize_hex_color(value: Any, default: str = DEFAULT_EMPTY_COLOR) -> str:
+    """``RRGGBB`` / ``#RRGGBB`` / ``RRGGBBAA`` -> ``#RRGGBB`` (upper-case)."""
+    if not value:
+        return default
+    text = str(value).strip().lstrip("#")
+    if len(text) >= 6 and all(c in "0123456789abcdefABCDEF" for c in text[:6]):
+        return f"#{text[:6].upper()}"
+    return default
+
+
+def ams_letter(ams_id: int) -> str:
+    return chr(ord("A") + ams_id) if 0 <= ams_id < 26 else str(ams_id)
+
+
+def ams_kind(ams_id: int, unit: dict[str, Any] | None = None) -> str:
+    if unit and unit.get("is_ams_ht"):
+        return "ams_ht"
+    return "ams_ht" if ams_id >= AMS_HT_ID_BASE else "ams"
+
+
+def ams_label(ams_id: int, kind: str) -> str:
+    if kind == "ams_ht":
+        n = ams_id - AMS_HT_ID_BASE + 1 if ams_id >= AMS_HT_ID_BASE else ams_id + 1
+        return f"HT{n}"
+    return f"AMS {ams_letter(ams_id)}"
+
+
+def slot_label(ams_id: int, slot: int, kind: str) -> str:
+    if kind == "ams_ht":
+        return ams_label(ams_id, kind)
+    return f"{ams_letter(ams_id)}{slot + 1}"
+
+
+def parse_slot_index(slot: PrinterSlot) -> tuple[int, int]:
+    """(ams_id, tray) for a FilaMan printer slot.
+
+    Drivers store ``custom_fields.slot_index = "<ams>-<tray>"``; without it
+    the slot number is interpreted as consecutive 4-slot AMS units.
+    """
+    raw = (slot.custom_fields or {}).get("slot_index")
+    if isinstance(raw, str) and "-" in raw:
+        a, _, t = raw.partition("-")
+        try:
+            return int(a), int(t)
+        except ValueError:
+            pass
+    return slot.slot_no // SLOTS_PER_AMS, slot.slot_no % SLOTS_PER_AMS
+
+
+# ---------------------------------------------------------------------------
+# driver state normalisation
+# ---------------------------------------------------------------------------
+
+
+def extract_ams_units(state: dict[str, Any]) -> list[dict[str, Any]]:
+    """Find the AMS list in a driver state (normalised or Bambuddy-shaped)."""
+    for candidate in (
+        state.get("ams"),
+        _deep_get(state, ("print", "ams", "ams")),
+        _deep_get(state, ("ams", "ams")),
+        _deep_get(state, ("print", "ams")),
+    ):
+        if isinstance(candidate, dict) and isinstance(candidate.get("ams"), list):
+            candidate = candidate["ams"]
+        if isinstance(candidate, list):
+            return [u for u in candidate if isinstance(u, dict)]
+    return []
+
+
+def extract_trays(unit: dict[str, Any]) -> list[dict[str, Any]]:
+    for key in ("slots", "trays", "tray"):
+        trays = unit.get(key)
+        if isinstance(trays, list):
+            return [t for t in trays if isinstance(t, dict)]
+    return []
+
+
+def _tray_has_filament(tray: dict[str, Any]) -> bool:
+    return bool(str(_first(tray, ("material", "tray_type", "filament_type"), "") or "").strip())
+
+
+def normalize_driver_state(raw: dict[str, Any] | None) -> dict[str, Any]:
+    """Reduce whatever a driver returned to the documented live-state shape.
+
+    Accepted input keys (first match wins), so a driver can return either the
+    normalised shape or Bambu/Bambuddy status verbatim::
+
+        connected            bool
+        state                gcode_state | status
+        job.name             subtask_name | gcode_file | current_print.filename
+        job.progress         progress | mc_percent (0-100)
+        job.layer / total    layer_num | current_layer, total_layers | total_layer_num
+        job.remaining_sec    remaining_seconds | remaining_time (minutes) | mc_remaining_time
+        temperatures.*       temperatures.{nozzle,bed,chamber,*_target} | nozzle_temper ...
+        speed_level          speed_level | spd_lvl
+        active_tray          active_tray | tray_now (ams*4+slot, 254/255 = none)
+        hms                  [{code, msg}] | []
+        ams[]                ams_id|id, is_ams_ht, temperature|temp, humidity,
+                             dry_status, dry_target_temp, dry_time,
+                             slots|trays|tray[]: slot|id|tray_id, material|tray_type,
+                             color|tray_color, remaining_percent|remain, tag_uid,
+                             tray_uuid, nozzle_min|nozzle_temp_min, nozzle_max|
+                             nozzle_temp_max, color_name|tray_id_name|tray_sub_brands,
+                             active | state==27
+    """
+    raw = raw or {}
+    job_src = raw.get("job") if isinstance(raw.get("job"), dict) else {}
+    cur = raw.get("current_print") if isinstance(raw.get("current_print"), dict) else {}
+    temps = raw.get("temperatures") if isinstance(raw.get("temperatures"), dict) else {}
+
+    remaining_seconds = _as_int(_first(job_src, ("remaining_seconds",)))
+    if remaining_seconds is None:
+        minutes = _as_float(
+            _first(
+                raw,
+                ("remaining_seconds",),
+                None,
+            )
+        )
+        if minutes is not None:
+            remaining_seconds = int(minutes)
+        else:
+            minutes = _as_float(
+                _first(
+                    job_src,
+                    ("remaining_minutes", "remaining_time"),
+                    _first(raw, ("remaining_time", "mc_remaining_time"), _first(cur, ("remaining_time",))),
+                )
+            )
+            remaining_seconds = int(minutes * 60) if minutes is not None else None
+
+    job_name = _first(
+        job_src,
+        ("name",),
+        _first(raw, ("subtask_name", "gcode_file", "task_name"), _first(cur, ("filename", "name", "subtask_name"), "")),
+    )
+    if isinstance(job_name, dict):
+        job_name = _first(job_name, ("filename", "name"), "")
+
+    progress = _as_int(
+        _first(job_src, ("progress",), _first(raw, ("progress", "mc_percent"), _first(cur, ("progress",))))
+    )
+    if progress is not None:
+        progress = max(0, min(100, progress))
+
+    active_tray = _as_int(_first(raw, ("active_tray", "tray_now")))
+    if active_tray is None:
+        active_tray = _as_int(_deep_get(raw, ("ams", "tray_now")))
+    if active_tray is not None and (active_tray < 0 or active_tray >= 254):
+        active_tray = None
+
+    hms_raw = raw.get("hms") or raw.get("hms_errors") or []
+    hms: list[dict[str, Any]] = []
+    if isinstance(hms_raw, list):
+        for item in hms_raw[:10]:
+            if isinstance(item, dict):
+                hms.append(
+                    {
+                        "code": str(_first(item, ("code", "full_code", "attr"), "") or ""),
+                        "message": str(_first(item, ("msg", "message", "description", "desc"), "") or ""),
+                    }
+                )
+            elif item:
+                hms.append({"code": "", "message": str(item)})
+
+    units: list[dict[str, Any]] = []
+    for unit in extract_ams_units(raw):
+        ams_id = _as_int(_first(unit, ("ams_id", "id"), 0)) or 0
+        kind = ams_kind(ams_id, unit)
+        drying = None
+        if _first(unit, ("dry_status", "dry_target_temp", "dry_time")) is not None:
+            drying = {
+                "status": _first(unit, ("dry_status",)),
+                "target_temp": _as_float(_first(unit, ("dry_target_temp",))),
+                "time": _as_int(_first(unit, ("dry_time",))),
+            }
+        slots: list[dict[str, Any]] = []
+        for tray in extract_trays(unit):
+            slot_no = _as_int(_first(tray, ("slot", "id", "tray_id"), 0)) or 0
+            slots.append(
+                {
+                    "slot": slot_no,
+                    "material": str(_first(tray, ("material", "tray_type", "filament_type"), "") or ""),
+                    "color": normalize_hex_color(_first(tray, ("color", "tray_color", "filament_color")), ""),
+                    "color_name": str(_first(tray, ("color_name", "tray_id_name", "tray_sub_brands"), "") or ""),
+                    "remaining_percent": _as_int(_first(tray, ("remaining_percent", "remain"))),
+                    "nozzle_min": _as_int(_first(tray, ("nozzle_min", "nozzle_temp_min"))),
+                    "nozzle_max": _as_int(_first(tray, ("nozzle_max", "nozzle_temp_max"))),
+                    "rfid": any(
+                        tray.get(k) not in (None, "", 0, "0", "0000000000000000")
+                        for k in ("tag_uid", "tray_uuid", "rfid_uid")
+                    ),
+                    "active": bool(_first(tray, ("active", "is_active"), False)) or tray.get("state") == 27,
+                    "has_filament": _tray_has_filament(tray),
+                }
+            )
+        units.append(
+            {
+                "ams_id": ams_id,
+                "kind": kind,
+                "temperature": _as_float(_first(unit, ("temperature", "temp"))),
+                "humidity": _as_float(_first(unit, ("humidity", "humidity_raw"))),
+                "drying": drying,
+                "slots": slots,
+            }
+        )
+
+    return {
+        "connected": bool(raw.get("connected", True)) if raw else False,
+        "state": str(_first(raw, ("state", "gcode_state", "status"), "unknown")),
+        "job": {
+            "name": str(job_name or ""),
+            "progress": progress,
+            "layer": _as_int(_first(job_src, ("layer",), _first(raw, ("layer_num", "current_layer"), _first(cur, ("current_layer", "layer_num"))))),
+            "total_layers": _as_int(_first(job_src, ("total_layers",), _first(raw, ("total_layers", "total_layer_num"), _first(cur, ("total_layers",))))),
+            "remaining_seconds": remaining_seconds,
+        },
+        "temperatures": {
+            "nozzle": _as_int(_first(temps, ("nozzle",), _first(raw, ("nozzle_temper",)))),
+            "nozzle_target": _as_int(_first(temps, ("nozzle_target",), _first(raw, ("nozzle_target_temper",)))),
+            "bed": _as_int(_first(temps, ("bed",), _first(raw, ("bed_temper",)))),
+            "bed_target": _as_int(_first(temps, ("bed_target",), _first(raw, ("bed_target_temper",)))),
+            "chamber": _as_int(_first(temps, ("chamber",), _first(raw, ("chamber_temper",)))),
+            "chamber_target": _as_int(_first(temps, ("chamber_target",))),
+        },
+        "speed_level": _as_int(_first(raw, ("speed_level", "spd_lvl"))),
+        "active_tray": active_tray,
+        "hms": hms,
+        "ams": units,
+    }
+
+
+# ---------------------------------------------------------------------------
+# FilaMan side: spools per slot
+# ---------------------------------------------------------------------------
+
+
+def _spool_swatch(spool: Spool) -> dict[str, Any]:
+    filament = spool.filament
+    manufacturer = filament.manufacturer.name if filament and filament.manufacturer else ""
+    color_hex = ""
+    color_name = ""
+    if filament and filament.filament_colors:
+        colors = sorted(filament.filament_colors, key=lambda fc: getattr(fc, "position", 0) or 0)
+        if colors and colors[0].color:
+            color_hex = colors[0].color.hex_code or ""
+            color_name = colors[0].color.name or ""
+    if not color_name and filament:
+        color_name = filament.manufacturer_color_name or ""
+
+    remaining = spool.remaining_weight_g
+    initial = spool.initial_total_weight_g
+    empty = spool.empty_spool_weight_g
+    net_initial = None
+    if initial is not None and empty is not None:
+        net_initial = max(initial - empty, 0)
+    remaining_percent = None
+    if remaining is not None and net_initial:
+        remaining_percent = max(0, min(100, int(round(remaining / net_initial * 100))))
+
+    return {
+        "spool_id": spool.id,
+        "filament": filament.designation if filament else "",
+        "material": (filament.material_type if filament else "") or "",
+        "manufacturer": manufacturer,
+        "color": normalize_hex_color(color_hex, ""),
+        "color_name": color_name,
+        "remaining_grams": int(round(remaining)) if remaining is not None else None,
+        "remaining_percent": remaining_percent,
+        "nozzle_min": _as_int(getattr(filament, "nozzle_temp_min", None)) if filament else None,
+        "nozzle_max": _as_int(getattr(filament, "nozzle_temp_max", None)) if filament else None,
+        "rfid": bool(spool.rfid_uid or getattr(spool, "rfid_uid_2", None)),
+        "last_used": spool.last_used_at.isoformat() if spool.last_used_at else None,
+    }
+
+
+async def load_slot_spools(db: AsyncSession, printer_id: int) -> dict[tuple[int, int], dict[str, Any]]:
+    """{(ams_id, tray): swatch} from FilaMan's slot assignments for one printer."""
+    result = await db.execute(
+        select(PrinterSlot)
+        .where(PrinterSlot.printer_id == printer_id, PrinterSlot.is_active.is_(True))
+        .options(
+            selectinload(PrinterSlot.assignment)
+            .selectinload(PrinterSlotAssignment.spool)
+            .selectinload(Spool.filament)
+            .selectinload(Filament.manufacturer),
+            selectinload(PrinterSlot.assignment)
+            .selectinload(PrinterSlotAssignment.spool)
+            .selectinload(Spool.filament)
+            .selectinload(Filament.filament_colors)
+            .selectinload(FilamentColor.color),
+        )
+        .order_by(PrinterSlot.slot_no)
+    )
+    out: dict[tuple[int, int], dict[str, Any]] = {}
+    for slot in result.scalars().all():
+        key = parse_slot_index(slot)
+        assignment = slot.assignment
+        entry: dict[str, Any] = {"present": bool(assignment and assignment.present)}
+        if assignment and assignment.spool:
+            entry.update(_spool_swatch(assignment.spool))
+        out[key] = entry
+    return out
+
+
+# ---------------------------------------------------------------------------
+# merge
+# ---------------------------------------------------------------------------
+
+
+def _merge_slot(
+    ams_id: int,
+    slot_no: int,
+    kind: str,
+    live: dict[str, Any] | None,
+    fm: dict[str, Any] | None,
+) -> dict[str, Any]:
+    live = live or {}
+    fm = fm or {}
+    has_spool = fm.get("spool_id") is not None
+    has_live = bool(live.get("has_filament"))
+    empty = not has_spool and not has_live
+
+    remaining_percent = fm.get("remaining_percent")
+    remaining_source: str | None = "filaman" if remaining_percent is not None else None
+    if remaining_percent is None and live.get("remaining_percent") is not None:
+        rp = live["remaining_percent"]
+        if 0 <= rp <= 100:
+            remaining_percent = rp
+            remaining_source = "printer"
+
+    return {
+        "ams_id": ams_id,
+        "slot": slot_no,
+        "label": slot_label(ams_id, slot_no, kind),
+        "empty": empty,
+        "active": bool(live.get("active", False)),
+        "color": fm.get("color") or live.get("color") or DEFAULT_EMPTY_COLOR,
+        "color_name": fm.get("color_name") or live.get("color_name") or "",
+        "material": fm.get("material") or live.get("material") or "",
+        "manufacturer": fm.get("manufacturer") or "",
+        "filament": fm.get("filament") or "",
+        "spool_id": fm.get("spool_id"),
+        "remaining_percent": remaining_percent,
+        "remaining_grams": fm.get("remaining_grams"),
+        "remaining_source": remaining_source,
+        "nozzle_min": fm.get("nozzle_min") if fm.get("nozzle_min") is not None else live.get("nozzle_min"),
+        "nozzle_max": fm.get("nozzle_max") if fm.get("nozzle_max") is not None else live.get("nozzle_max"),
+        "rfid": bool(fm.get("rfid") or live.get("rfid")),
+        "last_used": fm.get("last_used"),
+        "backup_of": None,
+    }
+
+
+def _apply_backups(slots: list[dict[str, Any]]) -> None:
+    """Mark slots holding the same material+colour as another slot."""
+    for slot in slots:
+        if slot["empty"] or not slot["material"]:
+            continue
+        for other in slots:
+            if other is slot or other["empty"]:
+                continue
+            if (
+                other["material"].lower() == slot["material"].lower()
+                and other["color"] == slot["color"]
+            ):
+                slot["backup_of"] = other["label"]
+                break
+
+
+def _apply_active(units: list[dict[str, Any]], active_tray: int | None) -> dict[str, Any] | None:
+    """Return {ams_id, slot} of the active slot; honour tray_now over per-tray flags."""
+    if active_tray is not None:
+        ams_id, slot_no = divmod(active_tray, SLOTS_PER_AMS)
+        for unit in units:
+            for slot in unit["slots"]:
+                slot["active"] = unit["ams_id"] == ams_id and slot["slot"] == slot_no and not slot["empty"]
+    for unit in units:
+        for slot in unit["slots"]:
+            if slot["active"]:
+                return {"ams_id": unit["ams_id"], "slot": slot["slot"]}
+    return None
+
+
+def _build_alerts(printer_name: str, live: dict[str, Any], units: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    alerts: list[dict[str, Any]] = []
+    state = str(live.get("state") or "").upper()
+    if live and not live.get("connected", True):
+        alerts.append({"id": "printer-offline", "severity": "danger", "title": "Printer offline", "detail": printer_name, "source": "printer"})
+    if state in {"PAUSE", "PAUSED"}:
+        alerts.append({"id": "print-paused", "severity": "warn", "title": "Print paused", "detail": live.get("job", {}).get("name", ""), "source": "printer"})
+    if state in {"FAILED", "FAIL", "ERROR"}:
+        alerts.append({"id": "print-failed", "severity": "danger", "title": "Print failed", "detail": live.get("job", {}).get("name", ""), "source": "printer"})
+    for i, item in enumerate(live.get("hms") or []):
+        code = item.get("code") or f"hms-{i}"
+        alerts.append({"id": f"hms-{code}", "severity": "danger", "title": f"HMS {code}".strip(), "detail": item.get("message", ""), "source": "hms"})
+    return alerts
+
+
+def build_printer_display(
+    printer: Printer,
+    fm_slots: dict[tuple[int, int], dict[str, Any]],
+    driver_state: dict[str, Any] | None,
+) -> dict[str, Any]:
+    live = normalize_driver_state(driver_state) if driver_state is not None else None
+
+    # Collect AMS units from both sources; live wins for climate, FilaMan fills spools.
+    units_by_id: dict[int, dict[str, Any]] = {}
+    live_slots: dict[tuple[int, int], dict[str, Any]] = {}
+    if live:
+        for unit in live["ams"]:
+            units_by_id[unit["ams_id"]] = {
+                "ams_id": unit["ams_id"],
+                "kind": unit["kind"],
+                "temperature": unit["temperature"],
+                "humidity": unit["humidity"],
+                "drying": unit["drying"],
+                "_slot_nos": {s["slot"] for s in unit["slots"]},
+            }
+            for s in unit["slots"]:
+                live_slots[(unit["ams_id"], s["slot"])] = s
+    for (ams_id, slot_no) in fm_slots:
+        unit = units_by_id.setdefault(
+            ams_id,
+            {"ams_id": ams_id, "kind": ams_kind(ams_id), "temperature": None, "humidity": None, "drying": None, "_slot_nos": set()},
+        )
+        unit["_slot_nos"].add(slot_no)
+
+    units: list[dict[str, Any]] = []
+    for ams_id in sorted(units_by_id):
+        unit = units_by_id[ams_id]
+        kind = unit["kind"]
+        slot_nos = unit.pop("_slot_nos")
+        if kind != "ams_ht":
+            slot_nos |= set(range(SLOTS_PER_AMS))
+        elif not slot_nos:
+            slot_nos = {0}
+        unit["label"] = ams_label(ams_id, kind)
+        unit["slots"] = [
+            _merge_slot(ams_id, n, kind, live_slots.get((ams_id, n)), fm_slots.get((ams_id, n)))
+            for n in sorted(slot_nos)
+        ]
+        units.append(unit)
+
+    all_slots = [s for u in units for s in u["slots"]]
+    _apply_backups(all_slots)
+    active = _apply_active(units, live["active_tray"] if live else None)
+
+    out: dict[str, Any] = {
+        "id": printer.id,
+        "name": printer.name,
+        "driver": printer.driver_key,
+        "connected": bool(live["connected"]) if live else None,
+        "state": live["state"] if live else "unknown",
+        "job": live["job"] if live else None,
+        "temperatures": live["temperatures"] if live else None,
+        "speed_level": live["speed_level"] if live else None,
+        "active": active,
+        "alerts": _build_alerts(printer.name, live or {}, units),
+        "ams": units,
+    }
+    return out
+
+
+def slots_only(printer_payload: dict[str, Any]) -> dict[str, Any]:
+    """The ``fields=slots`` projection: enough for a swatch board, small enough for an MCU."""
+    return {
+        "id": printer_payload["id"],
+        "name": printer_payload["name"],
+        "connected": printer_payload["connected"],
+        "state": printer_payload["state"],
+        "active": printer_payload["active"],
+        "ams": [
+            {
+                "ams_id": u["ams_id"],
+                "kind": u["kind"],
+                "label": u["label"],
+                "slots": [
+                    {k: s[k] for k in ("slot", "label", "empty", "active", "color", "material", "remaining_percent", "spool_id")}
+                    for s in u["slots"]
+                ],
+            }
+            for u in printer_payload["ams"]
+        ],
+    }
+
+
+DriverStateGetter = Callable[[Printer], Awaitable[dict[str, Any] | None]]
+
+
+async def build_display(
+    db: AsyncSession,
+    printers: list[Printer],
+    get_driver_state: DriverStateGetter,
+    *,
+    fields: str = "full",
+) -> dict[str, Any]:
+    payload_printers = []
+    for printer in printers:
+        fm_slots = await load_slot_spools(db, printer.id)
+        try:
+            driver_state = await get_driver_state(printer)
+        except Exception:  # a misbehaving driver must not blank the board
+            driver_state = None
+        item = build_printer_display(printer, fm_slots, driver_state)
+        payload_printers.append(slots_only(item) if fields == "slots" else item)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "printers": payload_printers,
+    }
+
+
+def compute_etag(payload: dict[str, Any]) -> str:
+    """Weak ETag over everything except the timestamp, so unchanged polls get 304."""
+    body = {k: v for k, v in payload.items() if k != "generated_at"}
+    digest = hashlib.sha1(json.dumps(body, sort_keys=True, default=str).encode()).hexdigest()[:20]
+    return f'W/"{digest}"'

--- a/backend/app/services/display_service.py
+++ b/backend/app/services/display_service.py
@@ -34,6 +34,9 @@ from sqlalchemy.orm import selectinload
 
 from app.models import Filament, FilamentColor, Printer, PrinterSlot, PrinterSlotAssignment, Spool
 
+_NOZZLE_MIN_KEY = "bambu_nozzle_temp_min"
+_NOZZLE_MAX_KEY = "bambu_nozzle_temp_max"
+
 SCHEMA_VERSION = 3
 DEFAULT_EMPTY_COLOR = "#202020"
 AMS_HT_ID_BASE = 128  # Bambu numbers AMS-HT units from 128
@@ -321,7 +324,33 @@ def normalize_driver_state(raw: dict[str, Any] | None) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _spool_swatch(spool: Spool) -> dict[str, Any]:
+def _params_for_printer(params: list[Any] | None, printer_id: int) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for param in params or []:
+        if (
+            getattr(param, "printer_id", None) == printer_id
+            and param.param_key
+            and param.param_value not in (None, "")
+        ):
+            out[param.param_key] = param.param_value
+    return out
+
+
+def _nozzle_range(spool: Spool, printer_id: int) -> tuple[int | None, int | None]:
+    """Bambu nozzle range lives on per-printer params, not on Filament.
+
+    ``FilamentPrinterProfile.nozzle_temp_c`` is a single setpoint, so it cannot
+    fill ``nozzle_min`` / ``nozzle_max``. Spool-level params override filament.
+    """
+    filament = spool.filament
+    merged = {
+        **_params_for_printer(getattr(filament, "printer_params", None) if filament else None, printer_id),
+        **_params_for_printer(getattr(spool, "printer_params", None), printer_id),
+    }
+    return _as_int(merged.get(_NOZZLE_MIN_KEY)), _as_int(merged.get(_NOZZLE_MAX_KEY))
+
+
+def _spool_swatch(spool: Spool, printer_id: int) -> dict[str, Any]:
     filament = spool.filament
     manufacturer = filament.manufacturer.name if filament and filament.manufacturer else ""
     color_hex = ""
@@ -348,6 +377,7 @@ def _spool_swatch(spool: Spool) -> dict[str, Any]:
     if remaining is not None and net_initial:
         remaining_percent = max(0, min(100, int(round(remaining / net_initial * 100))))
 
+    nozzle_min, nozzle_max = _nozzle_range(spool, printer_id)
     return {
         "spool_id": spool.id,
         "filament": filament.designation if filament else "",
@@ -357,8 +387,8 @@ def _spool_swatch(spool: Spool) -> dict[str, Any]:
         "color_name": color_name,
         "remaining_grams": int(round(remaining)) if remaining is not None else None,
         "remaining_percent": remaining_percent,
-        "nozzle_min": _as_int(getattr(filament, "nozzle_temp_min", None)) if filament else None,
-        "nozzle_max": _as_int(getattr(filament, "nozzle_temp_max", None)) if filament else None,
+        "nozzle_min": nozzle_min,
+        "nozzle_max": nozzle_max,
         "rfid": bool(spool.rfid_uid or getattr(spool, "rfid_uid_2", None)),
         "last_used": spool.last_used_at.isoformat() if spool.last_used_at else None,
     }
@@ -379,6 +409,13 @@ async def load_slot_spools(db: AsyncSession, printer_id: int) -> dict[tuple[int,
             .selectinload(Spool.filament)
             .selectinload(Filament.filament_colors)
             .selectinload(FilamentColor.color),
+            selectinload(PrinterSlot.assignment)
+            .selectinload(PrinterSlotAssignment.spool)
+            .selectinload(Spool.filament)
+            .selectinload(Filament.printer_params),
+            selectinload(PrinterSlot.assignment)
+            .selectinload(PrinterSlotAssignment.spool)
+            .selectinload(Spool.printer_params),
         )
         .order_by(PrinterSlot.slot_no)
     )
@@ -388,7 +425,7 @@ async def load_slot_spools(db: AsyncSession, printer_id: int) -> dict[tuple[int,
         assignment = slot.assignment
         entry: dict[str, Any] = {"present": bool(assignment and assignment.present)}
         if assignment and assignment.spool:
-            entry.update(_spool_swatch(assignment.spool))
+            entry.update(_spool_swatch(assignment.spool, printer_id))
         out[key] = entry
     return out
 

--- a/backend/app/services/display_service.py
+++ b/backend/app/services/display_service.py
@@ -110,8 +110,10 @@ def ams_label(ams_id: int, kind: str) -> str:
 
 
 def slot_label(ams_id: int, slot: int, kind: str) -> str:
-    if kind in ("ams_ht", "external"):
+    if kind == "ams_ht":
         return ams_label(ams_id, kind)
+    if kind == "external":
+        return f"Ext{slot + 1}"  # dual-extruder printers report several external trays
     return f"{ams_letter(ams_id)}{slot + 1}"
 
 

--- a/backend/app/services/display_service.py
+++ b/backend/app/services/display_service.py
@@ -338,6 +338,10 @@ def _spool_swatch(spool: Spool) -> dict[str, Any]:
     net_initial = None
     if initial is not None and empty is not None:
         net_initial = max(initial - empty, 0)
+    if not net_initial and filament is not None:
+        # No gross weight recorded on the spool: fall back to the filament's
+        # net weight (e.g. 1000 g) so the board can still show a percentage.
+        net_initial = getattr(filament, "raw_material_weight_g", None) or None
     remaining_percent = None
     if remaining is not None and net_initial:
         remaining_percent = max(0, min(100, int(round(remaining / net_initial * 100))))

--- a/backend/tests/test_display.py
+++ b/backend/tests/test_display.py
@@ -151,7 +151,7 @@ def test_build_merges_live_and_filaman_and_marks_backup():
     assert out["connected"] is True and out["job"]["progress"] == 42
     assert [u["label"] for u in out["ams"]] == ["AMS A", "HT1", "External"]
     ext = out["ams"][2]
-    assert ext["kind"] == "external" and [s["label"] for s in ext["slots"]] == ["External"] and ext["slots"][0]["empty"]
+    assert ext["kind"] == "external" and [s["label"] for s in ext["slots"]] == ["Ext1"] and ext["slots"][0]["empty"]
     a = out["ams"][0]["slots"]
     # slot 0: printer sees PETG, FilaMan has no spool -> non-empty, printer remaining
     assert a[0]["empty"] is False and a[0]["spool_id"] is None

--- a/backend/tests/test_display.py
+++ b/backend/tests/test_display.py
@@ -1,0 +1,254 @@
+"""Display API: merge of FilaMan slot assignments and optional driver live state."""
+
+from app.api.v1 import display as display_api
+from app.models import PrinterSlotAssignment
+from app.services.display_service import (
+    SCHEMA_VERSION,
+    build_printer_display,
+    compute_etag,
+    normalize_driver_state,
+    normalize_hex_color,
+    slots_only,
+)
+from tests.test_devices import (
+    _create_device,
+    _create_filament,
+    _create_manufacturer,
+    _create_spool,
+    _device_headers,
+    _get_status,
+    _register_device,
+)
+from tests.test_printers import _create_printer, _create_slot
+
+
+async def _printer_with_spool(db_session, *, slot_index="0-1", present=True):
+    printer = await _create_printer(db_session, name="P2S", driver_key="bambuddy")
+    slot = await _create_slot(
+        db_session, printer.id, slot_no=1, name="AMS 1 - Slot 2", custom_fields={"slot_index": slot_index}
+    )
+    manufacturer = await _create_manufacturer(db_session, name="SUNLU")
+    filament = await _create_filament(db_session, manufacturer.id)
+    status = await _get_status(db_session, "opened")
+    spool = await _create_spool(
+        db_session,
+        filament.id,
+        status.id,
+        initial_total_weight_g=1250.0,
+        empty_spool_weight_g=250.0,
+        remaining_weight_g=500.0,
+        rfid_uid="04:EF:14:10:C8:2A:81",
+    )
+    db_session.add(PrinterSlotAssignment(slot_id=slot.id, spool_id=spool.id, present=present))
+    await db_session.commit()
+    return printer, spool
+
+
+BAMBUDDY_STATUS = {
+    "connected": True,
+    "gcode_state": "RUNNING",
+    "subtask_name": "benchy.3mf",
+    "mc_percent": 42,
+    "layer_num": 57,
+    "total_layer_num": 130,
+    "mc_remaining_time": 62,
+    "nozzle_temper": 219.6,
+    "bed_temper": 60,
+    "tray_now": 1,
+    "ams": {
+        "ams": [
+            {
+                "id": 0,
+                "temp": 25.4,
+                "humidity": 3,
+                "tray": [
+                    {"id": 0, "tray_type": "PETG", "tray_color": "0000FFFF", "remain": 80, "tag_uid": "AAAA"},
+                    {"id": 1, "tray_type": "PLA", "tray_color": "F8A813FF", "remain": 20},
+                    {"id": 2},
+                    {"id": 3},
+                ],
+            },
+            {"id": 128, "temp": 40.0, "humidity": 1, "tray": [{"id": 0, "tray_type": "PA", "tray_color": "111111FF"}]},
+        ]
+    },
+    "hms": [{"code": "0x0500", "msg": "Nozzle clog"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_hex_color():
+    assert normalize_hex_color("f8a813ff") == "#F8A813"
+    assert normalize_hex_color("#F8A813") == "#F8A813"
+    assert normalize_hex_color("") == "#202020"
+    assert normalize_hex_color("nope") == "#202020"
+
+
+def test_normalize_bambuddy_status():
+    live = normalize_driver_state(BAMBUDDY_STATUS)
+    assert live["connected"] is True
+    assert live["state"] == "RUNNING"
+    assert live["job"] == {"name": "benchy.3mf", "progress": 42, "layer": 57, "total_layers": 130, "remaining_seconds": 3720}
+    assert live["temperatures"]["nozzle"] == 220 and live["temperatures"]["bed"] == 60
+    assert live["active_tray"] == 1
+    assert live["hms"] == [{"code": "0x0500", "message": "Nozzle clog"}]
+    assert [u["ams_id"] for u in live["ams"]] == [0, 128]
+    assert live["ams"][1]["kind"] == "ams_ht"
+    tray0 = live["ams"][0]["slots"][0]
+    assert tray0["color"] == "#0000FF" and tray0["rfid"] is True and tray0["remaining_percent"] == 80
+
+
+def test_normalize_documented_shape():
+    live = normalize_driver_state(
+        {
+            "connected": False,
+            "state": "IDLE",
+            "job": {"name": "x", "progress": 5, "remaining_seconds": 90},
+            "temperatures": {"nozzle": 30, "bed": 25},
+            "active_tray": 254,
+            "ams": [{"ams_id": 1, "slots": [{"slot": 2, "material": "TPU", "color": "#ABCDEF"}]}],
+        }
+    )
+    assert live["connected"] is False
+    assert live["job"]["remaining_seconds"] == 90
+    assert live["active_tray"] is None
+    assert live["ams"][0]["slots"][0]["color"] == "#ABCDEF"
+
+
+class _P:
+    def __init__(self, id=11, name="P2S", driver_key="bambuddy"):
+        self.id, self.name, self.driver_key = id, name, driver_key
+
+
+def test_build_without_driver_state_uses_assignments_only():
+    fm = {(0, 1): {"present": True, "spool_id": 5, "material": "PLA", "color": "#F8A813", "color_name": "Orange",
+                   "manufacturer": "SUNLU", "filament": "PLA Plus", "remaining_percent": 50, "remaining_grams": 500,
+                   "nozzle_min": 190, "nozzle_max": 230, "rfid": True, "last_used": None}}
+    out = build_printer_display(_P(), fm, None)
+    assert out["connected"] is None and out["job"] is None and out["state"] == "unknown"
+    assert [u["label"] for u in out["ams"]] == ["AMS A"]
+    slots = out["ams"][0]["slots"]
+    assert [s["label"] for s in slots] == ["A1", "A2", "A3", "A4"]
+    assert slots[1]["empty"] is False and slots[1]["spool_id"] == 5 and slots[1]["remaining_source"] == "filaman"
+    assert slots[0]["empty"] is True and slots[0]["color"] == "#202020"
+    assert out["active"] is None
+
+
+def test_build_merges_live_and_filaman_and_marks_backup():
+    fm = {
+        (0, 1): {"present": True, "spool_id": 5, "material": "PLA", "color": "#F8A813", "color_name": "Orange",
+                 "manufacturer": "SUNLU", "filament": "PLA Plus", "remaining_percent": 50, "remaining_grams": 500,
+                 "nozzle_min": None, "nozzle_max": None, "rfid": False, "last_used": None},
+        (0, 3): {"present": True, "spool_id": 6, "material": "PLA", "color": "#F8A813", "color_name": "Orange",
+                 "manufacturer": "SUNLU", "filament": "PLA Plus", "remaining_percent": 90, "remaining_grams": 900,
+                 "nozzle_min": None, "nozzle_max": None, "rfid": False, "last_used": None},
+    }
+    out = build_printer_display(_P(), fm, BAMBUDDY_STATUS)
+    assert out["connected"] is True and out["job"]["progress"] == 42
+    assert [u["label"] for u in out["ams"]] == ["AMS A", "HT1"]
+    a = out["ams"][0]["slots"]
+    # slot 0: printer sees PETG, FilaMan has no spool -> non-empty, printer remaining
+    assert a[0]["empty"] is False and a[0]["spool_id"] is None
+    assert a[0]["material"] == "PETG" and a[0]["remaining_source"] == "printer" and a[0]["remaining_percent"] == 80
+    # slot 1: FilaMan spool wins over tray data, active via tray_now
+    assert a[1]["spool_id"] == 5 and a[1]["remaining_percent"] == 50 and a[1]["active"] is True
+    assert out["active"] == {"ams_id": 0, "slot": 1}
+    # backups: A2 and A4 share PLA orange
+    assert a[1]["backup_of"] == "A4" and a[3]["backup_of"] == "A2"
+    # HT unit: single slot, label HT1
+    ht = out["ams"][1]
+    assert ht["kind"] == "ams_ht" and [s["label"] for s in ht["slots"]] == ["HT1"]
+    assert any(al["id"] == "hms-0x0500" for al in out["alerts"])
+
+
+def test_slots_projection_and_etag_ignore_timestamp():
+    out = build_printer_display(_P(), {}, BAMBUDDY_STATUS)
+    small = slots_only(out)
+    assert set(small) == {"id", "name", "connected", "state", "active", "ams"}
+    assert set(small["ams"][0]["slots"][0]) == {"slot", "label", "empty", "active", "color", "material", "remaining_percent", "spool_id"}
+    a = {"schema_version": SCHEMA_VERSION, "generated_at": "t1", "printers": [out]}
+    b = {"schema_version": SCHEMA_VERSION, "generated_at": "t2", "printers": [out]}
+    assert compute_etag(a) == compute_etag(b)
+
+
+# ---------------------------------------------------------------------------
+# endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestDisplayEndpoint:
+    async def test_requires_auth(self, client):
+        response = await client.get("/api/v1/display")
+        assert response.status_code == 401
+
+    async def test_user_gets_board_from_assignments(self, auth_client, db_session):
+        client, _ = auth_client
+        printer, spool = await _printer_with_spool(db_session)
+
+        response = await client.get("/api/v1/display")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["schema_version"] == SCHEMA_VERSION
+        [p] = body["printers"]
+        assert p["id"] == printer.id and p["name"] == "P2S" and p["connected"] is None
+        slot = p["ams"][0]["slots"][1]
+        assert slot["spool_id"] == spool.id
+        assert slot["manufacturer"] == "SUNLU" and slot["remaining_grams"] == 500
+        assert slot["remaining_percent"] == 50 and slot["rfid"] is True
+        assert slot["label"] == "A2"
+
+    async def test_etag_304_and_slots_projection(self, auth_client, db_session):
+        client, _ = auth_client
+        await _printer_with_spool(db_session)
+
+        first = await client.get("/api/v1/display", params={"fields": "slots"})
+        assert first.status_code == 200
+        etag = first.headers["etag"]
+        assert set(first.json()["printers"][0]) == {"id", "name", "connected", "state", "active", "ams"}
+
+        again = await client.get("/api/v1/display", params={"fields": "slots"}, headers={"If-None-Match": etag})
+        assert again.status_code == 304
+        assert again.headers["etag"] == etag
+
+    async def test_driver_live_state_is_merged(self, auth_client, db_session, monkeypatch):
+        client, _ = auth_client
+        printer, _ = await _printer_with_spool(db_session)
+
+        async def fake_state(p):
+            return BAMBUDDY_STATUS if p.id == printer.id else None
+
+        monkeypatch.setattr(display_api, "_driver_state", fake_state)
+        response = await client.get(f"/api/v1/display/printers/{printer.id}")
+        assert response.status_code == 200, response.text
+        [p] = response.json()["printers"]
+        assert p["connected"] is True and p["job"]["name"] == "benchy.3mf"
+        assert p["active"] == {"ams_id": 0, "slot": 1}
+        assert p["ams"][0]["slots"][1]["active"] is True
+
+    async def test_unknown_printer_404(self, auth_client):
+        client, _ = auth_client
+        response = await client.get("/api/v1/display/printers/9999")
+        assert response.status_code == 404
+
+    async def test_device_token_with_scope(self, auth_client, db_session):
+        client, csrf = auth_client
+        await _printer_with_spool(db_session)
+        await _create_device(db_session, device_code="DISP01", scopes=["display:read"])
+        token, _ = await _register_device(client, "DISP01", csrf)
+        client.cookies.clear()  # drop the admin session: authenticate as the device only
+
+        response = await client.get("/api/v1/display", headers=_device_headers(token))
+        assert response.status_code == 200, response.text
+        assert response.json()["printers"][0]["ams"][0]["slots"][1]["spool_id"] is not None
+
+    async def test_device_token_without_scope_is_forbidden(self, auth_client, db_session):
+        client, csrf = auth_client
+        await _create_device(db_session, device_code="DISP02", scopes=["spools:read"])
+        token, _ = await _register_device(client, "DISP02", csrf)
+        client.cookies.clear()  # drop the admin session: authenticate as the device only
+
+        response = await client.get("/api/v1/display", headers=_device_headers(token))
+        assert response.status_code == 403, response.text

--- a/backend/tests/test_display.py
+++ b/backend/tests/test_display.py
@@ -1,7 +1,7 @@
 """Display API: merge of FilaMan slot assignments and optional driver live state."""
 
 from app.api.v1 import display as display_api
-from app.models import PrinterSlotAssignment
+from app.models import Filament, PrinterSlotAssignment
 from app.services.display_service import (
     SCHEMA_VERSION,
     build_printer_display,
@@ -202,6 +202,20 @@ class TestDisplayEndpoint:
         assert slot["manufacturer"] == "SUNLU" and slot["remaining_grams"] == 500
         assert slot["remaining_percent"] == 50 and slot["rfid"] is True
         assert slot["label"] == "A2"
+
+    async def test_remaining_percent_falls_back_to_filament_net_weight(self, auth_client, db_session):
+        client, _ = auth_client
+        printer, spool = await _printer_with_spool(db_session)
+        spool.initial_total_weight_g = None
+        spool.remaining_weight_g = 250.0
+        filament = await db_session.get(Filament, spool.filament_id)
+        filament.raw_material_weight_g = 1000.0
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/display/printers/{printer.id}")
+        assert response.status_code == 200, response.text
+        slot = response.json()["printers"][0]["ams"][0]["slots"][1]
+        assert slot["remaining_percent"] == 25 and slot["remaining_grams"] == 250
 
     async def test_etag_304_and_slots_projection(self, auth_client, db_session):
         client, _ = auth_client

--- a/backend/tests/test_display.py
+++ b/backend/tests/test_display.py
@@ -69,6 +69,7 @@ BAMBUDDY_STATUS = {
                 ],
             },
             {"id": 128, "temp": 40.0, "humidity": 1, "tray": [{"id": 0, "tray_type": "PA", "tray_color": "111111FF"}]},
+            {"id": 255, "tray": [{"id": 0}]},
         ]
     },
     "hms": [{"code": "0x0500", "msg": "Nozzle clog"}],
@@ -95,8 +96,8 @@ def test_normalize_bambuddy_status():
     assert live["temperatures"]["nozzle"] == 220 and live["temperatures"]["bed"] == 60
     assert live["active_tray"] == 1
     assert live["hms"] == [{"code": "0x0500", "message": "Nozzle clog"}]
-    assert [u["ams_id"] for u in live["ams"]] == [0, 128]
-    assert live["ams"][1]["kind"] == "ams_ht"
+    assert [u["ams_id"] for u in live["ams"]] == [0, 128, 255]
+    assert [u["kind"] for u in live["ams"]] == ["ams", "ams_ht", "external"]
     tray0 = live["ams"][0]["slots"][0]
     assert tray0["color"] == "#0000FF" and tray0["rfid"] is True and tray0["remaining_percent"] == 80
 
@@ -148,7 +149,9 @@ def test_build_merges_live_and_filaman_and_marks_backup():
     }
     out = build_printer_display(_P(), fm, BAMBUDDY_STATUS)
     assert out["connected"] is True and out["job"]["progress"] == 42
-    assert [u["label"] for u in out["ams"]] == ["AMS A", "HT1"]
+    assert [u["label"] for u in out["ams"]] == ["AMS A", "HT1", "External"]
+    ext = out["ams"][2]
+    assert ext["kind"] == "external" and [s["label"] for s in ext["slots"]] == ["External"] and ext["slots"][0]["empty"]
     a = out["ams"][0]["slots"]
     # slot 0: printer sees PETG, FilaMan has no spool -> non-empty, printer remaining
     assert a[0]["empty"] is False and a[0]["spool_id"] is None

--- a/backend/tests/test_display.py
+++ b/backend/tests/test_display.py
@@ -1,7 +1,7 @@
 """Display API: merge of FilaMan slot assignments and optional driver live state."""
 
 from app.api.v1 import display as display_api
-from app.models import Filament, PrinterSlotAssignment
+from app.models import Filament, FilamentPrinterParam, PrinterSlotAssignment, SpoolPrinterParam
 from app.services.display_service import (
     SCHEMA_VERSION,
     build_printer_display,
@@ -202,6 +202,40 @@ class TestDisplayEndpoint:
         assert slot["manufacturer"] == "SUNLU" and slot["remaining_grams"] == 500
         assert slot["remaining_percent"] == 50 and slot["rfid"] is True
         assert slot["label"] == "A2"
+        assert slot["nozzle_min"] is None and slot["nozzle_max"] is None
+
+    async def test_nozzle_temps_come_from_printer_params(self, auth_client, db_session):
+        client, _ = auth_client
+        printer, spool = await _printer_with_spool(db_session)
+        db_session.add_all(
+            [
+                FilamentPrinterParam(
+                    filament_id=spool.filament_id,
+                    printer_id=printer.id,
+                    param_key="bambu_nozzle_temp_min",
+                    param_value="190",
+                ),
+                FilamentPrinterParam(
+                    filament_id=spool.filament_id,
+                    printer_id=printer.id,
+                    param_key="bambu_nozzle_temp_max",
+                    param_value="230",
+                ),
+                SpoolPrinterParam(
+                    spool_id=spool.id,
+                    printer_id=printer.id,
+                    param_key="bambu_nozzle_temp_max",
+                    param_value="240",
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        response = await client.get(f"/api/v1/display/printers/{printer.id}")
+        assert response.status_code == 200, response.text
+        slot = response.json()["printers"][0]["ams"][0]["slots"][1]
+        assert slot["nozzle_min"] == 190
+        assert slot["nozzle_max"] == 240
 
     async def test_remaining_percent_falls_back_to_filament_net_weight(self, auth_client, db_session):
         client, _ = auth_client

--- a/docs/display-api.md
+++ b/docs/display-api.md
@@ -79,7 +79,7 @@ Authorization: Device 12.34.abcdef…
       "ams": [
         {
           "ams_id": 0,                // as the printer numbers it (AMS-HT start at 128)
-          "kind": "ams",              // "ams" | "ams_ht"
+          "kind": "ams",              // "ams" | "ams_ht" | "external" (spool holder, id 254/255)
           "label": "AMS A",           // "AMS A".."AMS D", "HT1".. — use it or make your own
           "temperature": 25.4, "humidity": 3,
           "drying": null,             // or { status, target_temp, time }
@@ -114,7 +114,7 @@ Rules you can rely on:
 
 - Numbers are raw. No pre-formatted strings, no thresholds — decide "low" yourself.
 - `color` is always a 7-char `#RRGGBB`. Alpha is stripped.
-- A regular AMS always lists slots 0–3, even when empty. An AMS-HT lists slot 0.
+- A regular AMS always lists slots 0–3, even when empty. An AMS-HT and the external holder list slot 0.
 - `spool_id` is set only when FilaMan has a spool assigned to that slot; a slot
   can still be non-empty (the printer sees filament) with `spool_id: null`.
 - Adding fields never bumps `schema_version`; changing a field's meaning does.

--- a/docs/display-api.md
+++ b/docs/display-api.md
@@ -1,0 +1,135 @@
+# Display API — build your own dashboard or digital swatch board
+
+`GET /api/v1/display` is a read-only feed of every printer FilaMan manages: each
+AMS unit, each slot, and the filament in it (colour, material, manufacturer,
+remaining amount), plus a small printer/job summary. It exists so you can build
+a wall display, an e-paper swatch panel, a tablet kiosk or a Home Assistant card
+without knowing anything about FilaMan's internals or the printer driver.
+
+FilaMan ships a reference client at `/display` (a full-screen swatch board that
+runs in any browser). Read its source in `frontend/src/pages/display.astro` —
+it is ~200 lines and uses nothing but this endpoint.
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/display` | All active printers |
+| `GET` | `/api/v1/display/printers/{id}` | One printer, same envelope |
+
+Query parameters:
+
+- `fields=full` (default) — everything below.
+- `fields=slots` — only what a swatch board needs (id/name/state/active + per slot:
+  `slot, label, empty, active, color, material, remaining_percent, spool_id`).
+  A two-AMS printer is well under 2 KB; fine for a microcontroller.
+
+## Authentication
+
+Any principal holding the `display:read` permission:
+
+- a logged-in browser session (the kiosk page uses this),
+- a personal API key,
+- **a registered device** — register your panel like a scale (Admin → Devices),
+  give it the `display:read` scope, and send `Authorization: Device <token>`.
+
+Users and viewers get `display:read` by default.
+
+## Polling cheaply
+
+The response carries an `ETag`. Send it back as `If-None-Match`; if nothing on
+the board changed you get `304 Not Modified` with no body. Poll every 3–10 s.
+
+```
+GET /api/v1/display?fields=slots
+If-None-Match: W/"9f2c…"
+Authorization: Device 12.34.abcdef…
+```
+
+## Schema (version 3)
+
+```jsonc
+{
+  "schema_version": 3,
+  "generated_at": "2026-09-04T18:00:00+00:00",
+  "printers": [
+    {
+      "id": 11,
+      "name": "P2S",
+      "driver": "bambuddy",
+      "connected": true,              // null when the driver reports nothing
+      "state": "RUNNING",             // driver's state string, "unknown" if none
+      "job": {                        // null without live data
+        "name": "benchy.3mf",
+        "progress": 42,               // 0-100
+        "layer": 57, "total_layers": 130,
+        "remaining_seconds": 3720
+      },
+      "temperatures": {               // null without live data; °C integers
+        "nozzle": 220, "nozzle_target": 220,
+        "bed": 60,  "bed_target": 60,
+        "chamber": 31, "chamber_target": null
+      },
+      "speed_level": 2,               // Bambu 1-4, raw
+      "active": { "ams_id": 0, "slot": 1 },   // slot currently feeding, or null
+      "alerts": [
+        { "id": "print-paused", "severity": "warn", "title": "Print paused",
+          "detail": "benchy.3mf", "source": "printer" }
+      ],
+      "ams": [
+        {
+          "ams_id": 0,                // as the printer numbers it (AMS-HT start at 128)
+          "kind": "ams",              // "ams" | "ams_ht"
+          "label": "AMS A",           // "AMS A".."AMS D", "HT1".. — use it or make your own
+          "temperature": 25.4, "humidity": 3,
+          "drying": null,             // or { status, target_temp, time }
+          "slots": [
+            {
+              "ams_id": 0, "slot": 0, "label": "A1",
+              "empty": false,
+              "active": false,
+              "color": "#F8A813",     // always #RRGGBB; "#202020" when empty
+              "color_name": "Orange",
+              "material": "PLA",
+              "manufacturer": "SUNLU",
+              "filament": "PLA Plus",
+              "spool_id": 128,        // FilaMan spool id, null if only the printer sees filament
+              "remaining_percent": 51,
+              "remaining_grams": 510,
+              "remaining_source": "filaman",   // "filaman" | "printer" | null
+              "nozzle_min": 190, "nozzle_max": 230,
+              "rfid": true,
+              "last_used": "2026-09-03T21:10:00+00:00",
+              "backup_of": "B2"       // another slot with the same material+colour, or null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Rules you can rely on:
+
+- Numbers are raw. No pre-formatted strings, no thresholds — decide "low" yourself.
+- `color` is always a 7-char `#RRGGBB`. Alpha is stripped.
+- A regular AMS always lists slots 0–3, even when empty. An AMS-HT lists slot 0.
+- `spool_id` is set only when FilaMan has a spool assigned to that slot; a slot
+  can still be non-empty (the printer sees filament) with `spool_id: null`.
+- Adding fields never bumps `schema_version`; changing a field's meaning does.
+
+## What the feed is built from
+
+1. **FilaMan's slot assignments** — which spool is in which slot. This works for
+   every printer, with any driver, and yields colour/material/remaining from the
+   spool record.
+2. **The driver's live state (optional)** — a driver may implement
+   `get_display_state()` on its `BaseDriver` subclass to add tray contents as the
+   printer sees them, job progress, temperatures and the active slot. The
+   Bambuddy driver does. Without it, `connected`, `job` and `temperatures` are
+   `null` and the board is still complete.
+
+Driver authors: return either the normalised shape documented in
+`app/services/display_service.py::normalize_driver_state`, or a Bambu-style
+status dict — both are accepted. Keep it cached; it is called on every poll.

--- a/docs/display-api.md
+++ b/docs/display-api.md
@@ -114,7 +114,7 @@ Rules you can rely on:
 
 - Numbers are raw. No pre-formatted strings, no thresholds — decide "low" yourself.
 - `color` is always a 7-char `#RRGGBB`. Alpha is stripped.
-- A regular AMS always lists slots 0–3, even when empty. An AMS-HT and the external holder list slot 0.
+- A regular AMS always lists slots 0–3, even when empty. An AMS-HT lists slot 0; the external holder lists as many trays as the printer reports (labels `Ext1`, `Ext2`, …).
 - `spool_id` is set only when FilaMan has a spool assigned to that slot; a slot
   can still be non-empty (the printer sees filament) with `spool_id: null`.
 - Adding fields never bumps `schema_version`; changing a field's meaning does.

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -12,6 +12,7 @@
     "locations": "Standorte",
     "printers": "Drucker",
     "spoolLog": "Protokoll",
+    "display": "Anzeige",
     "admin": "Admin",
     "adminPanel": "Admin-Bereich",
     "settings": "Einstellungen",
@@ -1164,6 +1165,19 @@
     "popupTitle": "Was ist neu?",
     "dismiss": "Verstanden",
     "viewAll": "Alle \u00c4nderungen"
+  },
+  "display": {
+    "title": "Anzeige",
+    "kiosk": "Kiosk-Modus",
+    "rawJson": "JSON",
+    "empty": "leer",
+    "offline": "offline",
+    "nozzle": "Düse",
+    "bed": "Bett",
+    "backupOf": "Ersatz für {slot}",
+    "upToDate": "aktualisiert {time}",
+    "error": "Anzeige-Feed konnte nicht geladen werden",
+    "noPrinters": "Keine aktiven Drucker."
   },
   "spoolLog": {
     "title": "Protokoll",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -12,6 +12,7 @@
     "locations": "Locations",
     "printers": "Printers",
     "spoolLog": "Spool Log",
+    "display": "Display",
     "admin": "Admin",
     "adminPanel": "Admin Panel",
     "settings": "Settings",
@@ -1163,6 +1164,19 @@
     "popupTitle": "What's New",
     "dismiss": "Got it",
     "viewAll": "All Changes"
+  },
+  "display": {
+    "title": "Display",
+    "kiosk": "Kiosk mode",
+    "rawJson": "JSON",
+    "empty": "empty",
+    "offline": "offline",
+    "nozzle": "Nozzle",
+    "bed": "Bed",
+    "backupOf": "backup of {slot}",
+    "upToDate": "updated {time}",
+    "error": "Could not load the display feed",
+    "noPrinters": "No active printers."
   },
   "spoolLog": {
     "title": "Spool Log",

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -84,6 +84,10 @@ const { title } = Astro.props
               <span class="fm-nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:20px;height:20px;"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
               <span data-i18n="nav.spoolLog">Spool Log</span>
             </a>
+            <a href="/display" class="fm-nav-item">
+              <span class="fm-nav-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:20px;height:20px;"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+              <span data-i18n="nav.display">Display</span>
+            </a>
 
             <div id="plugin-nav" class="invisible" style="margin-top: 4px;"></div>
 

--- a/frontend/src/pages/display.astro
+++ b/frontend/src/pages/display.astro
@@ -1,0 +1,162 @@
+---
+import Layout from '../layouts/Layout.astro'
+---
+
+<!--
+  Reference client for the Display API (docs/display-api.md).
+  Everything on this page comes from GET /api/v1/display — copy it as a
+  starting point for your own dashboard / digital swatch board.
+-->
+<Layout title="FilaMan - Display">
+  <style is:global>
+    .dp-toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; gap: 12px; flex-wrap: wrap; }
+    .dp-status { font-size: 0.85rem; color: var(--text-muted); }
+    .dp-printers { display: grid; gap: 24px; }
+    .dp-printer { display: grid; gap: 14px; }
+    .dp-printer-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+    .dp-printer-name { font-size: 1.4rem; font-weight: 700; font-family: var(--font-serif); margin: 0; }
+    .dp-printer-meta { font-size: 0.9rem; color: var(--text-muted); display: flex; gap: 14px; flex-wrap: wrap; }
+    .dp-progress { height: 6px; border-radius: 3px; background: var(--bg-soft); overflow: hidden; width: 100%; max-width: 420px; }
+    .dp-progress > div { height: 100%; background: var(--accent); }
+    .dp-units { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+    .dp-unit { display: grid; gap: 10px; }
+    .dp-unit-head { display: flex; justify-content: space-between; align-items: baseline; font-size: 0.85rem; color: var(--text-muted); }
+    .dp-unit-head b { color: var(--text); font-size: 1rem; }
+    .dp-slots { display: grid; gap: 10px; grid-template-columns: repeat(4, 1fr); }
+    .dp-unit.ht .dp-slots { grid-template-columns: 1fr; }
+    .dp-slot { position: relative; border-radius: 12px; padding: 12px 10px 10px; min-height: 118px; display: flex; flex-direction: column; justify-content: flex-end; gap: 2px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,.55); overflow: hidden; border: 2px solid transparent; }
+    .dp-slot.empty { background: var(--bg-soft) !important; color: var(--text-muted); text-shadow: none; border: 2px dashed var(--border); }
+    .dp-slot.active { border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent); }
+    .dp-slot .lbl { position: absolute; top: 8px; left: 10px; font-size: 0.75rem; font-weight: 700; opacity: .9; }
+    .dp-slot .rfid { position: absolute; top: 8px; right: 10px; font-size: 0.7rem; opacity: .9; }
+    .dp-slot .mat { font-weight: 800; font-size: 1.05rem; line-height: 1.1; }
+    .dp-slot .sub { font-size: 0.75rem; opacity: .95; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .dp-slot .bar { height: 5px; border-radius: 3px; background: rgba(0,0,0,.35); margin-top: 6px; overflow: hidden; }
+    .dp-slot .bar > div { height: 100%; background: rgba(255,255,255,.9); }
+    .dp-slot .bar.low > div { background: #f59e0b; }
+    .dp-slot .bar.crit > div { background: #ef4444; }
+    .dp-alerts { display: flex; gap: 8px; flex-wrap: wrap; }
+    .dp-alert { font-size: 0.8rem; padding: 4px 10px; border-radius: 999px; background: color-mix(in srgb, #f59e0b 18%, transparent); }
+    .dp-alert.danger { background: color-mix(in srgb, #ef4444 18%, transparent); }
+    /* kiosk: hide chrome, fill the screen */
+    body.dp-kiosk .fm-sidebar, body.dp-kiosk .fm-sidebar-backdrop, body.dp-kiosk #sidebar-toggle { display: none !important; }
+    body.dp-kiosk main { padding: 16px !important; }
+    body.dp-kiosk .dp-toolbar h1 { display: none; }
+  </style>
+
+  <div class="dp-toolbar">
+    <h1 style="font-size: 1.8rem; font-weight: 700; margin: 0; font-family: var(--font-serif);" data-i18n="display.title">Display</h1>
+    <div style="display: flex; gap: 10px; align-items: center;">
+      <span class="dp-status" id="dp-status"></span>
+      <button id="dp-kiosk" class="fm-btn fm-btn-outline" data-i18n="display.kiosk">Kiosk mode</button>
+      <a href="/api/v1/display" target="_blank" class="fm-btn fm-btn-outline" data-i18n="display.rawJson">JSON</a>
+    </div>
+  </div>
+
+  <div id="dp-printers" class="dp-printers"></div>
+
+  <script>
+    import { t, initI18n, translatePage } from '../lib/i18n'
+    import { getAbortSignal, isAbortError } from '../lib/abort'
+
+    await initI18n()
+    translatePage()
+
+    const POLL_MS = 5000
+    const LOW = 30, CRIT = 15
+    let etag: string | null = null
+
+    const esc = (v: any) => String(v ?? '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string))
+
+    function fmtRemaining(seconds: number | null) {
+      if (seconds == null) return ''
+      const h = Math.floor(seconds / 3600), m = Math.round((seconds % 3600) / 60)
+      return h > 0 ? `${h}h ${String(m).padStart(2, '0')}m` : `${m} min`
+    }
+
+    function renderSlot(s: any) {
+      if (s.empty) return `<div class="dp-slot empty"><span class="lbl">${esc(s.label)}</span><div class="sub">${t('display.empty')}</div></div>`
+      const pct = s.remaining_percent
+      const barCls = pct == null ? '' : pct <= CRIT ? 'crit' : pct <= LOW ? 'low' : ''
+      const sub = [s.manufacturer, s.color_name || s.filament].filter(Boolean).join(' · ')
+      const rem = pct != null ? `${pct}%` : (s.remaining_grams != null ? `${s.remaining_grams} g` : '')
+      return `
+        <div class="dp-slot ${s.active ? 'active' : ''}" style="background: ${esc(s.color)}" title="${esc(s.filament)}${s.backup_of ? ' — ' + t('display.backupOf', { slot: s.backup_of }) : ''}">
+          <span class="lbl">${esc(s.label)}</span>
+          ${s.rfid ? '<span class="rfid">RFID</span>' : ''}
+          <div class="mat">${esc(s.material || '?')}</div>
+          <div class="sub">${esc(sub)}</div>
+          ${pct != null ? `<div class="bar ${barCls}"><div style="width:${pct}%"></div></div>` : ''}
+          <div class="sub">${esc(rem)}${s.backup_of ? ` · ${t('display.backupOf', { slot: s.backup_of })}` : ''}</div>
+        </div>`
+    }
+
+    function renderUnit(u: any) {
+      const climate = [u.temperature != null ? `${Math.round(u.temperature)}°C` : '', u.humidity != null ? `${Math.round(u.humidity)}% RH` : ''].filter(Boolean).join(' · ')
+      return `
+        <div class="dp-unit ${u.kind === 'ams_ht' ? 'ht' : ''} fm-card">
+          <div class="dp-unit-head"><b>${esc(u.label)}</b><span>${esc(climate)}</span></div>
+          <div class="dp-slots">${u.slots.map(renderSlot).join('')}</div>
+        </div>`
+    }
+
+    function renderPrinter(p: any) {
+      const job = p.job || {}
+      const temps = p.temperatures || {}
+      const meta: string[] = []
+      if (p.connected === false) meta.push(t('display.offline'))
+      else if (p.state && p.state !== 'unknown') meta.push(esc(p.state))
+      if (job.name) meta.push(esc(job.name))
+      if (job.remaining_seconds != null) meta.push(fmtRemaining(job.remaining_seconds))
+      if (temps.nozzle != null) meta.push(`${t('display.nozzle')} ${temps.nozzle}${temps.nozzle_target ? '/' + temps.nozzle_target : ''}°C`)
+      if (temps.bed != null) meta.push(`${t('display.bed')} ${temps.bed}${temps.bed_target ? '/' + temps.bed_target : ''}°C`)
+      const alerts = (p.alerts || []).map((a: any) => `<span class="dp-alert ${a.severity}">${esc(a.title)}${a.detail ? ': ' + esc(a.detail) : ''}</span>`).join('')
+      return `
+        <section class="dp-printer">
+          <div class="dp-printer-head">
+            <h2 class="dp-printer-name">${esc(p.name)}</h2>
+            <div class="dp-printer-meta">${meta.map(m => `<span>${m}</span>`).join('')}</div>
+          </div>
+          ${job.progress != null ? `<div class="dp-progress"><div style="width:${job.progress}%"></div></div>` : ''}
+          ${alerts ? `<div class="dp-alerts">${alerts}</div>` : ''}
+          <div class="dp-units">${(p.ams || []).map(renderUnit).join('')}</div>
+        </section>`
+    }
+
+    async function poll() {
+      const statusEl = document.getElementById('dp-status')!
+      try {
+        const res = await fetch('/api/v1/display', {
+          credentials: 'include',
+          signal: getAbortSignal(),
+          headers: etag ? { 'If-None-Match': etag } : {},
+        })
+        if (res.status === 304) { statusEl.textContent = t('display.upToDate', { time: new Date().toLocaleTimeString() }); return }
+        if (!res.ok) throw new Error(String(res.status))
+        etag = res.headers.get('ETag')
+        const data = await res.json()
+        const root = document.getElementById('dp-printers')!
+        root.innerHTML = data.printers.length
+          ? data.printers.map(renderPrinter).join('')
+          : `<div class="fm-card" style="color: var(--text-muted);">${t('display.noPrinters')}</div>`
+        statusEl.textContent = t('display.upToDate', { time: new Date().toLocaleTimeString() })
+      } catch (e) {
+        if (isAbortError(e)) return
+        statusEl.textContent = t('display.error')
+      }
+    }
+
+    document.getElementById('dp-kiosk')?.addEventListener('click', () => {
+      document.body.classList.toggle('dp-kiosk')
+      if (document.body.classList.contains('dp-kiosk')) document.documentElement.requestFullscreen?.().catch(() => {})
+      else document.exitFullscreen?.().catch(() => {})
+    })
+    document.addEventListener('fullscreenchange', () => {
+      if (!document.fullscreenElement) document.body.classList.remove('dp-kiosk')
+    })
+    if (new URLSearchParams(location.search).get('kiosk') === '1') document.body.classList.add('dp-kiosk')
+
+    await poll()
+    setInterval(poll, POLL_MS)
+  </script>
+</Layout>


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/display` (and per-printer) as a read-only feed for dashboards and swatch boards, merging FilaMan slot assignments with optional live driver state.
- Include later Display API fixes: external holder 254/255, remaining-percent fallback to filament net weight, Ext1/Ext2 labels.
- Read `nozzle_min` / `nozzle_max` from per-printer `bambu_nozzle_temp_*` params (spool overrides filament). Filament has no such fields, so the swatch previously always fell through to the live tray.

## Test plan
- [ ] `GET /api/v1/display` as a logged-in user and as a device token with `display:read`
- [ ] Assigned spool shows colour, material, remaining grams/percent without live driver data
- [ ] With Bambuddy live state, job/active slot/HMS merge in
- [ ] Filament/spool `bambu_nozzle_temp_min`/`max` appear as `nozzle_min`/`nozzle_max`; spool param wins
- [ ] `pytest backend/tests/test_display.py`