### PR TITLE
feat(ui): display update notification badge next to version in sidebar

### DIFF
--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -285,7 +285,7 @@ class VersionCheckResponse(BaseModel):
 @router.get("/version-check", response_model=VersionCheckResponse)
 async def version_check(
     db: DBSession,
-    principal=RequirePermission("admin:plugins_manage"),
+    principal: PrincipalDep,
 ):
     """System-Version und Plugin-Updates pruefen (24h Cache)."""
     now = time.time()

--- a/backend/tests/test_app_settings.py
+++ b/backend/tests/test_app_settings.py
@@ -261,3 +261,13 @@ class TestLoginBypass:
         assert response.status_code == 401
         data = response.json()
         assert data["detail"]["code"] == "invalid_credentials"
+
+    @pytest.mark.asyncio
+    async def test_version_check_accessible_to_authenticated_user(self, auth_client):
+        """GET /api/v1/admin/system/version-check should be accessible to authenticated user."""
+        client, _ = auth_client
+        response = await client.get("/api/v1/admin/system/version-check")
+        assert response.status_code == 200
+        data = response.json()
+        assert "installed_version" in data
+        assert "update_available" in data

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -17,7 +17,8 @@
     "settings": "Einstellungen",
     "logout": "Abmelden",
     "supportProject": "Unterstütze das Projekt",
-    "plugins": "Plugins"
+    "plugins": "Plugins",
+    "updateAvailable": "Update verfügbar"
   },
   "theme": {
     "default": "Standard",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -17,7 +17,8 @@
     "settings": "Settings",
     "logout": "Logout",
     "supportProject": "Support the project",
-    "plugins": "Plugins"
+    "plugins": "Plugins",
+    "updateAvailable": "Update available"
   },
   "theme": {
     "default": "Default",

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -141,7 +141,18 @@ const { title } = Astro.props
               </a>
             </div>
 
-            <div style="font-size: 0.7rem; color: var(--text-muted); text-align: center;">{'v' + VERSION}</div>
+            <div id="sidebar-version-container" style="font-size: 0.7rem; color: var(--text-muted); text-align: center; display: flex; flex-direction: column; align-items: center; gap: 4px;">
+              <div id="sidebar-version-label">{'v' + VERSION}</div>
+              <a
+                id="sidebar-version-update"
+                href="/admin"
+                class="invisible"
+                style="display: inline-flex; align-items: center; gap: 5px; padding: 2px 8px; font-size: 0.65rem; font-weight: 600; color: var(--info-text, #93c5fd); background: var(--info-bg, rgba(59, 130, 246, 0.15)); border: 1px solid var(--info-border, rgba(59, 130, 246, 0.4)); border-radius: 9999px; text-decoration: none; transition: opacity var(--transition);"
+              >
+                <span class="fm-dot" style="background: #60a5fa; width: 6px; height: 6px;"></span>
+                <span id="sidebar-version-update-text">Update</span>
+              </a>
+            </div>
             <div style="font-size: 0.7rem; color: var(--text-muted); text-align: center;">
               <a href="https://www.filaman.app" target="_blank" style="color: var(--text-muted); text-decoration: none; display: inline-flex; align-items: center; gap: 4px;">
                 Made with <img src="/coffeecup.svg" width="14" height="14" style="vertical-align: middle;"> and <img src="/heart.svg" width="14" height="14" style="vertical-align: middle;"> by Manuel Weiser
@@ -337,6 +348,7 @@ const { title } = Astro.props
           }
 
           loadPluginNav()
+          checkSystemVersion(user)
 
           // Auth succeeded — reveal page content
           document.getElementById('fm-page')!.style.visibility = 'visible'
@@ -353,6 +365,52 @@ const { title } = Astro.props
       }
 
       checkAuth()
+
+      /* ── System version check ────────────────────────────────── */
+      async function checkSystemVersion(user: any) {
+        try {
+          const cachedRaw = sessionStorage.getItem('fm_version_check')
+          if (cachedRaw) {
+            try {
+              const cached = JSON.parse(cachedRaw)
+              if (cached?.ts && Date.now() - cached.ts < 30 * 60 * 1000 && cached.data) {
+                applyVersionStatus(cached.data, user)
+                return
+              }
+            } catch { /* ignore corrupted cache */ }
+          }
+
+          const resp = await fetch('/api/v1/admin/system/version-check', {
+            credentials: 'include',
+            signal: getAbortSignal(),
+          })
+          if (!resp.ok) return
+          const data = await resp.json()
+          sessionStorage.setItem('fm_version_check', JSON.stringify({ ts: Date.now(), data }))
+          applyVersionStatus(data, user)
+        } catch { /* Version check is non-critical */ }
+      }
+
+      function applyVersionStatus(data: any, user: any) {
+        if (!data?.update_available) return
+        const updateBadge = document.getElementById('sidebar-version-update') as HTMLAnchorElement | null
+        const updateText = document.getElementById('sidebar-version-update-text')
+        if (!updateBadge || !updateText) return
+
+        const isAdmin = Boolean(user?.is_superadmin || (user?.permissions || []).some((p: string) => p.startsWith('admin:')))
+        if (isAdmin) {
+          updateBadge.href = '/admin'
+        } else {
+          updateBadge.href = 'https://github.com/Fire-Devils/filaman-system/releases/latest'
+          updateBadge.target = '_blank'
+          updateBadge.rel = 'noopener noreferrer'
+        }
+
+        const label = t('nav.updateAvailable') || 'Update available'
+        updateText.textContent = data.latest_version ? `${label}: v${data.latest_version}` : label
+        updateBadge.title = `${label}: v${data.latest_version || ''}`
+        updateBadge.classList.remove('invisible')
+      }
 
       /* ── Plugin navigation ───────────────────────────────────── */
       const pluginNav = document.getElementById('plugin-nav')!


### PR DESCRIPTION
## Summary

Currently, users have to open `/admin` to see whether a new release of FilaMan is available. In the sidebar footer (bottom left), only the static installed version is displayed (e.g. `v1.2.48`).

This PR adds an automatic, non-intrusive update notification badge next to the version in the sidebar whenever a newer build is released.

## Changes

- **Backend (`app/api/v1/system.py`)**:
  - Changed `/api/v1/admin/system/version-check` permission requirement from `admin:plugins_manage` to any authenticated user (`PrincipalDep`). This allows the sidebar to check version status regardless of specific granular plugin permissions while retaining authentication protection.

- **Frontend Layout (`Layout.astro`)**:
  - Replaced the static version text with a version container that displays an update badge (`Update available: vX.Y.Z`) with an indicator dot when an update is detected.
  - Implemented `checkSystemVersion` with client-side `sessionStorage` caching (30-minute TTL) so page navigation does not trigger repeated network requests. (The backend already maintains its own 24-hour server-side cache for GitHub release queries).
  - If the user has admin rights, the badge links directly to `/admin`. For non-admin users, it links to the GitHub release page.

- **i18n (`en.json`, `de.json`)**:
  - Added `nav.updateAvailable` (`"Update available"` / `"Update verfügbar"`).

- **Automated Tests (`test_app_settings.py`)**:
  - Added test verifying `/api/v1/admin/system/version-check` is accessible to authenticated sessions.
