### PR TITLE
feat(filaments): support tag color matching with backwards-compatible fallbacks

### DIFF
--- a/backend/app/api/v1/filaments.py
+++ b/backend/app/api/v1/filaments.py
@@ -44,6 +44,7 @@ from app.models import (
     SpoolStatus,
     SystemExtraField,
 )
+from app.utils.colors import normalize_hex_color
 
 logger = logging.getLogger(__name__)
 
@@ -666,14 +667,42 @@ async def resolve_filament_from_tag(
         await db.flush()
         manufacturer_created = True
 
-    filament_result = await db.execute(
-        select(Filament)
-        .where(Filament.manufacturer_id == manufacturer.id)
-        .where(func.upper(Filament.material_type) == material_type_raw)
-        .order_by(Filament.id.asc())
-        .limit(1)
-    )
-    filament = filament_result.scalar_one_or_none()
+    target_color_hex: str | None = None
+    if data.color_hex and str(data.color_hex).strip():
+        try:
+            target_color_hex = normalize_hex_color(data.color_hex)
+        except ValueError:
+            target_color_hex = None
+
+    filament = None
+    if target_color_hex:
+        color_query = (
+            select(Filament)
+            .join(Filament.filament_colors)
+            .join(FilamentColor.color)
+            .where(Filament.manufacturer_id == manufacturer.id)
+            .where(func.upper(Filament.material_type) == material_type_raw)
+            .where(
+                or_(
+                    func.upper(Color.hex_code) == target_color_hex,
+                    func.upper(func.substr(Color.hex_code, 1, 7)) == target_color_hex[:7],
+                )
+            )
+            .order_by(Filament.id.asc())
+            .limit(1)
+        )
+        filament_result = await db.execute(color_query)
+        filament = filament_result.scalar_one_or_none()
+
+    if filament is None:
+        filament_result = await db.execute(
+            select(Filament)
+            .where(Filament.manufacturer_id == manufacturer.id)
+            .where(func.upper(Filament.material_type) == material_type_raw)
+            .order_by(Filament.id.asc())
+            .limit(1)
+        )
+        filament = filament_result.scalar_one_or_none()
 
     filament_created = False
     filament_updated = False
@@ -696,6 +725,27 @@ async def resolve_filament_from_tag(
         db.add(filament)
         await db.flush()
         filament_created = True
+
+        if target_color_hex:
+            color_match = await db.execute(
+                select(Color).where(
+                    or_(
+                        func.upper(Color.hex_code) == target_color_hex,
+                        func.upper(func.substr(Color.hex_code, 1, 7)) == target_color_hex[:7],
+                    )
+                ).limit(1)
+            )
+            matched_color = color_match.scalar_one_or_none()
+            if matched_color is None:
+                matched_color = Color(name=target_color_hex, hex_code=target_color_hex)
+                db.add(matched_color)
+                await db.flush()
+            fc = FilamentColor(
+                filament_id=filament.id,
+                color_id=matched_color.id,
+                position=1,
+            )
+            db.add(fc)
     else:
         designation = filament.designation
 

--- a/backend/app/api/v1/schemas_filament.py
+++ b/backend/app/api/v1/schemas_filament.py
@@ -168,6 +168,7 @@ class ResolveFilamentFromTagRequest(BaseModel):
     brand: str | None = None
     type: str | None = None
     subtype: str | None = None
+    color_hex: str | None = None
     min_temp: int | float | str | None = None
     max_temp: int | float | str | None = None
     diameter: float | str | None = None

--- a/backend/tests/test_filaments.py
+++ b/backend/tests/test_filaments.py
@@ -694,6 +694,117 @@ class TestFilamentCRUD:
         assert response.json()["detail"]["code"] == "validation_error"
 
     @pytest.mark.asyncio
+    async def test_resolve_from_tag_matches_color_when_available(self, auth_client, db_session):
+        client, csrf_token = auth_client
+
+        manufacturer = await _create_manufacturer(db_session, name="Bambu Lab")
+        color_white = await _create_color(db_session, name="White", hex_code="#FFFFFF")
+        color_black = await _create_color(db_session, name="Black", hex_code="#000000")
+
+        filament_white = await _create_filament(
+            db_session, manufacturer.id, designation="Bambu Lab PETG Basic White", material_type="PETG"
+        )
+        db_session.add(FilamentColor(filament_id=filament_white.id, color_id=color_white.id, position=1))
+
+        filament_black = await _create_filament(
+            db_session, manufacturer.id, designation="Bambu Lab PETG Basic Black", material_type="PETG"
+        )
+        db_session.add(FilamentColor(filament_id=filament_black.id, color_id=color_black.id, position=1))
+        await db_session.commit()
+
+        # Resolve with black color hex (without #)
+        response = await client.post(
+            "/api/v1/filaments/resolve-from-tag",
+            json={
+                "brand": "Bambu Lab",
+                "type": "PETG",
+                "color_hex": "000000",
+            },
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["filament_id"] == filament_black.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_from_tag_falls_back_when_color_unmatched(self, auth_client, db_session):
+        client, csrf_token = auth_client
+
+        manufacturer = await _create_manufacturer(db_session, name="Bambu Lab Fallback")
+        color_white = await _create_color(db_session, name="White", hex_code="#FFFFFF")
+        filament_white = await _create_filament(
+            db_session, manufacturer.id, designation="Bambu Lab PETG Basic White", material_type="PETG"
+        )
+        db_session.add(FilamentColor(filament_id=filament_white.id, color_id=color_white.id, position=1))
+        await db_session.commit()
+
+        # Tag has red color which doesn't exist in DB - should fallback to existing PETG
+        response = await client.post(
+            "/api/v1/filaments/resolve-from-tag",
+            json={
+                "brand": "Bambu Lab Fallback",
+                "type": "PETG",
+                "color_hex": "FF0000",
+            },
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["filament_id"] == filament_white.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_from_tag_works_without_color_for_backwards_compat(self, auth_client, db_session):
+        client, csrf_token = auth_client
+
+        manufacturer = await _create_manufacturer(db_session, name="Generic Brand")
+        filament = await _create_filament(
+            db_session, manufacturer.id, designation="Generic PLA", material_type="PLA"
+        )
+        await db_session.commit()
+
+        # No color_hex provided at all
+        response = await client.post(
+            "/api/v1/filaments/resolve-from-tag",
+            json={
+                "brand": "Generic Brand",
+                "type": "PLA",
+            },
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["filament_id"] == filament.id
+
+    @pytest.mark.asyncio
+    async def test_resolve_from_tag_creates_filament_with_color(self, auth_client, db_session):
+        client, csrf_token = auth_client
+
+        response = await client.post(
+            "/api/v1/filaments/resolve-from-tag",
+            json={
+                "brand": "NewBrand",
+                "type": "TPU",
+                "color_hex": "#00FF00",
+            },
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["filament_created"] is True
+
+        # Check color relationship was created
+        fc_res = await db_session.execute(
+            select(FilamentColor).where(FilamentColor.filament_id == payload["filament_id"])
+        )
+        fc = fc_res.scalar_one_or_none()
+        assert fc is not None
+
+        color_res = await db_session.execute(select(Color).where(Color.id == fc.color_id))
+        color = color_res.scalar_one_or_none()
+        assert color is not None
+        assert color.hex_code == "#00FF00"
+
+    @pytest.mark.asyncio
     async def test_get_filament_detail(self, auth_client, db_session):
         client, _ = auth_client
 

--- a/frontend/src/pages/spools/new.astro
+++ b/frontend/src/pages/spools/new.astro
@@ -1078,6 +1078,9 @@ const filamentId = Astro.url.searchParams.get('filament_id')
       const subtype = String(tagData?.subtype || '').trim()
       if (subtype) payload.subtype = subtype
 
+      const colorHex = String(tagData?.color_hex || tagData?.color || '').trim()
+      if (colorHex) payload.color_hex = colorHex
+
       if (tagData?.min_temp != null && String(tagData.min_temp).trim() !== '') {
         payload.min_temp = tagData.min_temp
       }
@@ -1119,6 +1122,7 @@ const filamentId = Astro.url.searchParams.get('filament_id')
     async function applyTagDataToForm(tagData: any) {
       const brand = (tagData.brand || '').toLowerCase().trim()
       const type  = (tagData.type  || '').toLowerCase().trim()
+      const colorHex = String(tagData?.color_hex || tagData?.color || '').trim()
       let matchedFilament: any = null
 
       if (type) {
@@ -1136,6 +1140,14 @@ const filamentId = Astro.url.searchParams.get('filament_id')
       }
 
       if (type) {
+        if (!matchedFilament && colorHex) {
+          const normHex = (colorHex.startsWith('#') ? colorHex : '#' + colorHex).toLowerCase()
+          matchedFilament = filaments.find((f: any) =>
+            brand && (f.manufacturer?.name || '').toLowerCase().includes(brand) &&
+            (f.material_type || '').toLowerCase() === type &&
+            f.colors?.some((fc: any) => (fc.color?.hex_code || '').toLowerCase().startsWith(normHex.slice(0, 7)))
+          )
+        }
         if (!matchedFilament) {
           matchedFilament = filaments.find((f: any) =>
             brand && (f.manufacturer?.name || '').toLowerCase().includes(brand) &&


### PR DESCRIPTION
## Summary

When importing a spool from a tag (OpenSpool, Bambu, or NFC scale device) on `/spools/new`, `color_hex` was previously dropped during tag resolution. Because the backend query only filtered by `manufacturer_id` and `material_type` with `.order_by(Filament.id.asc()).limit(1)`, it always selected the very first filament created for that material type (e.g. selecting White when Black or another color was scanned).

This PR adds color awareness to `resolve-from-tag` while preserving complete backwards compatibility for tags without color.

## Changes

- **Backend Schema (`schemas_filament.py`)**:
  - Added optional `color_hex: str | None = None` to `ResolveFilamentFromTagRequest`.

- **Backend Resolver (`filaments.py:resolve_filament_from_tag`)**:
  - Safely normalizes `color_hex` (accepts `#RRGGBB`, `RRGGBB`, and alpha suffixes). Invalid or malformed strings are safely ignored.
  - **Tier 1 (Color match)**: If `color_hex` is present, queries `Filament` joined with `FilamentColor` and `Color` matching `manufacturer_id`, `material_type`, and the color hex code.
  - **Tier 2 (Fallback)**: If no matching color exists in the database (or no color was provided on the tag), falls back to the existing query (`manufacturer_id` + `material_type`), preserving existing behavior.
  - **Tier 3 (New filament)**: When auto-creating a new filament from tag data, also creates/links the `Color` and `FilamentColor` entry if `color_hex` is provided.

- **Frontend (`new.astro`)**:
  - `resolveFilamentFromTag` now forwards `color_hex` in its request payload.
  - `applyTagDataToForm` checks color in the local fallback `find()` before falling back to type-only matching.

- **Automated Tests (`test_filaments.py`)**:
  - `test_resolve_from_tag_matches_color_when_available`: Verifies that a black tag resolves the black filament and not the white one.
  - `test_resolve_from_tag_falls_back_when_color_unmatched`: Verifies that scanning a color not in DB still resolves the manufacturer + material without error.
  - `test_resolve_from_tag_works_without_color_for_backwards_compat`: Verifies tags with no color data continue to resolve identically to before.
  - `test_resolve_from_tag_creates_filament_with_color`: Verifies auto-creating a new filament attaches the color swatch.

## Backward Compatibility

- Standard OpenSpool tags, FilaMan NTAGs, and Bambu tags benefit immediately when matching colors exist.
- Tags without color data (or legacy tags) continue to match on manufacturer + material type without disruption.
- Unmatched colors gracefully fall back to the first material match rather than failing.
