### PR TITLE
fix(settings): default RFID UID colons off when unset

### DIFF
--- a/backend/alembic/versions/e8a1c4d2b907_default_rfid_display_colons_off.py
+++ b/backend/alembic/versions/e8a1c4d2b907_default_rfid_display_colons_off.py
@@ -1,0 +1,40 @@
+"""default RFID display-colons setting to off
+
+Revision ID: e8a1c4d2b907
+Revises: d5f3b8c2a614
+Create Date: 2026-09-12 20:20:00.000000
+
+The column shipped with server_default=true. New rows and unset clients
+should show compact UIDs unless an admin has already saved the toggle.
+Existing stored values are left unchanged.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e8a1c4d2b907"
+down_revision: str | Sequence[str] | None = "d5f3b8c2a614"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("app_settings") as batch_op:
+        batch_op.alter_column(
+            "rfid_display_colons",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.false(),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("app_settings") as batch_op:
+        batch_op.alter_column(
+            "rfid_display_colons",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.true(),
+        )

--- a/backend/app/api/v1/app_settings_admin.py
+++ b/backend/app/api/v1/app_settings_admin.py
@@ -16,7 +16,7 @@ class AppSettingsResponse(BaseModel):
     currency: str
     rfid_extended_data_enabled: bool
     rfid_protocol: str
-    rfid_display_colons: bool = True
+    rfid_display_colons: bool = False
     default_spool_core_weight_g: float | None = None
     bambu_unmatched_profile_fallback: str = "generic"
 
@@ -61,7 +61,7 @@ async def get_app_settings(
             currency="EUR",
             rfid_extended_data_enabled=False,
             rfid_protocol="openspool",
-            rfid_display_colons=True,
+            rfid_display_colons=False,
         )
 
     return AppSettingsResponse(
@@ -126,7 +126,7 @@ async def get_public_app_settings(db: DBSession):
             currency="EUR",
             rfid_extended_data_enabled=False,
             rfid_protocol="openspool",
-            rfid_display_colons=True,
+            rfid_display_colons=False,
         )
     else:
         resp = AppSettingsResponse(

--- a/backend/app/models/app_settings.py
+++ b/backend/app/models/app_settings.py
@@ -20,7 +20,7 @@ class AppSettings(Base, TimestampMixin):
     currency: Mapped[str] = mapped_column(String(3), default="EUR", nullable=False)
     rfid_extended_data_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     rfid_protocol: Mapped[str] = mapped_column(String(20), default="openspool", nullable=False)
-    rfid_display_colons: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    rfid_display_colons: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     default_spool_core_weight_g: Mapped[float | None] = mapped_column(Float, nullable=True)
     # Fallback when no slicer profile resolves for a filament/model: "generic"
     # (Generic <material>) or "bambu" (Bambu-brand basic profile for the material).

--- a/backend/tests/test_app_settings.py
+++ b/backend/tests/test_app_settings.py
@@ -12,6 +12,7 @@ class TestAppSettingsAdmin:
         assert response.status_code == 200
         data = response.json()
         assert data["login_disabled"] is False
+        assert data["rfid_display_colons"] is False
 
     @pytest.mark.asyncio
     async def test_put_app_settings_creates_row(self, auth_client):
@@ -65,6 +66,25 @@ class TestAppSettingsAdmin:
         public_response = await client.get("/api/v1/app-settings/public-info")
         assert public_response.status_code == 200
         assert public_response.json()["rfid_display_colons"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_without_display_colons_keeps_default_off(self, auth_client):
+        client, csrf_token = auth_client
+
+        response = await client.put(
+            "/api/v1/admin/app-settings/",
+            json={"currency": "USD"},
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert response.status_code == 200
+        assert response.json()["rfid_display_colons"] is False
+
+        enabled = await client.put(
+            "/api/v1/admin/app-settings/",
+            json={"rfid_display_colons": True},
+            headers={"X-CSRF-Token": csrf_token},
+        )
+        assert enabled.json()["rfid_display_colons"] is True
 
     @pytest.mark.asyncio
     async def test_put_app_settings_updates_existing(self, auth_client):
@@ -197,6 +217,7 @@ class TestAppSettingsPublic:
         assert response.status_code == 200
         data = response.json()
         assert data["login_disabled"] is False
+        assert data["rfid_display_colons"] is False
 
     @pytest.mark.asyncio
     async def test_public_info_returns_login_disabled_true(self, client, auth_client):

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -30,7 +30,7 @@ export function formatRfidUid(value: string | null | undefined): string {
     return value;
   }
   const upper = compact.toUpperCase();
-  const showColons = localStorage.getItem('rfid_display_colons') !== 'false';
+  const showColons = localStorage.getItem('rfid_display_colons') === 'true';
   return showColons ? upper.match(/.{2}/g)!.join(':') : upper;
 }
 
@@ -38,10 +38,10 @@ export async function initRfidDisplayFormat(): Promise<boolean> {
   try {
     const res = await fetch('/api/v1/app-settings/public-info');
     const data = await res.json();
-    const showColons = data.rfid_display_colons !== false;
+    const showColons = data.rfid_display_colons === true;
     localStorage.setItem('rfid_display_colons', String(showColons));
     return showColons;
   } catch {
-    return localStorage.getItem('rfid_display_colons') !== 'false';
+    return localStorage.getItem('rfid_display_colons') === 'true';
   }
 }

--- a/frontend/src/pages/admin/app-settings.astro
+++ b/frontend/src/pages/admin/app-settings.astro
@@ -249,7 +249,7 @@ import Layout from '../../layouts/Layout.astro'
           warningDiv.classList.toggle('hidden', !data.login_disabled)
           rfidExtendedDataInput.checked = data.rfid_extended_data_enabled ?? false
           rfidProtocolSelect.value = data.rfid_protocol || 'openspool'
-          rfidDisplayColonsInput.checked = data.rfid_display_colons !== false
+          rfidDisplayColonsInput.checked = data.rfid_display_colons === true
           updateRfidProtocolVisibility()
           defaultSpoolCoreWeightInput.value = data.default_spool_core_weight_g != null ? String(data.default_spool_core_weight_g) : ''
           bambuUnmatchedFallbackSelect.value = data.bambu_unmatched_profile_fallback || 'generic'


### PR DESCRIPTION
## Summary
- App Settings "Show colons in RFID UIDs" now defaults to off when the preference has never been saved.
- An already-saved on/off value is left unchanged. UID matching and stored values are unaffected.

## Test plan
- [ ] Fresh / unset install: toggle is off and spool UIDs render without colons.
- [ ] After turning the toggle on and saving, colons stay on across reload.
- [ ] Saving other App Settings without touching the toggle does not turn colons on.